### PR TITLE
chore: pin FTP deploy action

### DIFF
--- a/.github/workflows/deploy-api-hotfix.yml
+++ b/.github/workflows/deploy-api-hotfix.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Deploy via FTPS to Hostinger docroot
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/deploy-api-minimal.yml
+++ b/.github/workflows/deploy-api-minimal.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Deploy via FTPS
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -21,7 +21,7 @@ jobs:
           API_ENV: ${{ secrets.API_ENV }}
 
       - name: Deploy via FTPS
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/ops-probe-deploy-verify.yml
+++ b/.github/workflows/ops-probe-deploy-verify.yml
@@ -27,7 +27,7 @@ jobs:
           echo "file=__probe-$ts.txt" >> "$GITHUB_OUTPUT"
 
       - name: Upload probe (no clean slate)
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
@@ -94,7 +94,7 @@ jobs:
           HT
 
       - name: Deploy minimal API (endpoints + .htaccess)
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/probe-api-docroot.yml
+++ b/.github/workflows/probe-api-docroot.yml
@@ -14,7 +14,7 @@ jobs:
           echo "probe-$TS" > api-minimal/__probe-$TS.txt
           echo "PROBE_FILE=__probe-$TS.txt" >> $GITHUB_OUTPUT
       - name: Upload probe to Hostinger
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}


### PR DESCRIPTION
## Summary
- pin SamKirkland/FTP-Deploy-Action to v4.3.5 across all FTP deployment workflows

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc3dc9b848327b5cc992c5a37e313