### PR TITLE
feat(ci+tests): E2E health, CTA/link clicks, API/CORS checks, nightly reports

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,67 @@
+name: E2E
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run smoke:app
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: BASE=https://quickgig.ph npm run test:e2e
+      - name: Check API
+        run: npm run smoke:api || echo "::warning::API check failed"
+      - name: Check CORS
+        run: node tools/check_cors.mjs || echo "::warning::CORS check failed"
+      - name: Summary
+        if: always()
+        run: node tools/ci_summary.mjs >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit
+          path: reports/junit.xml
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: traces
+          path: test-results/**/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@
 # production
 /build
 
+# playwright reports
+playwright-report/
+reports/
+test-results/
+
 # misc
 .DS_Store
 *.pem

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ BASE=https://quickgig.ph node tools/check_root.mjs
 BASE=https://api.quickgig.ph npm run check:api
 ```
 
+### E2E tests
+
+Run the Playwright end-to-end suite locally against a dev server:
+
+```bash
+BASE=http://localhost:3000 npm run test:e2e
+```
+
+Run against production:
+
+```bash
+BASE=https://quickgig.ph npm run test:e2e
+```
+
+Use `npm run test:e2e:headed` to watch the browser and `npm run test:e2e:report` to open the last HTML report.
+Tests are non-destructive; no posts or purchases are submitted. When test credentials are added later via `TEST_EMAIL` and `TEST_PASSWORD` GitHub secrets, real login flows can be enabled.
+
 ## Production routing
 - `https://quickgig.ph` → 308 to `https://app.quickgig.ph`
 - `https://www.quickgig.ph` → 308 to `https://app.quickgig.ph`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report",
+    "smoke:app": "node tools/check_app.mjs",
+    "smoke:api": "node tools/check_api.mjs",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/scan_links.mjs"
   },
@@ -42,6 +46,7 @@
     "eslint-config-next": "14.2.31",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@playwright/test": "^1.45.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: process.env.BASE ?? 'https://quickgig.ph',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
+  reporter: [
+    ['list'],
+    ['html'],
+    ['junit', { outputFile: './reports/junit.xml' }]
+  ],
+  projects: [{ name: 'prod' }]
+});

--- a/tests/e2e/auth_entrypoints.spec.ts
+++ b/tests/e2e/auth_entrypoints.spec.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+
+async function openLink(page, name: RegExp) {
+  const link = page.getByRole('link', { name }).first();
+  if (await link.isVisible()) {
+    await link.click();
+  } else {
+    await page.goto(`https://app.quickgig.ph/${name.source.toLowerCase().replace(/[^a-z]/g,'')}`);
+  }
+}
+
+test('login and signup entrypoints render', async ({ page }) => {
+  await page.goto('https://app.quickgig.ph');
+  await openLink(page, /Login|Log in/i);
+  await expect(page.locator('form')).toBeVisible();
+  await page.goto('https://app.quickgig.ph');
+  await openLink(page, /Sign Up|Register/i);
+  await expect(page.locator('form')).toBeVisible();
+});

