### PR TITLE
hotfix: 308 redirect quickgig.ph → https://app.quickgig.ph (no app DNS change)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,27 +18,43 @@ jobs:
           echo "event: ${{ github.event_name }}"
           echo "ref: ${{ github.ref }}"
 
-      # 👉 PRs: DO NOT block on external checks (runners may block CONNECT).
-      - name: PR soft check (headers only, non-blocking)
+      # 👉 PRs: check redirects but do not block (network may be restricted)
+      - name: PR redirect check (non-blocking)
         if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
         run: |
-          set -x
-          curl -I -L --max-time 8 --retry 1 https://app.quickgig.ph || true
-          curl -I -L --max-time 8 --retry 1 https://quickgig.ph || true
-          curl -I -L --max-time 8 --retry 1 https://www.quickgig.ph || true
-          echo "::notice::PR soft check completed (non-blocking)."
+          set +e
+          fail=0
+          curl -I --max-time 8 --retry 1 https://app.quickgig.ph || true
+          check() {
+            url=$1
+            out=$(curl -sI --max-time 8 --retry 1 "$url" || true)
+            echo "$out"
+            echo "$out" | grep -q 'HTTP/.* 308' && echo "$out" | grep -q 'Location: https://app.quickgig.ph/' || fail=1
+          }
+          check https://quickgig.ph
+          check https://www.quickgig.ph
+          if [ $fail -ne 0 ]; then
+            echo "::notice::Redirect check failed (non-blocking)."
+          else
+            echo "::notice::Redirect check passed."
+          fi
 
-      # 👉 main: still check, but warn-only (never fail deploys)
-      - name: Main branch external check (warn-only)
+      # 👉 main: redirect assertions are required
+      - name: Main branch redirect check
         if: ${{ github.ref == 'refs/heads/main' }}
-        continue-on-error: true
         run: |
-          set -x
-          echo "Checking production endpoints..."
-          curl -I -L --max-time 10 --retry 2 https://app.quickgig.ph || true
-          curl -I -L --max-time 10 --retry 2 https://quickgig.ph || true
-          curl -I -L --max-time 10 --retry 2 https://www.quickgig.ph || true
-          echo "::notice::Main branch external check done (warn-only)."
+          set -e
+          echo "Checking production redirects..."
+          curl -I --max-time 10 --retry 2 https://app.quickgig.ph
+          check() {
+            url=$1
+            out=$(curl -sI --max-time 10 --retry 2 "$url")
+            echo "$out"
+            echo "$out" | grep -q 'HTTP/.* 308'
+            echo "$out" | grep -q 'Location: https://app.quickgig.ph/'
+          }
+          check https://quickgig.ph
+          check https://www.quickgig.ph
+          echo "Redirect checks passed."
 
       # Keep any existing build/lint/type steps if they lived in this file before.

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath: '',
   async redirects() {
     return [
-      // Catch legacy /app paths and send them to the root app
-      { source: '/app', destination: '/', permanent: true },
-      { source: '/app/:path*', destination: '/:path*', permanent: true },
+      {
+        source: '/:path*',
+        destination: 'https://app.quickgig.ph/:path*',
+        permanent: true, // use 308 on Vercel
+      },
     ];
-  },
-  async rewrites() {
-    return [];
   },
 };
 


### PR DESCRIPTION
## Summary
- Issue 308 from quickgig.ph/www to https://app.quickgig.ph; remove stale /app proxy rules; add CI assertions.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`

## Rollback
- Revert commit; redeploy.

------
https://chatgpt.com/codex/tasks/task_e_689dcde01d988327b8edb6e165f7e231