### PR TITLE
fix: update API deploy path and add health check page

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -20,31 +20,16 @@ jobs:
         env:
           API_ENV: ${{ secrets.API_ENV }}
 
-      - name: Try deploy to /domains/.../public_html (primary)
-        id: deploy_primary
-        continue-on-error: true
+      - name: Deploy API via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           port: ${{ secrets.FTP_PORT || 21 }}
-          protocol: ftp
+          protocol: ftps
           local-dir: api.quickgig.ph/
-          server-dir: /domains/api.quickgig.ph/public_html/
-          dangerous-clean-slate: true
-
-      - name: Fallback deploy to /public_html (if primary failed)
-        if: steps.deploy_primary.outcome == 'failure'
-        uses: SamKirkland/FTP-Deploy-Action@v4
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          port: ${{ secrets.FTP_PORT || 21 }}
-          protocol: ftp
-          local-dir: api.quickgig.ph/
-          server-dir: /public_html/
+          server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
           dangerous-clean-slate: true
 
       - name: Verify API endpoints

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 # local env files
 .env*
 !.env.example
+!.env.local
 
 # vercel
 .vercel

--- a/src/app/health-check/page.tsx
+++ b/src/app/health-check/page.tsx
@@ -1,0 +1,22 @@
+export const dynamic = 'force-dynamic';
+
+async function getHealth() {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/health`, { cache: 'no-store' });
+    const json = await res.json();
+    return { ok: res.ok, json };
+  } catch (err) {
+    return { ok: false, json: { error: (err as Error).message } };
+  }
+}
+
+export default async function HealthCheckPage() {
+  const { ok, json } = await getHealth();
+  return (
+    <main className="p-8 font-mono">
+      <h1 className="text-xl mb-4">API Health Check</h1>
+      <pre>{JSON.stringify(json, null, 2)}</pre>
+      <p className="mt-4">{ok ? 'API reachable' : 'API unreachable'}</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- deploy API via FTP to Hostinger docroot
- allow .env.local in repo and set API URL
- add frontend /health-check page for API monitoring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `node tools/check_live_api.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ca2add7088327aec26b691a760118