### PR TITLE
Style homepage to match app.quickgig.ph + fix Vercel metadata build error

### DIFF
--- a/src/app/_components/HomeHeroClient.tsx
+++ b/src/app/_components/HomeHeroClient.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Button from '@/components/ui/Button';
+import { Card, CardContent } from '@/components/ui/Card';
+import { Briefcase, MousePointerClick, Shield } from 'lucide-react';
+import { safeFetch } from '@/lib/api';
+
+type ApiStatus = 'loading' | 'ok' | 'error';
+
+export default function HomeHeroClient() {
+  const [status, setStatus] = useState<ApiStatus>('loading');
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const res = await safeFetch('/health');
+        if (!res.ok) throw new Error(String(res.status));
+        const data = JSON.parse(res.body);
+        if (data?.status === 'ok' || data?.message === 'QuickGig API') setStatus('ok');
+        else setStatus('error');
+      } catch {
+        setStatus('error');
+      }
+    }
+    check();
+  }, []);
+
+  const features = [
+    { title: 'Post a gig in minutes', icon: Briefcase },
+    { title: 'Apply with one tap', icon: MousePointerClick },
+    { title: 'Secure messaging & updates', icon: Shield },
+  ];
+
+  return (
+    <div>
+      <section className="bg-gradient-to-br from-primary via-primary to-secondary text-white">
+        <div className="qg-container text-center py-24">
+          <h1 className="font-heading text-5xl font-bold mb-4">QuickGig</h1>
+          <p className="font-body text-xl mb-8 text-white/90">
+            Gigs and talent, matched fast.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a
+              href="https://app.quickgig.ph"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button size="lg" variant="secondary" className="text-lg">
+                Open the app
+              </Button>
+            </a>
+            <Link href="/health-check">
+              <Button
+                size="lg"
+                variant="outline"
+                className="text-lg border-white text-white hover:bg-white hover:text-primary"
+              >
+                Health check
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <div className="bg-gray-100">
+        <div className="qg-container py-2 flex justify-center">
+          {status === 'loading' ? (
+            <span className="text-sm text-gray-600">Checking API…</span>
+          ) : (
+            <span
+              className={`px-3 py-1 rounded-full text-sm font-medium text-white ${
+                status === 'ok' ? 'bg-green-600' : 'bg-red-600'
+              }`}
+            >
+              API: {status === 'ok' ? 'OK' : 'ERROR'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <section className="py-20">
+        <div className="qg-container grid gap-8 md:grid-cols-3">
+          {features.map(({ title, icon: Icon }) => (
+            <Card key={title} className="text-center">
+              <CardContent className="flex flex-col items-center">
+                <Icon className="h-10 w-10 text-primary mb-4" />
+                <h3 className="font-heading text-xl font-semibold text-fg">
+                  {title}
+                </h3>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,14 +6,18 @@
 @import '../styles/design-system.css';
 
 :root {
-  --background: #ffffff;
-  --foreground: #374151;
+  --color-primary: #00B272;
+  --color-secondary: #FFD447;
+  --bg: #ffffff;
+  --fg: #002C3E;
+  --background: var(--bg);
+  --foreground: var(--fg);
 }
 
 /* Base styles with QuickGig branding */
 body {
-  color: var(--foreground);
-  background: var(--background);
+  color: var(--fg);
+  background: var(--bg);
   font-family: var(--qg-font-body);
   line-height: var(--qg-leading-normal);
   -webkit-font-smoothing: antialiased;
@@ -24,7 +28,7 @@ body {
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--qg-font-heading);
   font-weight: var(--qg-font-bold);
-  color: var(--qg-navy);
+  color: var(--fg);
   line-height: var(--qg-leading-tight);
 }
 
@@ -46,13 +50,19 @@ button {
 
 /* Link styles */
 a {
-  color: var(--qg-primary-green);
+  color: var(--color-primary);
   text-decoration: none;
   transition: color var(--qg-transition-fast);
 }
 
 a:hover {
-  color: var(--qg-green-hover);
+  color: var(--color-secondary);
+}
+
+a:focus,
+button:focus {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 2px;
 }
 
 /* Form element styles */
@@ -64,7 +74,7 @@ input, textarea, select {
 
 input:focus, textarea:focus, select:focus {
   outline: none;
-  border-color: var(--qg-primary-green);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(0, 178, 114, 0.1);
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,105 +1,10 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import Button from '@/components/ui/Button';
-import { Card, CardContent } from '@/components/ui/Card';
-import { Briefcase, MousePointerClick, Shield } from 'lucide-react';
-import { safeFetch } from '@/lib/api';
-
 export const metadata = {
   title: 'QuickGig',
   description: 'Gigs and talent, matched fast.',
 };
-
-type ApiStatus = 'loading' | 'ok' | 'error';
+import HomeHeroClient from './_components/HomeHeroClient';
 
 export default function HomePage() {
-  const [status, setStatus] = useState<ApiStatus>('loading');
-
-  useEffect(() => {
-    async function check() {
-      try {
-        const res = await safeFetch('/health');
-        if (!res.ok) throw new Error(String(res.status));
-        const data = JSON.parse(res.body);
-        if (data?.status === 'ok' || data?.message === 'QuickGig API') setStatus('ok');
-        else setStatus('error');
-      } catch {
-        setStatus('error');
-      }
-    }
-    check();
-  }, []);
-
-  const features = [
-    { title: 'Post a gig in minutes', icon: Briefcase },
-    { title: 'Apply with one tap', icon: MousePointerClick },
-    { title: 'Secure messaging & updates', icon: Shield },
-  ];
-
-  return (
-    <div>
-      <section className="qg-hero bg-gradient-to-br from-qg-primary via-qg-primary-dark to-qg-navy text-white">
-        <div className="qg-container text-center py-24">
-          <h1 className="font-heading text-5xl font-bold mb-4">QuickGig</h1>
-          <p className="font-body text-xl mb-8 text-white/90">
-            Gigs and talent, matched fast.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
-              href="https://app.quickgig.ph"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button size="lg" variant="secondary" className="text-lg">
-                Open the app
-              </Button>
-            </a>
-            <Link href="/health-check">
-              <Button
-                size="lg"
-                variant="outline"
-                className="text-lg border-white text-white hover:bg-white hover:text-qg-navy"
-              >
-                Health check
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      <div className="bg-gray-100">
-        <div className="qg-container py-2 flex justify-center">
-          {status === 'loading' ? (
-            <span className="text-sm text-gray-600">Checking API…</span>
-          ) : (
-            <span
-              className={`px-3 py-1 rounded-full text-sm font-medium text-white ${
-                status === 'ok' ? 'bg-green-600' : 'bg-red-600'
-              }`}
-            >
-              API: {status === 'ok' ? 'OK' : 'ERROR'}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <section className="py-20">
-        <div className="qg-container grid gap-8 md:grid-cols-3">
-          {features.map(({ title, icon: Icon }) => (
-            <Card key={title} className="text-center">
-              <CardContent className="flex flex-col items-center">
-                <Icon className="h-10 w-10 text-qg-primary mb-4" />
-                <h3 className="font-heading text-xl font-semibold text-qg-navy">
-                  {title}
-                </h3>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
+  return <HomeHeroClient />;
 }
 

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -12,13 +12,13 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'primary', size = 'md', children, loading, disabled, ...props }, ref) => {
-    const baseClasses = 'qg-btn inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
-    
+    const baseClasses = 'inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+
     const variants = {
-      primary: 'qg-btn-primary focus:ring-qg-primary',
-      secondary: 'qg-btn-secondary focus:ring-qg-accent',
-      outline: 'qg-btn-outline focus:ring-qg-primary',
-      ghost: 'bg-transparent text-qg-primary hover:bg-qg-primary/10 focus:ring-qg-primary',
+      primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
+      secondary: 'bg-secondary text-fg hover:bg-secondary/90 focus:ring-secondary',
+      outline: 'border border-primary text-primary hover:bg-primary hover:text-white focus:ring-primary',
+      ghost: 'bg-transparent text-primary hover:bg-primary/10 focus:ring-primary',
     };
     
     const sizes = {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -39,7 +39,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          'qg-card bg-white rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
+          'bg-white rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
           hover && 'hover:shadow-qg-lg hover:-translate-y-1 cursor-pointer',
           paddingClasses[padding],
           className
@@ -56,8 +56,8 @@ const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
     const variants = {
       default: 'bg-gray-50 text-gray-900',
-      primary: 'qg-card-header bg-qg-primary text-white',
-      accent: 'bg-qg-accent text-qg-navy',
+      primary: 'bg-primary text-white',
+      accent: 'bg-secondary text-fg',
     };
 
     return (
@@ -108,8 +108,8 @@ const CardTag = React.forwardRef<HTMLSpanElement, CardTagProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
     const variants = {
       default: 'bg-gray-100 text-gray-800',
-      primary: 'bg-qg-primary text-white',
-      accent: 'qg-card-tag bg-qg-accent text-qg-navy',
+      primary: 'bg-primary text-white',
+      accent: 'bg-secondary text-fg',
     };
 
     return (

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -32,7 +32,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="space-y-2">
         {label && (
-          <label htmlFor={inputId} className="qg-label block text-sm font-medium text-qg-navy">
+          <label htmlFor={inputId} className="block text-sm font-medium text-fg">
             {label}
           </label>
         )}
@@ -46,8 +46,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             type={type}
             id={inputId}
             className={cn(
-              'qg-input block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-              'focus:ring-2 focus:ring-qg-primary/20 focus:border-qg-primary transition-all duration-qg-fast',
+              'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+              'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
               'placeholder:text-gray-400',
               error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
               icon && iconPosition === 'left' && 'pl-10',
@@ -81,19 +81,19 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <div className="space-y-2">
         {label && (
-          <label htmlFor={textareaId} className="qg-label block text-sm font-medium text-qg-navy">
+          <label htmlFor={textareaId} className="block text-sm font-medium text-fg">
             {label}
           </label>
         )}
         <textarea
           id={textareaId}
-          className={cn(
-            'qg-input block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-            'focus:ring-2 focus:ring-qg-primary/20 focus:border-qg-primary transition-all duration-qg-fast',
-            'placeholder:text-gray-400 resize-vertical min-h-[100px]',
-            error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
-            className
-          )}
+            className={cn(
+              'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+              'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
+              'placeholder:text-gray-400 resize-vertical min-h-[100px]',
+              error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
+              className
+            )}
           ref={ref}
           {...props}
         />
@@ -115,15 +115,15 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <div className="space-y-2">
         {label && (
-          <label htmlFor={selectId} className="qg-label block text-sm font-medium text-qg-navy">
+          <label htmlFor={selectId} className="block text-sm font-medium text-fg">
             {label}
           </label>
         )}
         <select
           id={selectId}
           className={cn(
-            'qg-input block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-            'focus:ring-2 focus:ring-qg-primary/20 focus:border-qg-primary transition-all duration-qg-fast',
+            'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+            'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
             'bg-white cursor-pointer',
             error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
             className

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,8 +9,12 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        primary: 'var(--color-primary)',
+        secondary: 'var(--color-secondary)',
+        bg: 'var(--bg)',
+        fg: 'var(--fg)',
+        background: 'var(--bg)',
+        foreground: 'var(--fg)',
         // QuickGig Brand Colors
         qg: {
           primary: {


### PR DESCRIPTION
## Summary
- expose `--color-primary`/`secondary` and foreground/background tokens and map to Tailwind
- restyle shared components and homepage to use new color tokens
- move homepage metadata to server component to fix Vercel build

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run check:api` *(fails: fetch failed)*
- `npm run check:app` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d52ca87a483279fa76b8a2f9ae23d