### PR TITLE
fix: /app asset proxy (styles & scripts)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -27,3 +27,5 @@ jobs:
         run: npm run check:api
       - name: Check App (skips if BASE not set)
         run: npm run check:app
+      - name: Check App Assets (skips if BASE not set)
+        run: npm run check:appassets

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,47 @@ const nextConfig = {
     return [{ source: '/', destination: '/app', permanent: true }];
   },
   async rewrites() {
-    return [{ source: '/app/:path*', destination: 'https://app.quickgig.ph/:path*' }];
+    return [
+      // Existing proxy for the HTML itself
+      { source: '/app/:path*', destination: 'https://app.quickgig.ph/:path*' },
+
+      // --- Asset proxies (only when coming from /app) ---
+      {
+        source: '/_next/:path*',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/_next/:path*',
+      },
+      {
+        source: '/assets/:path*',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/assets/:path*',
+      },
+      {
+        source: '/static/:path*',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/static/:path*',
+      },
+      {
+        source: '/images/:path*',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/images/:path*',
+      },
+      {
+        source: '/fonts/:path*',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/fonts/:path*',
+      },
+      {
+        source: '/favicon.ico',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/favicon.ico',
+      },
+      {
+        source: '/manifest.json',
+        has: [{ type: 'header', key: 'referer', value: '.*\\/app.*' }],
+        destination: 'https://app.quickgig.ph/manifest.json',
+      },
+    ];
   },
   eslint: { ignoreDuringBuilds: false },
   typescript: { ignoreBuildErrors: false },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:api": "node tools/check_api.mjs",
     "check:api:soft": "node tools/check_live_api.mjs || true",
     "check:app": "node tools/check_app.mjs",
+    "check:appassets": "node tools/check_app_assets.mjs",
     "check:app:soft": "node tools/check_live_app.mjs || true",
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",

--- a/tools/check_app_assets.mjs
+++ b/tools/check_app_assets.mjs
@@ -1,0 +1,34 @@
+const base = (process.env.BASE || '').replace(/\/\$/, '');
+if (!base) { console.warn('No BASE provided; skipping asset check'); process.exit(0); }
+
+const fetchImpl = globalThis.fetch;
+
+function pickAssets(html) {
+  // naive scrape: collect first few absolute assets (href/src starting with "/")
+  const urls = new Set();
+  const re = /(href|src)=["'](\/[^"']+\.(?:css|js))["']/gi;
+  let m; let count = 0;
+  while ((m = re.exec(html)) && count < 6) { urls.add(m[2]); count++; }
+  return Array.from(urls);
+}
+
+(async () => {
+  const page = await fetchImpl(base + '/app', { redirect: 'manual' });
+  if (page.status < 200 || page.status >= 400) {
+    throw new Error(`GET /app ${page.status}`);
+  }
+  const html = await page.text();
+  const assets = pickAssets(html);
+  if (!assets.length) {
+    console.log('No absolute .css/.js assets detected; nothing to check. (OK)');
+    process.exit(0);
+  }
+
+  for (const a of assets) {
+    const r = await fetchImpl(base + a, { redirect: 'manual' });
+    if (r.status < 200 || r.status >= 400) {
+      throw new Error(`Asset ${a} failed with ${r.status}`);
+    }
+  }
+  console.log('App assets OK');
+})();


### PR DESCRIPTION
## Summary
- proxy asset paths like `/_next/*`, `/assets/*`, etc to `app.quickgig.ph` when Referer contains `/app`
- add `check_app_assets.mjs` script and hook it into smoke CI
- result: `https://quickgig.ph/app` should render with CSS/JS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `BASE=https://quickgig.ph npm run check:appassets` *(fails: fetch failed, connect ENETUNREACH)*
- `npm run check:appassets`

------
https://chatgpt.com/codex/tasks/task_e_689d85af9ca08327964156524ffb5f29