### PR TITLE
fix vercel redirect and update ftp path

### DIFF
--- a/.github/workflows/deploy-api-minimal.yml
+++ b/.github/workflows/deploy-api-minimal.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy API via FTP
+      - name: Deploy via FTPS
         uses: SamKirkland/FTP-Deploy-Action@v4
         with:
           server: ${{ secrets.FTP_SERVER }}
@@ -23,6 +23,7 @@ jobs:
           port: ${{ secrets.FTP_PORT || 21 }}
           protocol: ftps
           local-dir: api-minimal
+          # *** IMPORTANT: exact docroot path for api.quickgig.ph ***
           server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
           dangerous-clean-slate: true
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           API_ENV: ${{ secrets.API_ENV }}
 
-      - name: Deploy API via FTP
+      - name: Deploy via FTPS
         uses: SamKirkland/FTP-Deploy-Action@v4
         with:
           server: ${{ secrets.FTP_SERVER }}
@@ -29,6 +29,7 @@ jobs:
           port: ${{ secrets.FTP_PORT || 21 }}
           protocol: ftps
           local-dir: api.quickgig.ph/
+          # *** IMPORTANT: exact docroot path for api.quickgig.ph ***
           server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
           dangerous-clean-slate: true
 

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        // NOTE: source must be a PATH, not a full URL
         source: '/:path*',
         has: [{ type: 'host', value: 'www.quickgig.ph' }],
         destination: 'https://quickgig.ph/:path*',

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "redirects": [
-    { "source": "https://www.quickgig.ph/(.*)", "destination": "https://quickgig.ph/$1", "permanent": true }
-  ]
-}


### PR DESCRIPTION
## Summary
- remove invalid redirect from vercel.json and rely on Next.js config
- document Hostinger FTP docroot and use FTPS in deploy workflows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node tools/check_live_api.mjs` *(fails: Cannot find module 'tools/check_live_api.mjs')*
- `curl -fsSL --proxy "" https://api.quickgig.ph/` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689cab014a6c8327994eefffd26f8638