### PR TITLE
Add minimal PHP API and FTPS deployment workflow

### DIFF
--- a/.github/workflows/deploy-api-hotfix.yml
+++ b/.github/workflows/deploy-api-hotfix.yml
@@ -1,0 +1,22 @@
+name: Deploy API hotfix (minimal endpoints)
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy via FTPS to Hostinger docroot
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          port: ${{ secrets.FTP_PORT || 21 }}
+          protocol: ftps
+          local-dir: api-minimal
+          # IMPORTANT: actual docroot for api.quickgig.ph
+          server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
+          dangerous-clean-slate: true

--- a/api-minimal/.htaccess
+++ b/api-minimal/.htaccess
@@ -1,13 +1,10 @@
-# No directory listings; ensure PHP/HTML are index
 Options -Indexes
 DirectoryIndex index.php index.html
 
-# Deny access to dotfiles and sensitive files
 <FilesMatch "^(\.|composer\.json|composer\.lock|\.env|README|LICENSE)$">
   Require all denied
 </FilesMatch>
 
-# Basic security headers
 <IfModule mod_headers.c>
   Header set X-Content-Type-Options "nosniff"
   Header set X-Frame-Options "SAMEORIGIN"
@@ -16,7 +13,6 @@ DirectoryIndex index.php index.html
   Header set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 </IfModule>
 
-# Prevent access to phpinfo if accidentally left behind
 <Files "phpinfo.php">
   Require all denied
 </Files>

--- a/api-minimal/README.txt
+++ b/api-minimal/README.txt
@@ -1,0 +1,4 @@
+Drop-in minimal API for api.quickgig.ph
+- index.php   -> {"message":"QuickGig API"}
+- health.php  -> {"status":"ok"}
+Docroot target: /home/u789476867/domains/quickgig.ph/public_html/api/

--- a/api-minimal/health.php
+++ b/api-minimal/health.php
@@ -10,3 +10,4 @@ header('Access-Control-Allow-Headers: Content-Type, Authorization');
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
 header('Content-Type: application/json');
 echo json_encode(['status' => 'ok']);
+

--- a/api-minimal/index.php
+++ b/api-minimal/index.php
@@ -10,3 +10,4 @@ header('Access-Control-Allow-Headers: Content-Type, Authorization');
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
 header('Content-Type: application/json');
 echo json_encode(['message' => 'QuickGig API']);
+

--- a/api-minimal/phpinfo.php
+++ b/api-minimal/phpinfo.php
@@ -1,0 +1,1 @@
+<?php phpinfo();


### PR DESCRIPTION
## Summary
- serve minimal PHP API with `index.php` and `/health` endpoints
- add hardening `.htaccess`, README, and temporary `phpinfo.php`
- deploy API folder via new `deploy-api-hotfix` GitHub Action

## Testing
- `npm test` *(fails: fetch failed for https://api.quickgig.ph)*
- `curl -fsSL https://api.quickgig.ph/` *(fails: HTTP 403)*
- `curl -fsSL https://api.quickgig.ph/health` *(fails: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cb1a867348327b5f07561ba374470