### PR TITLE
Connect auth forms to Hostinger backend and add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npx next export
+      - name: Deploy to Hostinger
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_HOST }}
+          username: ${{ secrets.HOSTINGER_FTP_USER }}
+          password: ${{ secrets.HOSTINGER_FTP_PASS }}
+          protocol: ftps
+          server-dir: /public_html/app/
+          local-dir: ./out

--- a/next.config.js
+++ b/next.config.js
@@ -13,8 +13,6 @@ const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
 
-  // Optional CSS inlining (safe now that critters is installed)
-  experimental: { optimizeCss: true },
 };
 
 module.exports = nextConfig;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
     if (!email || !password) { setError('Email and password are required'); return; }
     setLoading(true);
     try {
-      const res = await fetch(`${API_BASE}/auth/login.php`, {
+      const res = await fetch(`${API_BASE}/login.php`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -30,7 +30,15 @@ export default function LoginPage() {
         setLoading(false);
         return;
       }
-      router.push('/?login=success');
+
+      // Persist basic auth state for the rest of the app
+      try {
+        if (data.token) localStorage.setItem('token', data.token);
+        if (data.user) localStorage.setItem('user', JSON.stringify(data.user));
+        localStorage.setItem('auth', 'true');
+      } catch {}
+
+      router.push('/');
     } catch (err:any) {
       setError('Network error. Please try again.');
     } finally {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -20,7 +20,7 @@ export default function SignupPage() {
     if (!name || !email || !phone || !password) { setError('Please fill in all required fields'); return; }
     setLoading(true);
     try {
-      const res = await fetch(`${API_BASE}/auth/register.php`, {
+      const res = await fetch(`${API_BASE}/register.php`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- Post login and signup forms to Hostinger PHP endpoints and persist auth state
- Configure Next.js for static export without experimental flags
- Deploy `out/` directly to Hostinger using FTPS via `SamKirkland/FTP-Deploy-Action`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b24f584008327936a4ed662b757d6