### PR TITLE
fix: cross-domain auth (cookies + CORS)

### DIFF
--- a/api.quickgig.ph/health.php
+++ b/api.quickgig.ph/health.php
@@ -1,4 +1,4 @@
 <?php
 require_once __DIR__ . '/src/cors.php';
 cors();
-echo json_encode(['status' => 'ok']);
+echo json_encode(['ok' => true, 'ts' => time()]);

--- a/api.quickgig.ph/index.php
+++ b/api.quickgig.ph/index.php
@@ -59,6 +59,14 @@ try {
     $u = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$u || !password_verify($pass, $u['password_hash'])) return json_bad('Invalid credentials', 401);
     $token = jwt_sign(['uid' => (int)$u['id'], 'iat'=>time(), 'exp'=>time()+60*60*24*7]); // 7d
+    setcookie('qg_session', $token, [
+      'expires' => time() + 60*60*24*30,
+      'path' => '/',
+      'domain' => '.quickgig.ph',
+      'secure' => true,
+      'httponly' => true,
+      'samesite' => 'None',
+    ]);
     return json_ok(['token'=>$token]);
   }
 

--- a/api.quickgig.ph/src/cors.php
+++ b/api.quickgig.ph/src/cors.php
@@ -1,9 +1,17 @@
 <?php
 function cors() {
-  header('Access-Control-Allow-Origin: https://quickgig.ph');
+  $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+  $allowed = ['https://quickgig.ph', 'https://app.quickgig.ph'];
+  if (in_array($origin, $allowed, true)) {
+    header("Access-Control-Allow-Origin: $origin");
+  }
   header('Vary: Origin');
-  header('Access-Control-Allow-Methods: GET, OPTIONS');
-  header('Access-Control-Allow-Headers: Content-Type');
-  if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
+  header('Access-Control-Allow-Credentials: true');
+  header('Access-Control-Allow-Headers: Content-Type, Authorization');
+  header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+  if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit;
+  }
   header('Content-Type: application/json; charset=utf-8');
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,7 @@ export async function safeFetch(
     const res = await fetch(`${getApiBase()}${path}`, {
       mode: 'cors',
       ...init,
+      credentials: 'include',
       signal: controller.signal,
     });
     const body = await res.text();


### PR DESCRIPTION
## Summary
- adjust API CORS to allow quickgig.ph and app.quickgig.ph with credentials
- set qg_session cookie on login for 30 days
- include credentials on frontend API fetches and expose health timestamp

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `curl -i https://api.quickgig.ph/health.php -H "Origin: https://quickgig.ph"` *(failed: CONNECT tunnel failed, response 403)*
- `curl -i -X OPTIONS https://api.quickgig.ph/health.php -H "Origin: https://quickgig.ph" -H "Access-Control-Request-Method: GET"` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d796045948327a3df6588d265cd25