### PR TITLE
Fix deploy workflow action version and triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,10 @@ name: Build and Deploy
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +27,7 @@ jobs:
           npx next export
 
       - name: Deploy to Hostinger (FTPS)
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@4.3.4
         with:
           server: ${{ secrets.HOSTINGER_FTP_HOST }}
           username: ${{ secrets.HOSTINGER_FTP_USER }}
@@ -34,9 +35,10 @@ jobs:
           protocol: ftps
           port: 21
           local-dir: ./out/
-          server-dir: /public_html/app/
-          dangerous-clean-slate: true
+          server-dir: ${{ secrets.HOSTINGER_SERVER_DIR }}
           exclude: |
             **/.git*
-            **/.DS_Store
-            **/*.map
+            **/.github/**
+            **/node_modules/**
+            **/.next/**
+          dangerous-clean-slate: true


### PR DESCRIPTION
## Summary
- fix FTP deploy action version to 4.3.4 and adjust server directory secret
- enable workflow_dispatch trigger and keep push to main for auto deploy
- refine excluded paths for FTP deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / unused vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689b46b21fec8327b537f03ea877e383