--- a/tests/e2e/find_work.spec.ts
+++ b/tests/e2e/find_work.spec.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+
+test('find work page loads', async ({ page }) => {
+  await page.goto('https://app.quickgig.ph');
+  const link = page.getByRole('link', { name: /Find Work|Jobs/i }).first();
+  if (await link.isVisible()) {
+    await link.click();
+  } else {
+    await page.goto('https://app.quickgig.ph/jobs');
+  }
+  await page.waitForLoadState('networkidle');
+  expect(page.url()).toMatch(/jobs/);
+  const xhrFailures: string[] = [];
+  page.on('response', r => {
+    if (r.request().resourceType() === 'xhr' && r.status() >= 400) {
+      xhrFailures.push(`${r.url()} ${r.status()}`);
+    }
+  });
+  const hasList = await page.locator('[data-testid="job-card"]').first().isVisible().catch(() => false);
+  const hasEmpty = await page.locator('text=/No jobs/i').first().isVisible().catch(() => false);
+  expect(hasList || hasEmpty).toBeTruthy();
+  expect(xhrFailures).toEqual([]);
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+const ctaSelector = 'text=/Simulan Na!|Browse Jobs|Login|Sign Up/i';
+
+ test('home page renders', async ({ page, request }) => {
+  fs.mkdirSync('reports', { recursive: true });
+  const redirect = await request.get('/', { maxRedirects: 0 });
+  expect(redirect.status()).toBeGreaterThanOrEqual(301);
+  expect(redirect.status()).toBeLessThan(309);
+  expect(redirect.headers()['location']).toContain('app.quickgig.ph');
+
+  const consoleErrors: string[] = [];
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+  const assetErrors: {url:string,status:number}[] = [];
+  page.on('response', r => {
+    if (/\.(css|js)(\?|$)/.test(r.url()) && r.status() >= 400) {
+      assetErrors.push({ url: r.url(), status: r.status() });
+    }
+  });
+
+  await page.goto('/');
+  expect(page.url()).toContain('app.quickgig.ph');
+  await expect(page).toHaveTitle(/QuickGig/i);
+
+  await expect(page.locator(ctaSelector).first()).toBeVisible();
+
+  fs.writeFileSync('reports/console-errors.json', JSON.stringify([{ page: 'home', errors: consoleErrors }], null, 2));
+  expect(consoleErrors).toEqual([]);
+  expect(assetErrors).toEqual([]);
+});

--- a/tests/e2e/nav_cta_clicks.spec.ts
+++ b/tests/e2e/nav_cta_clicks.spec.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import { test, expect, Browser } from '@playwright/test';
+import fs from 'fs';
+
+async function checkLink(browser: Browser, href: string) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  let error;
+  page.on('pageerror', e => { error = e; });
+  const res = await page.goto(href);
+  await context.close();
+  return { status: res ? res.status() : 0, error };
+}
+
+test('nav links and CTAs', async ({ page, browser }) => {
+  fs.mkdirSync('reports', { recursive: true });
+  await page.goto('https://app.quickgig.ph');
+  const selector = 'header a, nav a, a[role="button"], button, .btn, .hero a';
+  const handles = await page.locator(selector).filter({ has: page.locator(':visible') }).elementHandles();
+  const links: { label: string; href: string }[] = [];
+  for (const h of handles) {
+    const href = await h.getAttribute('href');
+    if (!href) continue;
+    const label = (await h.innerText()).trim() || href;
+    if (!links.find(l => l.href === href)) links.push({ label, href });
+  }
+  interface LinkResult { label: string; href: string; status: number | string }
+  const results: LinkResult[] = [];
+  for (const l of links) {
+    if (/^mailto:|^tel:|^https?:\/\/(?!app\.quickgig\.ph)/.test(l.href)) {
+      results.push({ ...l, status: 'skipped' });
+      continue;
+    }
+    const url = l.href.startsWith('http') ? l.href : `https://app.quickgig.ph${l.href}`;
+    const { status, error } = await checkLink(browser, url);
+    expect(status).toBeGreaterThanOrEqual(200);
+    expect(status).toBeLessThan(400);
+    expect(error).toBeFalsy();
+    results.push({ ...l, href: url, status });
+  }
+  console.table(results);
+  fs.writeFileSync('reports/cta-links.json', JSON.stringify(results, null, 2));
+});

--- a/tests/e2e/post_job_flow.smoke.spec.ts
+++ b/tests/e2e/post_job_flow.smoke.spec.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+
+test('post job form validates', async ({ page }) => {
+  await page.goto('https://app.quickgig.ph');
+  const link = page.getByRole('link', { name: /Post Job/i }).first();
+  if (await link.isVisible()) {
+    await link.click();
+  } else {
+    await page.goto('https://app.quickgig.ph/post');
+  }
+  await page.waitForLoadState('domcontentloaded');
+  const required = page.locator('form input[required], form textarea[required], form select[required]');
+  await expect(required.first()).toBeVisible();
+  if (process.env.ALLOW_DESTRUCTIVE !== 'true') {
+    const submit = page.locator('form button[type="submit"], form input[type="submit"]').first();
+    if (await submit.isVisible()) {
+      await submit.click();
+      const invalid = page.locator(':invalid');
+      expect(await invalid.count()).toBeGreaterThan(0);
+    }
+  }
+  const errors: string[] = [];
+  page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+  expect(errors).toEqual([]);
+});

--- a/tools/check_cors.mjs
+++ b/tools/check_cors.mjs
@@ -1,0 +1,34 @@
+import fs from 'fs';
+
+const url = 'https://api.quickgig.ph/health.php';
+const origin = 'https://quickgig.ph';
+fs.mkdirSync('reports', { recursive: true });
+
+(async () => {
+  const pre = await fetch(url, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: origin,
+      'Access-Control-Request-Method': 'GET',
+      'Access-Control-Request-Headers': 'Content-Type'
+    }
+  });
+  const allowOrigin = pre.headers.get('access-control-allow-origin');
+  const allowCreds = pre.headers.get('access-control-allow-credentials');
+  if (pre.status !== 200 || !allowOrigin ||
+      ![origin, 'https://app.quickgig.ph'].includes(allowOrigin) ||
+      allowCreds !== 'true') {
+    fs.writeFileSync('reports/cors.json', JSON.stringify({ status: 'fail', code: pre.status, allowOrigin, allowCreds }));
+    throw new Error('CORS preflight failed');
+  }
+  const res = await fetch(url, {
+    headers: { Origin: origin },
+    credentials: 'include'
+  });
+  if (res.status !== 200) {
+    fs.writeFileSync('reports/cors.json', JSON.stringify({ status: 'fail', code: res.status }));
+    throw new Error(`CORS fetch failed ${res.status}`);
+  }
+  fs.writeFileSync('reports/cors.json', JSON.stringify({ status: 'ok' }));
+  console.log('CORS OK');
+})();

--- a/tools/ci_summary.mjs
+++ b/tools/ci_summary.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs';
+
+function readJSON(path) {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const links = readJSON('reports/cta-links.json') || [];
+console.log(`Links tested: ${links.length}`);
+const failing = links.filter(l => typeof l.status === 'number' && (l.status < 200 || l.status >= 400));
+if (failing.length) {
+  console.log('Failing links:');
+  for (const f of failing) console.log(`- ${f.label} -> ${f.href} (${f.status})`);
+}
+
+const consoles = readJSON('reports/console-errors.json') || [];
+for (const c of consoles) {
+  if (c.errors && c.errors.length) {
+    console.log(`Console errors on ${c.page}:`);
+    for (const e of c.errors) console.log(`  ${e}`);
+  }
+}
+
+const api = readJSON('reports/api.json');
+if (api) console.log(`API: ${api.status}`);
+const cors = readJSON('reports/cors.json');
+if (cors) console.log(`CORS: ${cors.status}`);


### PR DESCRIPTION
## Summary
- add Playwright config and non-destructive E2E tests for key flows and CTA/link coverage
- check API and CORS health with Node scripts and summarize results
- introduce nightly/PR GitHub Action uploading Playwright HTML and JUnit reports

## Testing
- `npm run lint`
- `npm run typecheck`
- `node tools/check_app.mjs` *(fails: connect ENETUNREACH)*
- `node tools/check_api.mjs` *(fails: connect ENETUNREACH)*
- `node tools/check_cors.mjs` *(fails: connect ENETUNREACH)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3734094832788ebfec56d9193a8