### PR TITLE
Finalize Vercel config for quickgig.ph; remove Hostinger FTP; add smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,21 @@
+name: smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Base URL to test
+        required: false
+        default: https://quickgig.ph
+  push:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run smoke test
+        env:
+          BASE_URL: ${{ inputs.base_url || 'https://quickgig.ph' }}
+        run: scripts/smoke.sh

--- a/README.md
+++ b/README.md
@@ -29,4 +29,9 @@ npm run dev
 
 ## Deployment
 
-This project is configured for Vercel. Connect the repository to Vercel and ensure the `NEXT_PUBLIC_API_URL` environment variable is set in your project settings.
+Deployment is handled via the Vercel GitHub integration. Ensure the
+`NEXT_PUBLIC_API_URL` environment variable is set in your Vercel project
+settings.
+
+Login, signup, and other protected pages call the external API at
+`https://api.quickgig.ph`; this Next.js app does not provide any API routes.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${BASE_URL:-https://quickgig.ph}"
+curl -sSf "$BASE" >/dev/null
+curl -sS "$BASE/login" | head -n 1 >/dev/null
+echo "Smoke OK: $BASE"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "https://www.quickgig.ph/(.*)", "destination": "https://quickgig.ph/$1", "permanent": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel domain normalization and env example for external API
- document Vercel GitHub deployment and API usage in README
- add smoke test script and GitHub Action; remove legacy Hostinger FTP workflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors)*
- `./scripts/smoke.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd0308888327be4325f8ec0badd5