### PR TITLE
feat: canonical redirect to app.quickgig.ph (drop /app proxy)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,11 +21,9 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci --ignore-scripts
-      - name: Scan for hardcoded app subdomain
-        run: npm run scan:appdomain
+      - name: Scan for stale /app links
+        run: npm run scan:links
       - name: Check API health
         run: npm run check:api
-      - name: Check App (skips if BASE not set)
-        run: npm run check:app
-      - name: Check App Assets (skips if BASE not set)
-        run: npm run check:appassets
+      - name: Check Root Redirect (skips if BASE not set)
+        run: node tools/check_root_redirect.mjs

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ settings.
 Login, signup, and other protected pages call the external API at
 `https://api.quickgig.ph`; this Next.js app does not provide any API routes.
 
-### Option A behavior
+### Behavior
 
-* The main site `/` redirects to `/app`, which proxies `https://app.quickgig.ph`.
+* The root `https://quickgig.ph` permanently redirects to `https://app.quickgig.ph`.
 * `/health-check` remains available for diagnostics.
-* If login via `/app` has cookie issues, set API/app cookies with:
+* If login via `https://app.quickgig.ph` has cookie issues, set API/app cookies with:
   `Domain=.quickgig.ph; Path=/; Secure; HttpOnly; SameSite=None`.
