### PR TITLE
Add ops-clean-api-docroot workflow for minimal API deployment

### DIFF
--- a/.github/workflows/ops-clean-api-docroot.yml
+++ b/.github/workflows/ops-clean-api-docroot.yml
@@ -1,0 +1,18 @@
+name: ops-clean-api-docroot
+on: { workflow_dispatch: {} }
+jobs:
+  clean_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean-slate deploy minimal API
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server:     ${{ secrets.FTP_SERVER }}
+          username:   ${{ secrets.FTP_USERNAME }}
+          password:   ${{ secrets.FTP_PASSWORD }}
+          port:       ${{ secrets.FTP_PORT || 21 }}
+          protocol:   ftps
+          local-dir:  api-minimal/
+          server-dir: /home/u789476867/domains/quickgig.ph/public_html/api/
+          dangerous-clean-slate: true

--- a/api-minimal/README.txt
+++ b/api-minimal/README.txt
@@ -1,4 +1,0 @@
-Drop-in minimal API for api.quickgig.ph
-- index.php   -> {"message":"QuickGig API"}
-- health.php  -> {"status":"ok"}
-Docroot target: /home/u789476867/domains/quickgig.ph/public_html/api/

--- a/api-minimal/phpinfo.php
+++ b/api-minimal/phpinfo.php
@@ -1,1 +1,0 @@
-<?php phpinfo();


### PR DESCRIPTION
## Summary
- add manual ops-clean-api-docroot workflow using FTP-Deploy-Action with clean slate
- prune api-minimal to only essential endpoints

## Testing
- `npm test`
- `gh workflow run ops-clean-api-docroot` *(fails: command not found)*
- `gh workflow run ops-probe-deploy-verify -f ref=main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d30140bbc8327888ec6dc29ff7da8