### PR TITLE
hotfix: restore product domain & enforce redirects

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      API: https://api.quickgig.ph
-      PAGE_ORIGIN: https://quickgig.ph
-      # On PRs we don't know the preview URL; skip app check unless BASE is set.
-      BASE: ${{ github.ref == 'refs/heads/main' && 'https://quickgig.ph' || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,7 +18,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - name: Scan for stale /app links
         run: npm run scan:links
+      - name: Check domain redirects
+        run: node tools/check_redirects.mjs
       - name: Check API health
-        run: npm run check:api
-      - name: Check Root Redirect (skips if BASE not set)
-        run: node tools/check_root_redirect.mjs
+        run: node tools/check_api_health.mjs

--- a/README.md
+++ b/README.md
@@ -142,3 +142,24 @@ Preflight (`OPTIONS`) should return `200`.
 * `api.quickgig.ph/health.php` JSON
 * Latest successful **Smoke** run on `main`
 
+
+## Production Domains (canonical)
+- Product: https://app.quickgig.ph  ✅
+- Root: https://quickgig.ph  → 308 to https://app.quickgig.ph
+- WWW:  https://www.quickgig.ph → 308 to https://app.quickgig.ph
+- API:  https://api.quickgig.ph
+
+### Operations
+- Verify redirects:
+  curl -I https://quickgig.ph
+  curl -I https://www.quickgig.ph
+
+- Verify product:
+  open https://app.quickgig.ph
+
+- Verify API:
+  curl -i https://api.quickgig.ph/health.php
+
+### Cookies & CORS
+- Cookies from API: Domain=.quickgig.ph; Path=/; Secure; HttpOnly; SameSite=None
+- CORS: allow https://app.quickgig.ph (and quickgig.ph if needed), with credentials.

--- a/tools/check_api_health.mjs
+++ b/tools/check_api_health.mjs
@@ -1,0 +1,8 @@
+const URL = 'https://api.quickgig.ph/health.php';
+(async ()=>{
+  const r = await fetch(URL, { redirect: 'manual' });
+  if (r.status !== 200) throw new Error(`API health ${r.status}`);
+  const text = await r.text();
+  if (!/ok/i.test(text)) throw new Error(`API payload missing ok: ${text.slice(0,120)}`);
+  console.log('API OK');
+})();

--- a/tools/check_redirects.mjs
+++ b/tools/check_redirects.mjs
@@ -1,0 +1,22 @@
+const fetchImpl = globalThis.fetch;
+async function head(u){ return fetchImpl(u,{method:'HEAD',redirect:'manual'}); }
+
+(async () => {
+  const ROOT = 'https://quickgig.ph';
+  const WWW  = 'https://www.quickgig.ph';
+  const APP  = 'https://app.quickgig.ph';
+
+  // root → app
+  let r = await head(ROOT + '/');
+  if (![301,302,307,308].includes(r.status)) throw new Error(`ROOT not redirecting: ${r.status}`);
+  let loc = r.headers.get('location')||'';
+  if (!loc.startsWith(APP)) throw new Error(`ROOT Location wrong: ${loc}`);
+  console.log('Root redirect OK →', loc);
+
+  // www → app
+  r = await head(WWW + '/');
+  if (![301,302,307,308].includes(r.status)) throw new Error(`WWW not redirecting: ${r.status}`);
+  loc = r.headers.get('location')||'';
+  if (!loc.startsWith(APP)) throw new Error(`WWW Location wrong: ${loc}`);
+  console.log('WWW redirect OK →', loc);
+})();


### PR DESCRIPTION
## Summary
- add redirect and API health checks to CI
- document canonical production domains and operations

### Domain Fix Checklist (run these outside the repo)

**Goal:** app.quickgig.ph serves the app; quickgig.ph & www redirect to it.

**Vercel (Project → Settings → Domains)**

1. **Remove** `app.quickgig.ph` from this project if it appears (we don’t want Vercel to serve it).
2. Set **quickgig.ph** → **Redirect to Another Domain** → `https://app.quickgig.ph` → **308 Permanent** → **Save**.
3. Set **[www.quickgig.ph](http://www.quickgig.ph)** → **Redirect to Another Domain** → `https://app.quickgig.ph` → **308 Permanent** → **Save**.

**Hostinger DNS (Zone for quickgig.ph)**
4. Record for **app** must point to the app host (NOT Vercel):

* If IP: **A** record — Name: `app`, Value: `<APP_SERVER_IP>`, TTL: 300.
* If CNAME: **CNAME** — Name: `app`, Value: `<APP_HOSTNAME>.`, TTL: 300.
* **Delete** any `app → cname.vercel-dns.com` entry.

**Verify**

```
dig +short app.quickgig.ph
dig +short CNAME app.quickgig.ph
curl -I https://quickgig.ph
curl -I https://www.quickgig.ph
curl -i https://api.quickgig.ph/health.php
```

Expect `quickgig.ph` & `www` → 308 Location `https://app.quickgig.ph/...`; API 200.


------
https://chatgpt.com/codex/tasks/task_e_689da85762f4832799017b745b4f8688