-* Direct usage of [https://app.quickgig.ph](https://app.quickgig.ph) still works.
+* Direct usage of [https://app.quickgig.ph](https://app.quickgig.ph) is canonical.
 
 ### Smoke checks
 
@@ -61,16 +61,15 @@ The app defaults to the public API if `NEXT_PUBLIC_API_URL` is unset:
 NEXT_PUBLIC_API_URL=https://api.quickgig.ph
 ```
 
-Verify the production app and API:
+Verify the production root redirect and API:
 
 ```bash
-npm run check:app
+BASE=https://quickgig.ph node tools/check_root_redirect.mjs
 BASE=https://api.quickgig.ph npm run check:api
 ```
 
 ## Production routing
-- quickgig.ph/ redirects to /app
-- /app/* proxies https://app.quickgig.ph/*
+- Root: `https://quickgig.ph` → **301/308 to `https://app.quickgig.ph`**
 
 # QuickGig Frontend – Production Runbook
 
@@ -78,14 +77,11 @@ This repo hosts the Next.js frontend for QuickGig.
 
 ## Domains
 - **Root (Vercel):** `https://quickgig.ph`
-- **Product path:** `https://quickgig.ph/app` *(proxied from `https://app.quickgig.ph` via Next.js rewrites)*
-- **Legacy app (preserved):** `https://app.quickgig.ph`
+- **App:** `https://app.quickgig.ph`
 - **API (PHP on Hostinger):** `https://api.quickgig.ph`
 
 ## Routing
-- `/` **redirects** to `/app` (permanent).
-- `/app/*` is **proxied** to `https://app.quickgig.ph/*` by `next.config.js` rewrites.
-- Deep links and nav CTAs must point to `/app` (same-origin). CI has a scan that fails if `https://app.quickgig.ph` is hardcoded in UI.
+- `/` **redirects** to `https://app.quickgig.ph` (permanent).
 
 ## Environment
 - `NEXT_PUBLIC_API_URL=https://api.quickgig.ph`
@@ -125,23 +121,23 @@ Preflight (`OPTIONS`) should return `200`.
 * **API health:** `https://api.quickgig.ph/health.php` → JSON `{ ok: true, ts: <unix> }`
 * **Smoke workflow** (`.github/workflows/smoke.yml`):
 
-  * On `main`: checks API health and that `/` redirects and `/app` loads (2xx/3xx) using `BASE=https://quickgig.ph`.
-  * On PRs: app check may skip unless `BASE` is provided.
+  * On `main`: checks API health and that `/` redirects to `https://app.quickgig.ph` using `BASE=https://quickgig.ph`.
+  * On PRs: redirect check may skip unless `BASE` is provided.
 
 ### Local/Preview Notes
 
-* Local dev: the `/app` rewrite attempts to reach `https://app.quickgig.ph`; if blocked, local `/app` may 500—this is expected and not a blocker. Validate on Vercel preview or production.
+* Local dev: root redirect may not be representative; validate on Vercel preview or production.
 
 ## Manual Triage
 
-* Frontend: visit `https://quickgig.ph/` (should redirect to `/app`) and navigate through the product.
+* Frontend: `curl -I https://quickgig.ph/` shows `Location: https://app.quickgig.ph/` and navigating to the app works.
 * API: `https://api.quickgig.ph/health.php` in a browser.
 * DevTools → Application → Cookies: confirm `.quickgig.ph` cookie, `Secure`, `HttpOnly`, `SameSite=None`.
 
 ## Screenshots / Evidence (attach in PR description)
 
-* `quickgig.ph` redirecting to `/app`
-* `/app` rendering under the **quickgig.ph** origin
+* `quickgig.ph` redirecting to `https://app.quickgig.ph`
+* `https://app.quickgig.ph` rendering correctly
 * `api.quickgig.ph/health.php` JSON
 * Latest successful **Smoke** run on `main`
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,33 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async redirects() {
-    return [{ source: '/', destination: '/app', permanent: true }];
-  },
-  async rewrites() {
     return [
-      // HTML proxy for the product under /app
-      { source: '/app/:path*', destination: 'https://app.quickgig.ph/:path*' },
-
-      // ==== GLOBAL ASSET PROXY (UNCONDITIONAL) ====
-      // Next/SPA assets
-      { source: '/_next/:path*', destination: 'https://app.quickgig.ph/_next/:path*' },
-      // Common static buckets used by the app
-      { source: '/assets/:path*', destination: 'https://app.quickgig.ph/assets/:path*' },
-      { source: '/static/:path*', destination: 'https://app.quickgig.ph/static/:path*' },
-      { source: '/images/:path*', destination: 'https://app.quickgig.ph/images/:path*' },
-      { source: '/img/:path*',    destination: 'https://app.quickgig.ph/img/:path*' },
-      { source: '/fonts/:path*',  destination: 'https://app.quickgig.ph/fonts/:path*' },
-      { source: '/media/:path*',  destination: 'https://app.quickgig.ph/media/:path*' },
-      { source: '/uploads/:path*',destination: 'https://app.quickgig.ph/uploads/:path*' },
-      // Root assets / meta
-      { source: '/favicon.ico',      destination: 'https://app.quickgig.ph/favicon.ico' },
-      { source: '/manifest.json',    destination: 'https://app.quickgig.ph/manifest.json' },
-      { source: '/site.webmanifest', destination: 'https://app.quickgig.ph/site.webmanifest' },
-      { source: '/robots.txt',       destination: 'https://app.quickgig.ph/robots.txt' },
-      { source: '/sitemap.xml',      destination: 'https://app.quickgig.ph/sitemap.xml' },
+      // Canonicalize root to the live product
+      { source: '/', destination: 'https://app.quickgig.ph', permanent: true },
+      // Safety: also catch any lingering /app usages
+      { source: '/app/:path*', destination: 'https://app.quickgig.ph/:path*', permanent: true },
+      { source: '/app', destination: 'https://app.quickgig.ph', permanent: true },
     ];
   },
-  eslint: { ignoreDuringBuilds: false },
-  typescript: { ignoreBuildErrors: false },
+  // No rewrites needed anymore.
+  async rewrites() { return []; },
 };
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",
-    "scan:appdomain": "node tools/scan_app_domain.mjs"
+    "scan:appdomain": "node tools/scan_app_domain.mjs",
+    "scan:links": "node tools/scan_links.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -36,7 +36,7 @@ export default function HomePageClient() {
             Gigs and talent, matched fast.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/app" prefetch={false}>
+            <Link href="https://app.quickgig.ph" prefetch={false}>
               <Button size="lg" variant="secondary" className="text-lg">
                 Open the app
               </Button>

--- a/tools/check_root_redirect.mjs
+++ b/tools/check_root_redirect.mjs
@@ -1,0 +1,9 @@
+const base = (process.env.BASE || '').replace(/\/$/, '');
+if (!base) { console.warn('No BASE provided; skipping root redirect check'); process.exit(0); }
+(async () => {
+  const r = await fetch(base + '/', { method: 'HEAD', redirect: 'manual' });
+  if (![301,302,307,308].includes(r.status)) throw new Error(`HEAD / expected redirect, got ${r.status}`);
+  const loc = r.headers.get('location') || '';
+  if (!/^https:\/\/app\.quickgig\.ph(\/|$)/.test(loc)) throw new Error(`Redirect location not app.quickgig.ph: ${loc}`);
+  console.log('Root redirect OK');
+})();

--- a/tools/scan_links.mjs
+++ b/tools/scan_links.mjs
@@ -1,0 +1,25 @@
+import { execSync } from 'node:child_process';
+const globs = [
+  'app/**/*.{js,jsx,ts,tsx,mdx}',
+  'pages/**/*.{js,jsx,ts,tsx,mdx}',
+  'components/**/*.{js,jsx,ts,tsx,mdx}',
+  'src/**/*.{js,jsx,ts,tsx,mdx}',
+  'public/**/*.{html,css,js}',
+].join(' ');
+
+function grep(pattern) {
+  try {
+    const out = execSync(`grep -RIl --line-number --fixed-strings "${pattern}" ${globs}`, { stdio: ['ignore','pipe','ignore'] }).toString().trim();
+    return out;
+  } catch (e) {
+    return ''; // not found
+  }
+}
+
+// Fail if any UI still links to /app (same-origin), we want the canonical full host
+const leftovers = grep('href="/app') || grep("href='/app");
+if (leftovers) {
+  console.error('Found stale /app links in UI (should be https://app.quickgig.ph):\n' + leftovers);
+  process.exit(1);
+}
+console.log('Scan OK: no stale /app links.');


### PR DESCRIPTION
## Summary
- Drop `/app` proxy and 301 quickgig.ph to `https://app.quickgig.ph`
- Replace any same-origin `/app` links with canonical host
- Tighten CI: scan for stale `/app` links and verify root redirect

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run scan:links`
- `node tools/check_root_redirect.mjs` *(fails: fetch failed ENETUNREACH)*
- `npm run check:api` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689d902934d483279d520d59ba07470d