### PR TITLE
feat: add minimal API and redirect

### DIFF
--- a/.github/workflows/deploy-api-minimal.yml
+++ b/.github/workflows/deploy-api-minimal.yml
@@ -1,0 +1,42 @@
+name: Deploy API minimal to Hostinger
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'api-minimal/**'
+      - '.github/workflows/deploy-api-minimal.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy API via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          port: ${{ secrets.FTP_PORT || 21 }}
+          protocol: ftps
+          local-dir: api-minimal
+          server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
+          dangerous-clean-slate: true
+
+      - name: Verify API endpoints
+        run: |
+          set -e
+          echo "Probing https://api.quickgig.ph ..."
+          curl -fsSL https://api.quickgig.ph/ | tee /tmp/root.json
+          curl -fsSL https://api.quickgig.ph/health | tee /tmp/health.json
+          node -e "
+            const fs=require('fs');
+            const root=JSON.parse(fs.readFileSync('/tmp/root.json','utf8'));
+            const health=JSON.parse(fs.readFileSync('/tmp/health.json','utf8'));
+            if (root.message!=='QuickGig API') { console.error('Root not ok:', root); process.exit(1); }
+            if (health.status!=='ok') { console.error('Health not ok:', health); process.exit(1); }
+            console.log('API verified ✓');
+          "

--- a/api-minimal/.htaccess
+++ b/api-minimal/.htaccess
@@ -1,0 +1,22 @@
+# No directory listings; ensure PHP/HTML are index
+Options -Indexes
+DirectoryIndex index.php index.html
+
+# Deny access to dotfiles and sensitive files
+<FilesMatch "^(\.|composer\.json|composer\.lock|\.env|README|LICENSE)$">
+  Require all denied
+</FilesMatch>
+
+# Basic security headers
+<IfModule mod_headers.c>
+  Header set X-Content-Type-Options "nosniff"
+  Header set X-Frame-Options "SAMEORIGIN"
+  Header set Referrer-Policy "no-referrer-when-downgrade"
+  Header set X-XSS-Protection "1; mode=block"
+  Header set Permissions-Policy "geolocation=(), microphone=(), camera=()"
+</IfModule>
+
+# Prevent access to phpinfo if accidentally left behind
+<Files "phpinfo.php">
+  Require all denied
+</Files>

--- a/api-minimal/health.php
+++ b/api-minimal/health.php
@@ -1,0 +1,12 @@
+<?php
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$allowed = ['https://quickgig.ph','https://www.quickgig.ph'];
+if (in_array($origin, $allowed, true)) {
+  header('Access-Control-Allow-Origin: ' . $origin);
+  header('Vary: Origin');
+}
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
+header('Content-Type: application/json');
+echo json_encode(['status' => 'ok']);

--- a/api-minimal/index.php
+++ b/api-minimal/index.php
@@ -1,0 +1,12 @@
+<?php
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$allowed = ['https://quickgig.ph','https://www.quickgig.ph'];
+if (in_array($origin, $allowed, true)) {
+  header('Access-Control-Allow-Origin: ' . $origin);
+  header('Vary: Origin');
+}
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
+header('Content-Type: application/json');
+echo json_encode(['message' => 'QuickGig API']);

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,16 @@ const nextConfig = {
     const target = process.env.API_BASE_URL;
     return target ? [{ source: '/api/:path*', destination: `${target}/:path*` }] : [];
   },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'www.quickgig.ph' }],
+        destination: 'https://quickgig.ph/:path*',
+        permanent: true,
+      },
+    ];
+  },
   eslint: { ignoreDuringBuilds: false },
   typescript: { ignoreBuildErrors: false },
 };


### PR DESCRIPTION
## Summary
- add host-aware redirect to canonical quickgig.ph
- expose minimal PHP API with dual-origin CORS and security hardening
- add FTP workflow targeting correct Hostinger docroot

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `node tools/check_live_api.mjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ca8963b688327ac3c95ecd0d05c69