### PR TITLE
Fix API docroot via FTP + wire frontend + health-check page

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph

--- a/.github/workflows/deploy-api-minimal.yml
+++ b/.github/workflows/deploy-api-minimal.yml
@@ -1,0 +1,20 @@
+name: Deploy API minimal to Hostinger
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ftps
+          port: 21
+          local-dir: api-minimal
+          server-dir: ${{ secrets.REMOTE_DIR }} # e.g. /domains/api.quickgig.ph/public_html/
+          dangerous-clean-slate: true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Run smoke test
         env:
           BASE_URL: ${{ inputs.base_url || 'https://quickgig.ph' }}
+          NEXT_PUBLIC_API_URL: https://api.quickgig.ph
         run: scripts/smoke.sh

--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ settings.
 
 Login, signup, and other protected pages call the external API at
 `https://api.quickgig.ph`; this Next.js app does not provide any API routes.
+
+## Health check
+
+The app expects an external API base URL provided via `NEXT_PUBLIC_API_URL` (set in `.env.local`). After running `npm run dev`, visit `/health-check` to verify connectivity. The page queries `${NEXT_PUBLIC_API_URL}/health` and shows a green **UP** badge when it returns `{status:"ok"}`.
+
+Deployments are handled by Vercel; once deployed, check https://quickgig.ph/health-check to confirm the badge reports **UP**.

--- a/api-minimal/.htaccess
+++ b/api-minimal/.htaccess
@@ -1,0 +1,5 @@
+Options -Indexes
+DirectoryIndex index.php index.html
+<FilesMatch "^\.">
+  Require all denied
+</FilesMatch>

--- a/api-minimal/README.txt
+++ b/api-minimal/README.txt
@@ -1,0 +1,1 @@
+Upload contents of this folder to /domains/api.quickgig.ph/public_html/ on the Hostinger server.

--- a/api-minimal/health.php
+++ b/api-minimal/health.php
@@ -1,0 +1,1 @@
+<?php header('Content-Type: application/json'); echo json_encode(['status'=>'ok']);

--- a/api-minimal/index.php
+++ b/api-minimal/index.php
@@ -1,0 +1,1 @@
+<?php header('Content-Type: application/json'); echo json_encode(['message'=>'QuickGig API']);

--- a/api-minimal/phpinfo.php
+++ b/api-minimal/phpinfo.php
@@ -1,0 +1,1 @@
+<?php phpinfo();

--- a/src/app/health-check/page.tsx
+++ b/src/app/health-check/page.tsx
@@ -1,0 +1,43 @@
+import { apiBase } from '@/lib/apiBase';
+import { safeFetch } from '@/lib/safeFetch';
+import { useEffect, useState } from 'react';
+
+type Result = {
+  ok: boolean;
+  status: number;
+  json: unknown;
+  error: string | null;
+};
+
+export default async function Page() {
+  const initial = await safeFetch(`${apiBase}/health`);
+  return <HealthCheck initial={initial} />;
+}
+
+function HealthCheck({ initial }: { initial: Result }) {
+  'use client';
+  const [result, setResult] = useState<Result>(initial);
+
+  const run = async () => {
+    setResult(await safeFetch(`${apiBase}/health`));
+  };
+
+  useEffect(() => {
+    if (!initial.ok) run();
+  }, [initial.ok]);
+
+  const json = result.json as { status?: string } | null;
+  const isUp = json?.status === 'ok';
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>API URL: {`${apiBase}/health`}</div>
+      <div>HTTP status: {result.status}</div>
+      <pre className="bg-gray-100 p-2 rounded">{JSON.stringify(json, null, 2)}</pre>
+      <div className={`text-2xl font-bold ${isUp ? 'text-green-600' : 'text-red-600'}`}>
+        {isUp ? 'UP' : 'DOWN'}
+      </div>
+      <button onClick={run} className="px-4 py-2 border rounded">Re-run check</button>
+    </div>
+  );
+}

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,0 +1,1 @@
+export const apiBase = process.env.NEXT_PUBLIC_API_URL || '';

--- a/src/lib/safeFetch.ts
+++ b/src/lib/safeFetch.ts
@@ -1,0 +1,15 @@
+export async function safeFetch(url: string, init?: RequestInit) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), 8000);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    let json: unknown = null;
+    try { json = await res.json(); } catch {}
+    return { ok: res.ok, status: res.status, json, error: null as string | null };
+  } catch (e) {
+    const message = (e as Error).message || String(e);
+    return { ok: false, status: 0, json: null, error: message };
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/tests/health-check.spec.ts
+++ b/tests/health-check.spec.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+
+test('shows UP when API returns ok', async ({ page }) => {
+  await page.route('https://api.quickgig.ph/health', route => {
+    route.fulfill({ json: { status: 'ok' } });
+  });
+  await page.goto('/health-check');
+  await expect(page.getByText('UP')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add minimal API files and FTP deploy workflow to fix Hostinger docroot
- wire frontend to NEXT_PUBLIC_API_URL and expose in CI
- add safeFetch helper, /health-check page, smoke test, and README docs

## Testing
- `node tools/check_live_api.mjs` *(fails: fetch failed)*
- `curl -i https://api.quickgig.ph/` *(403 CONNECT tunnel failed)*
- `curl -i https://api.quickgig.ph/health` *(403 CONNECT tunnel failed)*
- `npm run lint`
- `npm run typecheck`
- `npm run test:e2e` *(fails: playwright: not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c99b5da288327bc0a1b7a1d2db82d