### PR TITLE
Fix static routing on Hostinger with trailing slashes and .htaccess

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
           port: 21
           local-dir: ./out/
           server-dir: ${{ secrets.HOSTINGER_SERVER_DIR }}
+          include: |
+            .htaccess
+            **
           exclude: |
             **/.git*
             **/.github/**

--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,13 @@ const nextConfig = {
   // ⬇️ Static export for Hostinger
   output: 'export',
 
+  // Force trailing slashes so /login -> /login/index.html
+  trailingSlash: true,
+
   // next/image off for purely static hosting
-  images: { unoptimized: true },
+  images: {
+    unoptimized: true,
+  },
 
   // Let production build pass even if lint/types complain
   eslint: { ignoreDuringBuilds: true },

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,28 @@
+# Ensure Apache/LiteSpeed serves our static export correctly
+
+# Avoid content negotiation issues
+Options -MultiViews
+
+# Use index.html for directories
+DirectoryIndex index.html
+
+RewriteEngine On
+RewriteBase /
+
+# 1) Serve existing files or directories as-is (e.g., /_next/, /assets/, /login/index.html)
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# 2) If there's a matching .html file, serve it (e.g., /about -> /about.html)
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}.html -f
+RewriteRule ^(.+)$ $1.html [L]
+
+# 3) Fallback for client-side routing: send unknown paths to /index.html
+#    (This lets the Next.js router render the correct page if it's an SPA-style route)
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.html [L]
+


### PR DESCRIPTION
## Summary
- add trailingSlash and explicit image settings in next.config.js for static export
- include Apache rewrite rules via public/.htaccess
- ensure FTP deployment uploads .htaccess by whitelisting dotfiles

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b558d58ac8327bc699548c76216d1