### PR TITLE
Serve QuickGig app from root domain

### DIFF
--- a/api.quickgig.ph/src/cors.php
+++ b/api.quickgig.ph/src/cors.php
@@ -1,7 +1,7 @@
 <?php
 function cors() {
   $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-  $allowed = ['https://quickgig.ph', 'https://app.quickgig.ph'];
+  $allowed = ['https://quickgig.ph', 'https://www.quickgig.ph', 'https://app.quickgig.ph'];
   if (in_array($origin, $allowed, true)) {
     header("Access-Control-Allow-Origin: $origin");
   }

--- a/api.quickgig.ph/src/env.php
+++ b/api.quickgig.ph/src/env.php
@@ -5,4 +5,4 @@ define('DB_NAME', getenv('DB_NAME') ?: 'quickgig');
 define('DB_USER', getenv('DB_USER') ?: 'user');
 define('DB_PASS', getenv('DB_PASS') ?: 'pass');
 define('JWT_SECRET', getenv('JWT_SECRET') ?: 'change_this_super_secret_key');
-define('CORS_ORIGIN', getenv('CORS_ORIGIN') ?: 'https://app.quickgig.ph');
+define('CORS_ORIGIN', getenv('CORS_ORIGIN') ?: 'https://quickgig.ph');

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: '',
   async redirects() {
     return [
-      // Canonicalize root to the live product
-      { source: '/', destination: 'https://app.quickgig.ph', permanent: true },
-      // Safety: also catch any lingering /app usages
-      { source: '/app/:path*', destination: 'https://app.quickgig.ph/:path*', permanent: true },
-      { source: '/app', destination: 'https://app.quickgig.ph', permanent: true },
+      // Catch legacy /app paths and send them to the root app
+      { source: '/app', destination: '/', permanent: true },
+      { source: '/app/:path*', destination: '/:path*', permanent: true },
     ];
   },
-  // No rewrites needed anymore.
-  async rewrites() { return []; },
+  async rewrites() {
+    return [];
+  },
 };
