### PR TITLE
hotfix: restore routing (app on Hostinger; root/www 308→app) + verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,16 @@ Preflight (`OPTIONS`) should return `200`.
 ### Cookies & CORS
 - Cookies from API: Domain=.quickgig.ph; Path=/; Secure; HttpOnly; SameSite=None
 - CORS: allow https://app.quickgig.ph (and quickgig.ph if needed), with credentials.
+
+## Routing restore runbook
+
+- `app.quickgig.ph` serves the product on Hostinger (A=89.116.53.39).
+- `quickgig.ph` and `www.quickgig.ph` redirect with 308 to `https://app.quickgig.ph`.
+- No proxying of `/app` via Next.js or Vercel.
+- Verification commands:
+  ```bash
+  dig +short app.quickgig.ph; dig +short CNAME app.quickgig.ph
+  curl -I --resolve app.quickgig.ph:443:89.116.53.39 https://app.quickgig.ph
+  curl -I https://quickgig.ph; curl -I https://www.quickgig.ph
+  ```
+  Operator tools only; CI does not enforce these checks.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "check:app": "node tools/check_app.mjs",
     "check:appassets": "node tools/check_app_assets.mjs",
     "check:app:soft": "node tools/check_live_app.mjs || true",
+    "check:dns:app": "node tools/check_dns_app.mjs",
+    "check:app:host": "node tools/check_app_hostinger.mjs",
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",

--- a/tools/check_app_hostinger.mjs
+++ b/tools/check_app_hostinger.mjs
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+
+const cmd = 'curl -I --resolve app.quickgig.ph:443:89.116.53.39 https://app.quickgig.ph';
+let out = '';
+try {
+  out = execSync(cmd, { encoding: 'utf8', stdio: 'pipe' });
+} catch (e) {
+  out = e.stdout ? e.stdout.toString() : '';
+  if (out.trim()) console.log(out.trim());
+  console.error(e.message);
+  process.exit(1);
+}
+
+console.log(out.trim());
+const match = out.match(/HTTP\/\d\.\d (\d+)/);
+if (!match) { console.error('No HTTP status found'); process.exit(1); }
+const status = Number(match[1]);
+if (status >= 400) { console.error('Status ' + status); process.exit(1); }
+console.log('Host OK');

--- a/tools/check_dns_app.mjs
+++ b/tools/check_dns_app.mjs
@@ -1,0 +1,17 @@
+import { execSync } from 'node:child_process';
+
+const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
+
+const a = run('dig +short app.quickgig.ph');
+console.log('A app.quickgig.ph\n' + a);
+if (!a.split('\n').includes('89.116.53.39')) {
+  throw new Error('A app.quickgig.ph missing 89.116.53.39');
+}
+
+const cname = run('dig +short CNAME app.quickgig.ph');
+console.log('CNAME app.quickgig.ph\n' + cname);
+if (cname) {
+  throw new Error('CNAME app.quickgig.ph should be empty');
+}
+
+console.log('DNS OK');


### PR DESCRIPTION
## Summary
- add DNS and Hostinger verification scripts
- document routing restore runbook in README
- expose operator scripts via package.json

## Verification
- `node tools/check_dns_app.mjs`
```
A app.quickgig.ph
89.116.53.39
CNAME app.quickgig.ph

DNS OK
```
- `node tools/check_app_hostinger.mjs`
```
HTTP/1.1 403 Forbidden
content-length: 9
content-type: text/plain
date: Thu, 14 Aug 2025 10:46:41 GMT
server: envoy
connection: close
Command failed: curl -I --resolve app.quickgig.ph:443:89.116.53.39 https://app.quickgig.ph
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) CONNECT tunnel failed, response 403
```
- `curl -I https://quickgig.ph`
```
HTTP/1.1 403 Forbidden
content-length: 9
content-type: text/plain
date: Thu, 14 Aug 2025 10:45:25 GMT
server: envoy
connection: close
curl: (56) CONNECT tunnel failed, response 403
```
- `curl -I https://www.quickgig.ph`
```
HTTP/1.1 403 Forbidden
content-length: 9
content-type: text/plain
date: Thu, 14 Aug 2025 10:45:27 GMT
server: envoy
connection: close
curl: (56) CONNECT tunnel failed, response 403
```


------
https://chatgpt.com/codex/tasks/task_e_689dbdeb6ecc83278b80deb8f473bea2