### PR TITLE
Enable Hostinger FTP deploy; allow quickgig.ph origins

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy API to Hostinger
+on:
+  push:
+    branches: [ main ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install Composer deps
+        run: composer install --no-dev --prefer-dist --no-progress --no-interaction
+        working-directory: api.quickgig.ph
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_HOST }}
+          username: ${{ secrets.HOSTINGER_FTP_USER }}
+          password: ${{ secrets.HOSTINGER_FTP_PASS }}
+          server-dir: /public_html/api/
+          local-dir: api.quickgig.ph/
+          exclude: |
+            **/.git*
+            **/.github/**

--- a/README.md
+++ b/README.md
@@ -30,3 +30,65 @@ npm run dev
 ## Deployment
 
 This project is configured for Vercel. Connect the repository to Vercel and ensure the `NEXT_PUBLIC_API_URL` environment variable is set in your project settings.
+
+## API (Hostinger) Setup
+
+The `api.quickgig.ph` directory contains a lightweight PHP API that deploys to Hostinger. Deployment is automated via the GitHub Action in `.github/workflows/deploy.yml` which uploads the API to `/public_html/api/` over FTP.
+
+### Environment variables
+
+In the Hostinger control panel for the `api` subdomain, configure the following environment variables:
+
+- `DB_HOST`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASS`
+- `JWT_SECRET`
+- `CORS_ORIGIN` (optional, comma separated, defaults to `https://quickgig.ph,https://www.quickgig.ph`)
+
+### SQL schema
+
+Create the database tables by running:
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(120) NOT NULL,
+  email VARCHAR(190) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(200) NOT NULL,
+  description TEXT,
+  event_date DATETIME NOT NULL,
+  created_by INT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (created_by) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tickets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  event_id INT NOT NULL,
+  holder_name VARCHAR(160) NOT NULL,
+  status ENUM('reserved','paid','cancelled') DEFAULT 'reserved',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (event_id) REFERENCES events(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### Manual steps
+
+Some infrastructure settings still need to be configured manually:
+
+1. **Hostinger → Subdomains**: create `api` with document root `/public_html/api`.
+2. **Hostinger → SSL**: enable Let's Encrypt for `api.quickgig.ph`.
+3. **Hostinger → Environment Variables**: set the variables listed above.
+4. **Hostinger → DNS Zone**:
+   - `@` A → `76.76.21.21` (Vercel)
+   - `www` CNAME → `cname.vercel-dns.com`
+5. **Vercel → Project → Domains**: add `quickgig.ph` and optionally `www`.
+6. **Vercel → Settings → Env Vars**: set `NEXT_PUBLIC_API_URL=https://api.quickgig.ph` and redeploy.
+

--- a/api.quickgig.ph/.env.example
+++ b/api.quickgig.ph/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_NAME=quickgig
+DB_USER=user
+DB_PASS=pass
+JWT_SECRET=change_this_super_secret_key
+CORS_ORIGIN=https://quickgig.ph,https://www.quickgig.ph

--- a/api.quickgig.ph/src/cors.php
+++ b/api.quickgig.ph/src/cors.php
@@ -1,6 +1,11 @@
 <?php
 function cors() {
-  header('Access-Control-Allow-Origin: ' . CORS_ORIGIN);
+  $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+  $allowed = array_map('trim', explode(',', CORS_ORIGIN));
+  if ($origin && in_array($origin, $allowed, true)) {
+    header('Access-Control-Allow-Origin: ' . $origin);
+  }
+  header('Vary: Origin');
   header('Access-Control-Allow-Credentials: true');
   header('Access-Control-Allow-Headers: Content-Type, Authorization');
   header('Access-Control-Allow-Methods: GET, POST, OPTIONS');

--- a/api.quickgig.ph/src/env.php
+++ b/api.quickgig.ph/src/env.php
@@ -5,4 +5,4 @@ define('DB_NAME', getenv('DB_NAME') ?: 'quickgig');
 define('DB_USER', getenv('DB_USER') ?: 'user');
 define('DB_PASS', getenv('DB_PASS') ?: 'pass');
 define('JWT_SECRET', getenv('JWT_SECRET') ?: 'change_this_super_secret_key');
-define('CORS_ORIGIN', getenv('CORS_ORIGIN') ?: 'https://app.quickgig.ph');
+define('CORS_ORIGIN', getenv('CORS_ORIGIN') ?: 'https://quickgig.ph,https://www.quickgig.ph');


### PR DESCRIPTION
## Summary
- allow `quickgig.ph` and `www.quickgig.ph` in API CORS handling
- add `.env.example` and Hostinger FTP GitHub Action for automatic deploys
- document Hostinger environment setup and SQL schema

## Testing
- `php -l api.quickgig.ph/src/env.php`
- `php -l api.quickgig.ph/src/cors.php`
- `cd api.quickgig.ph && composer validate --no-check-publish && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_689bbe91ac5c83279ccf837dd71d1f7e