+
 module.exports = nextConfig;

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -36,7 +36,7 @@ export default function HomePageClient() {
             Gigs and talent, matched fast.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="https://app.quickgig.ph" prefetch={false}>
+            <Link href="/login" prefetch={false}>
               <Button size="lg" variant="secondary" className="text-lg">
                 Open the app
               </Button>

--- a/src/app/health-check/HealthCheckClient.tsx
+++ b/src/app/health-check/HealthCheckClient.tsx
@@ -24,7 +24,7 @@ export default function HealthCheckClient({
   useEffect(() => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
-    fetch('/app', { method: 'HEAD', signal: controller.signal })
+    fetch('/', { method: 'HEAD', signal: controller.signal })
       .then((res) =>
         setAppStatus(res.status >= 200 && res.status < 400 ? 'ok' : 'error'),
       )

--- a/tools/check_app.mjs
+++ b/tools/check_app.mjs
@@ -15,11 +15,13 @@ async function get(u, o) {
 (async () => {
   // HEAD /
   const head = await get(base + '/', { method: 'HEAD' });
-  if (![301,302,307,308].includes(head.status)) throw new Error(`HEAD / expected redirect, got ${head.status}`);
+  if (head.status < 200 || head.status >= 400) throw new Error(`HEAD / expected 2xx; got ${head.status}`);
 
-  // GET /app
-  const app = await get(base + '/app', { method: 'GET' });
-  if (app.status < 200 || app.status >= 400) throw new Error(`GET /app expected 2xx/3xx; got ${app.status}`);
+  // HEAD /app should redirect to root
+  const app = await get(base + '/app', { method: 'HEAD' });
+  if (![301,302,307,308].includes(app.status)) throw new Error(`HEAD /app expected redirect; got ${app.status}`);
+  const loc = app.headers.get('location') || '';
+  if (loc !== '/' && loc !== base + '/') throw new Error(`Redirect location not root: ${loc}`);
 
   console.log('App OK');
 })();

--- a/tools/check_app_assets.mjs
+++ b/tools/check_app_assets.mjs
@@ -17,8 +17,8 @@ function pickAssets(html) {
 }
 
 (async () => {
-  const page = await fetchImpl(base + '/app', { redirect: 'manual' });
-  if (page.status < 200 || page.status >= 400) throw new Error(`GET /app ${page.status}`);
+  const page = await fetchImpl(base + '/', { redirect: 'manual' });
+  if (page.status < 200 || page.status >= 400) throw new Error(`GET / ${page.status}`);
   const html = await page.text();
   const assets = pickAssets(html);
 

--- a/tools/check_root.mjs
+++ b/tools/check_root.mjs
@@ -1,0 +1,8 @@
+const base = (process.env.BASE || '').replace(/\/$/, '');
+if (!base) { console.warn('No BASE provided; skipping root check'); process.exit(0); }
+(async () => {
+  const r = await fetch(base + '/', { method: 'HEAD', redirect: 'manual' });
+  if (r.status < 200 || r.status >= 400) throw new Error(`HEAD / expected 2xx; got ${r.status}`);
+  if (r.headers.get('location')) throw new Error('Root should not redirect');
+  console.log('Root serving app directly (no redirect)');
+})();

--- a/tools/check_root_redirect.mjs
+++ b/tools/check_root_redirect.mjs
@@ -1,9 +1,0 @@
-const base = (process.env.BASE || '').replace(/\/$/, '');
-if (!base) { console.warn('No BASE provided; skipping root redirect check'); process.exit(0); }
-(async () => {
-  const r = await fetch(base + '/', { method: 'HEAD', redirect: 'manual' });
-  if (![301,302,307,308].includes(r.status)) throw new Error(`HEAD / expected redirect, got ${r.status}`);
-  const loc = r.headers.get('location') || '';
-  if (!/^https:\/\/app\.quickgig\.ph(\/|$)/.test(loc)) throw new Error(`Redirect location not app.quickgig.ph: ${loc}`);
-  console.log('Root redirect OK');
-})();

--- a/tools/scan_links.mjs
+++ b/tools/scan_links.mjs
@@ -9,17 +9,22 @@ const globs = [
 
 function grep(pattern) {
   try {
-    const out = execSync(`grep -RIl --line-number --fixed-strings "${pattern}" ${globs}`, { stdio: ['ignore','pipe','ignore'] }).toString().trim();
+    const out = execSync(`grep -RIl --line-number --fixed-strings "${pattern}" ${globs}`, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
     return out;
   } catch (e) {
-    return ''; // not found
+    return '';
   }
 }
 
-// Fail if any UI still links to /app (same-origin), we want the canonical full host
-const leftovers = grep('href="/app') || grep("href='/app");
+// Fail if any UI still links to legacy app domain or /app paths
+const leftovers =
+  grep('https://app.quickgig.ph') || grep('href="/app') || grep("href='/app");
 if (leftovers) {
-  console.error('Found stale /app links in UI (should be https://app.quickgig.ph):\n' + leftovers);
+  console.error('Found stale app.quickgig.ph or /app links in UI:\n' + leftovers);
   process.exit(1);
 }
-console.log('Scan OK: no stale /app links.');
+console.log('Scan OK: no stale app links.');

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -3,10 +3,11 @@ const fetchImpl = globalThis.fetch;
 const bail = (m)=>{ console.error(m); process.exit(1); };
 (async () => {
   const r1 = await fetchImpl(base + '/', { method: 'HEAD', redirect: 'manual' });
-  if (![301,302,307,308].includes(r1.status)) bail(`HEAD / expected redirect, got ${r1.status}`);
-  const loc = r1.headers.get('location') || '';
-  if (!loc.startsWith('/app')) bail(`HEAD / location must start with /app; got ${loc}`);
-  const r2 = await fetchImpl(base + '/app', { method: 'GET', redirect: 'manual' });
-  if (r2.status < 200 || r2.status >= 400) bail(`GET /app expected 2xx/3xx; got ${r2.status}`);
+  if (r1.status < 200 || r1.status >= 400) bail(`HEAD / expected 2xx; got ${r1.status}`);
+  if (r1.headers.get('location')) bail('HEAD / should not redirect');
+  const r2 = await fetchImpl(base + '/app', { method: 'HEAD', redirect: 'manual' });
+  if (![301,302,307,308].includes(r2.status)) bail(`HEAD /app expected redirect; got ${r2.status}`);
+  const loc = r2.headers.get('location') || '';
+  if (loc !== '/' && loc !== base + '/') bail(`HEAD /app location must be root; got ${loc}`);
   console.log('Smoke OK');
 })();


### PR DESCRIPTION
## Summary
- remove legacy `/app` base path and redirects
- update links, health checks, and docs for root-domain app
- adjust API configs and tooling for new domain setup

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run scan:appdomain`
- `npm run scan:links`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d9b3f59108327be286b59b0572c6d