### PR TITLE
feat(ui): match app.quickgig.ph styling + fix Next metadata build error

### DIFF
--- a/src/app/_components/HomePageClient.tsx
+++ b/src/app/_components/HomePageClient.tsx
@@ -9,7 +9,7 @@ import { safeFetch } from '@/lib/api';
 
 type ApiStatus = 'loading' | 'ok' | 'error';
 
-export default function HomeHeroClient() {
+export default function HomePageClient() {
   const [status, setStatus] = useState<ApiStatus>('loading');
 
   useEffect(() => {
@@ -35,10 +35,10 @@ export default function HomeHeroClient() {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-primary via-primary to-secondary text-white">
+      <section className="bg-gradient-to-br from-primary via-primary to-secondary text-fg">
         <div className="qg-container text-center py-24">
           <h1 className="font-heading text-5xl font-bold mb-4">QuickGig</h1>
-          <p className="font-body text-xl mb-8 text-white/90">
+          <p className="font-body text-xl mb-8 text-fg opacity-90">
             Gigs and talent, matched fast.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -55,7 +55,7 @@ export default function HomeHeroClient() {
               <Button
                 size="lg"
                 variant="outline"
-                className="text-lg border-white text-white hover:bg-white hover:text-primary"
+                className="text-lg border-fg text-fg hover:bg-fg hover:text-bg"
               >
                 Health check
               </Button>
@@ -64,14 +64,14 @@ export default function HomeHeroClient() {
         </div>
       </section>
 
-      <div className="bg-gray-100">
+      <div className="bg-bg">
         <div className="qg-container py-2 flex justify-center">
           {status === 'loading' ? (
-            <span className="text-sm text-gray-600">Checking API…</span>
+            <span className="text-sm text-fg opacity-80">Checking API…</span>
           ) : (
             <span
-              className={`px-3 py-1 rounded-full text-sm font-medium text-white ${
-                status === 'ok' ? 'bg-green-600' : 'bg-red-600'
+              className={`px-3 py-1 rounded-full text-sm font-medium text-fg ${
+                status === 'ok' ? 'bg-primary' : 'bg-red-600'
               }`}
             >
               API: {status === 'ok' ? 'OK' : 'ERROR'}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,10 +6,10 @@
 @import '../styles/design-system.css';
 
 :root {
-  --color-primary: #00B272;
-  --color-secondary: #FFD447;
-  --bg: #ffffff;
-  --fg: #002C3E;
+  --color-primary: #7C3AED; /* TODO: replace with real primary from app.quickgig.ph */
+  --color-secondary: #0EA5E9; /* TODO: replace with real secondary from app.quickgig.ph */
+  --bg: #0B0B0F; /* TODO: replace with real background from app.quickgig.ph */
+  --fg: #F5F7FA; /* TODO: replace with real foreground from app.quickgig.ph */
   --background: var(--bg);
   --foreground: var(--fg);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -81,7 +81,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
-      <body className="font-body antialiased bg-white text-gray-700">
+      <body className="font-body antialiased bg-bg text-fg">
         <AuthProvider>
           <SocketProvider>
             <Navigation />
@@ -94,24 +94,24 @@ export default function RootLayout({
                   <div className="col-span-1 md:col-span-2">
                     {/* eslint-disable-next-line @next/next/no-img-element -- logo placeholder */}
                     <img src="/logo-horizontal.png" alt="QuickGig.ph" className="h-8 mb-4" />
-                    <p className="text-gray-300 mb-4">
+                    <p className="text-fg opacity-70 mb-4">
                       Ang pinakamabilis na paraan para makahanap ng trabaho at talent sa Pilipinas.
                     </p>
-                    <p className="text-sm text-gray-400">
+                    <p className="text-sm text-fg opacity-60">
                       © 2024 QuickGig.ph. All rights reserved.
                     </p>
                   </div>
                   <div>
-                    <h3 className="font-heading font-semibold text-white mb-4">Para sa Freelancers</h3>
-                    <ul className="space-y-2 text-gray-300">
+                    <h3 className="font-heading font-semibold text-fg mb-4">Para sa Freelancers</h3>
+                    <ul className="space-y-2 text-fg opacity-70">
                       <li><a href="/find-work" className="hover:text-qg-accent transition-colors">Find Work</a></li>
                       <li><a href="/profile" className="hover:text-qg-accent transition-colors">Profile</a></li>
                       <li><a href="/my-jobs" className="hover:text-qg-accent transition-colors">My Jobs</a></li>
                     </ul>
                   </div>
                   <div>
-                    <h3 className="font-heading font-semibold text-white mb-4">Para sa Employers</h3>
-                    <ul className="space-y-2 text-gray-300">
+                    <h3 className="font-heading font-semibold text-fg mb-4">Para sa Employers</h3>
+                    <ul className="space-y-2 text-fg opacity-70">
                       <li><a href="/post-job" className="hover:text-qg-accent transition-colors">Post Job</a></li>
                       <li><a href="/buy-tickets" className="hover:text-qg-accent transition-colors">Buy Tickets</a></li>
                       <li><a href="/messages" className="hover:text-qg-accent transition-colors">Messages</a></li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
-export const metadata = {
+import type { Metadata } from 'next';
+import HomePageClient from './_components/HomePageClient';
+
+export const metadata: Metadata = {
   title: 'QuickGig',
   description: 'Gigs and talent, matched fast.',
 };
-import HomeHeroClient from './_components/HomeHeroClient';
 
-export default function HomePage() {
-  return <HomeHeroClient />;
+export default async function Page() {
+  return <HomePageClient />;
 }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -35,7 +35,7 @@ const Navigation: React.FC = () => {
                 className="h-10 w-10 transition-transform duration-qg-fast group-hover:scale-105"
                 priority
               />
-              <span className="font-heading text-xl font-bold text-white hidden sm:block">
+              <span className="font-heading text-xl font-bold text-fg hidden sm:block">
                 QuickGig<span className="text-qg-accent">.ph</span>
               </span>
             </Link>
@@ -109,11 +109,11 @@ const Navigation: React.FC = () => {
                   </Link>
                   <div className="hidden xl:flex flex-col">
                     <span className="text-xs text-gray-300">Kumusta,</span>
-                    <span className="text-sm font-medium text-white">{user?.name}</span>
+                    <span className="text-sm font-medium text-fg">{user?.name}</span>
                   </div>
                   <button
                     onClick={handleLogout}
-                    className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-white"
+                    className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-fg"
                   >
                     <LogOut className="w-4 h-4" />
                     <span className="hidden xl:inline ml-2">Logout</span>
@@ -123,7 +123,7 @@ const Navigation: React.FC = () => {
             ) : (
               <div className="flex items-center space-x-3 ml-4 pl-4 border-l border-qg-navy-light">
                 <Link href="/login">
-                  <Button variant="ghost" size="sm" className="text-white hover:bg-qg-navy-light hover:text-qg-accent">
+                  <Button variant="ghost" size="sm" className="text-fg hover:bg-qg-navy-light hover:text-qg-accent">
                     Login
                   </Button>
                 </Link>
@@ -181,7 +181,7 @@ const Navigation: React.FC = () => {
                 <>
                   <div className="border-t border-qg-navy-light my-4 pt-4">
                     <div className="px-4 py-2 text-sm text-gray-300">
-                      Kumusta, <span className="font-medium text-white">{user?.name}</span>
+                      Kumusta, <span className="font-medium text-fg">{user?.name}</span>
                     </div>
                   </div>
                   
@@ -225,7 +225,7 @@ const Navigation: React.FC = () => {
                   <div className="border-t border-qg-navy-light mt-4 pt-4">
                     <button
                       onClick={handleLogout}
-                      className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-white w-full text-left"
+                      className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-fg w-full text-left"
                     >
                       <LogOut className="w-5 h-5 mr-3" />
                       Logout
@@ -235,7 +235,7 @@ const Navigation: React.FC = () => {
               ) : (
                 <div className="border-t border-qg-navy-light mt-4 pt-4 space-y-3">
                   <Link href="/login" onClick={() => setIsMenuOpen(false)}>
-                    <Button variant="ghost" className="w-full text-white hover:bg-qg-navy-light hover:text-qg-accent">
+                    <Button variant="ghost" className="w-full text-fg hover:bg-qg-navy-light hover:text-qg-accent">
                       Login
                     </Button>
                   </Link>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -12,12 +12,12 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'primary', size = 'md', children, loading, disabled, ...props }, ref) => {
-    const baseClasses = 'inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+    const baseClasses = 'inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg disabled:opacity-50 disabled:cursor-not-allowed';
 
     const variants = {
-      primary: 'bg-primary text-white hover:bg-primary/90 focus:ring-primary',
+      primary: 'bg-primary text-fg hover:bg-primary/90 focus:ring-primary',
       secondary: 'bg-secondary text-fg hover:bg-secondary/90 focus:ring-secondary',
-      outline: 'border border-primary text-primary hover:bg-primary hover:text-white focus:ring-primary',
+      outline: 'border border-primary text-primary hover:bg-primary hover:text-fg focus:ring-primary',
       ghost: 'bg-transparent text-primary hover:bg-primary/10 focus:ring-primary',
     };
     

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -39,7 +39,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          'bg-white rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
+          'bg-bg text-fg rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
           hover && 'hover:shadow-qg-lg hover:-translate-y-1 cursor-pointer',
           paddingClasses[padding],
           className
@@ -55,8 +55,8 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
 const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
     const variants = {
-      default: 'bg-gray-50 text-gray-900',
-      primary: 'bg-primary text-white',
+      default: 'bg-bg text-fg',
+      primary: 'bg-primary text-fg',
       accent: 'bg-secondary text-fg',
     };
 
@@ -107,8 +107,8 @@ const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(
 const CardTag = React.forwardRef<HTMLSpanElement, CardTagProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
     const variants = {
-      default: 'bg-gray-100 text-gray-800',
-      primary: 'bg-primary text-white',
+      default: 'bg-bg text-fg border border-fg',
+      primary: 'bg-primary text-fg',
       accent: 'bg-secondary text-fg',
     };
 

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -7,10 +7,10 @@
 /* CSS Custom Properties - Brand Colors */
 :root {
   /* Primary Brand Colors */
-  --qg-primary-green: #00B272;
-  --qg-accent-yellow: #FFD447;
-  --qg-navy: #002C3E;
-  --qg-white: #FFFFFF;
+  --qg-primary-green: var(--color-primary);
+  --qg-accent-yellow: var(--color-secondary);
+  --qg-navy: var(--bg);
+  --qg-white: var(--fg);
   
   /* Color Variations */
   --qg-green-light: #00D085;


### PR DESCRIPTION
## Summary
- define primary/secondary/bg/fg CSS variables (placeholder hexes) and wire them through Tailwind and design system
- restyle shared UI components and layout to use the new tokens
- move homepage client logic into `HomePageClient` and keep `page.tsx` as a server component with metadata

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d5629d72c83279786e0ed596ec82e