### PR TITLE
feat(tests+ci): add Playwright E2E (smoke+nightly) and API/CORS health checks

### DIFF
--- a/.github/workflows/e2e-and-health.yml
+++ b/.github/workflows/e2e-and-health.yml
@@ -1,0 +1,71 @@
+name: E2E and Health Checks
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run test:e2e:install
+      - name: API health
+        id: api
+        run: npm run check:api
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+      - if: always()
+        run: echo "API check: ${{ steps.api.outcome }}" >> $GITHUB_STEP_SUMMARY
+      - name: CORS preflight
+        id: cors
+        run: npm run check:cors
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+      - if: always()
+        run: echo "CORS check: ${{ steps.cors.outcome }}" >> $GITHUB_STEP_SUMMARY
+      - name: App health
+        id: app
+        run: npm run check:app
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+      - if: always()
+        run: echo "App check: ${{ steps.app.outcome }}" >> $GITHUB_STEP_SUMMARY
+      - name: Smoke tests
+        id: smoke
+        if: github.event_name == 'pull_request'
+        run: npm run test:e2e:smoke
+        continue-on-error: true
+      - if: github.event_name == 'pull_request'
+        run: echo "Smoke tests: ${{ steps.smoke.outcome }}" >> $GITHUB_STEP_SUMMARY
+      - name: Full e2e tests
+        id: full
+        if: github.event_name == 'schedule'
+        run: npm run test:e2e
+      - if: github.event_name == 'schedule'
+        run: echo "Full e2e: ${{ steps.full.outcome }}" >> $GITHUB_STEP_SUMMARY
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+      - name: Upload junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit
+          path: junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+junit.xml
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ To verify the live API locally, run:
 BASE=https://api.quickgig.ph node tools/check_live_api.mjs
 ```
 
+## Testing
+
+Run the end-to-end suite against the live app:
+
+```bash
+BASE=https://app.quickgig.ph API_BASE=https://api.quickgig.ph \
+npm run test:e2e:install && npm run test:e2e
+```
+
+Run only the smoke subset and health checks:
+
+```bash
+npm run test:e2e:smoke
+npm run check:api && npm run check:cors && npm run check:app
+```
+
+Playwright HTML, JUnit, and trace artifacts are output to
+`playwright-report/`, `junit.xml`, and `test-results/` respectively in CI.
+
 ## Authentication
 
 The app communicates with an external API using the `/src/lib/api.ts` helper. When `auth` is set on a request, a JWT token stored in `localStorage` is sent in the `Authorization` header. If the backend issues HttpOnly cookies, they are included automatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "webpack-bundle-analyzer": "^4.10.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.43.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,18 @@
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
+    "test:e2e:install": "playwright install --with-deps",
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test -g \"@smoke\"",
     "check:api": "node tools/check_api.mjs",
-    "check:api:soft": "node tools/check_live_api.mjs || true",
+    "check:cors": "node tools/check_cors.mjs",
     "check:app": "node tools/check_app.mjs",
+    "check:api:soft": "node tools/check_live_api.mjs || true",
     "check:appassets": "node tools/check_app_assets.mjs",
     "check:app:soft": "node tools/check_live_app.mjs || true",
     "check:dns:app": "node tools/check_dns_app.mjs",
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
-    "test:e2e": "playwright test",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/scan_links.mjs"
   },
@@ -34,6 +37,7 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.43.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+const baseURL = process.env.BASE || 'https://app.quickgig.ph';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 30_000,
+  retries: 2,
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: 'junit.xml' }],
+    ['html', { open: 'never' }],
+  ],
+  use: {
+    baseURL,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  outputDir: 'test-results',
+});

--- a/tests/e2e/auth-links.spec.ts
+++ b/tests/e2e/auth-links.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_HOST = new URL(process.env.BASE || 'https://app.quickgig.ph').host;
+function assertAppUrl(url: string) {
+  expect(new URL(url).host).toBe(BASE_HOST);
+}
+
+test('login and signup forms render for anonymous users', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: /login/i }).click();
+  assertAppUrl(page.url());
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+  await expect(page.getByLabel(/password/i)).toBeVisible();
+  await page.goBack();
+  assertAppUrl(page.url());
+
+  await page.getByRole('link', { name: /sign up/i }).click();
+  assertAppUrl(page.url());
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+  await expect(page.getByLabel(/password/i)).toBeVisible();
+  await page.goBack();
+  assertAppUrl(page.url());
+});

--- a/tests/e2e/footer-nav.spec.ts
+++ b/tests/e2e/footer-nav.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_HOST = new URL(process.env.BASE || 'https://app.quickgig.ph').host;
+function assertAppUrl(url: string) {
+  expect(new URL(url).host).toBe(BASE_HOST);
+}
+
+test('footer links respond with 200', async ({ page, request }) => {
+  await page.goto('/');
+  const footer = page.locator('footer');
+  const links = ['terms', 'privacy', 'contact'];
+  for (const name of links) {
+    const el = footer.getByRole('link', { name: new RegExp(name, 'i') });
+    const href = await el.getAttribute('href');
+    if (!href) continue;
+    const res = await request.get(href);
+    expect(res.status()).toBe(200);
+    const text = await res.text();
+    expect(text.toLowerCase()).toContain(name);
+  }
+  assertAppUrl(page.url());
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_HOST = new URL(process.env.BASE || 'https://app.quickgig.ph').host;
+
+function assertAppUrl(url: string) {
+  expect(new URL(url).host).toBe(BASE_HOST);
+}
+
+test('home page renders header and nav', async ({ page }) => {
+  await page.goto('/');
+  assertAppUrl(page.url());
+  await expect(page.getByRole('banner')).toBeVisible();
+  await expect(page.getByRole('navigation')).toBeVisible();
+});
+
+test('Simulan Na CTA routes to onboarding or jobs @smoke', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: /simulan na/i }).click();
+  assertAppUrl(page.url());
+  await expect(page).toHaveURL(new RegExp('/(find-work|onboarding)'));
+});
+
+test('Browse Jobs CTA shows search @smoke', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: /browse jobs/i }).click();
+  assertAppUrl(page.url());
+  await expect(page).toHaveURL(/\/find-work/);
+  await expect(page.getByRole('main')).toBeVisible();
+});
+
+test('navigation links render pages', async ({ page }) => {
+  const links = [
+    { name: /home/i, path: '/' },
+    { name: /find work/i, path: '/find-work' },
+    { name: /post job/i, path: '/post-job' },
+  ];
+  for (const link of links) {
+    await page.goto('/');
+    await page.getByRole('link', { name: link.name }).click();
+    assertAppUrl(page.url());
+    await expect(page).toHaveURL(new RegExp(`${link.path}$`));
+  }
+});

--- a/tests/e2e/jobs.spec.ts
+++ b/tests/e2e/jobs.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_HOST = new URL(process.env.BASE || 'https://app.quickgig.ph').host;
+function assertAppUrl(url: string) {
+  expect(new URL(url).host).toBe(BASE_HOST);
+}
+
+test('job filters update results and open details', async ({ page }) => {
+  await page.goto('/find-work');
+  assertAppUrl(page.url());
+  await expect(page.getByLabel(/category/i)).toBeVisible();
+  await expect(page.getByLabel(/location/i)).toBeVisible();
+  await expect(page.getByLabel(/budget/i)).toBeVisible();
+
+  await page.getByLabel(/category/i).selectOption({ index: 1 });
+  await page.getByRole('button', { name: /search|apply|filter/i }).click();
+  assertAppUrl(page.url());
+  await expect(page).toHaveURL(/find-work\?/);
+  const first = page.getByRole('link').first();
+  await expect(first).toBeVisible();
+  await first.click();
+  assertAppUrl(page.url());
+  await expect(page.getByRole('heading')).toBeVisible();
+  await expect(page.getByRole('button')).toBeVisible();
+});

--- a/tests/e2e/post-job.spec.ts
+++ b/tests/e2e/post-job.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_HOST = new URL(process.env.BASE || 'https://app.quickgig.ph').host;
+function assertAppUrl(url: string) {
+  expect(new URL(url).host).toBe(BASE_HOST);
+}
+
+test('post job form renders and validates', async ({ page }) => {
+  await page.goto('/post-job');
+  assertAppUrl(page.url());
+  const title = page.getByLabel(/title/i);
+  const desc = page.getByLabel(/description/i);
+  const budget = page.getByLabel(/budget/i);
+  await expect(title).toBeVisible();
+  await expect(desc).toBeVisible();
+  await expect(budget).toBeVisible();
+
+  await title.fill('Test');
+  await page.getByRole('button', { name: /submit|post/i }).click();
+  await expect(page.getByText(/required/i)).toBeVisible();
+});

--- a/tools/check_api.mjs
+++ b/tools/check_api.mjs
@@ -1,13 +1,19 @@
-const api = (process.env.API || 'https://api.quickgig.ph').replace(/\/$/, '');
-const pageOrigin = (process.env.PAGE_ORIGIN || 'https://quickgig.ph');
+const API_BASE = (process.env.API_BASE || 'https://api.quickgig.ph').replace(/\/$/, '');
 
 (async () => {
-  const r = await fetch(api + '/health.php', { method: 'GET' });
-  if (!r.ok) throw new Error(`API health ${r.status}`);
-  // If server includes CORS on GET, ensure it's sane (some hosts only add it on actual CORS requests; tolerate absence)
-  const allowOrigin = r.headers.get('access-control-allow-origin');
-  if (allowOrigin && allowOrigin !== pageOrigin) {
-    throw new Error(`CORS allow-origin mismatch: got "${allowOrigin}" expected "${pageOrigin}"`);
+  try {
+    const res = await fetch(`${API_BASE}/health.php`);
+    if (res.status !== 200) {
+      throw new Error(`unexpected status ${res.status}`);
+    }
+    const body = await res.json().catch(() => ({}));
+    if (body.status !== 'ok') {
+      throw new Error(`unexpected body ${JSON.stringify(body)}`);
+    }
+    console.log('API ok', res.headers.get('server'), res.headers.get('date'));
+    process.exit(0);
+  } catch (err) {
+    console.error('API check failed:', err.message);
+    process.exit(1);
   }
-  console.log('API OK');
 })();

--- a/tools/check_cors.mjs
+++ b/tools/check_cors.mjs
@@ -1,0 +1,26 @@
+const API_BASE = (process.env.API_BASE || 'https://api.quickgig.ph').replace(/\/$/, '');
+const ORIGIN = 'https://quickgig.ph';
+
+(async () => {
+  try {
+    const res = await fetch(`${API_BASE}/health.php`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: ORIGIN,
+        'Access-Control-Request-Method': 'GET',
+      },
+    });
+    if (![200,204].includes(res.status)) {
+      throw new Error(`unexpected status ${res.status}`);
+    }
+    const allowOrigin = res.headers.get('access-control-allow-origin');
+    if (!allowOrigin) {
+      throw new Error('missing access-control-allow-origin');
+    }
+    console.log('CORS ok', allowOrigin, res.headers.get('access-control-allow-credentials'));
+    process.exit(0);
+  } catch (err) {
+    console.error('CORS check failed:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- configure Playwright with smoke-tagged tests
- add API/CORS/app health check scripts and CI workflow for PRs and nightly runs
- document how to run e2e and health checks locally

## Testing
- `npm run lint:ci`
- `npm run test:e2e:smoke` *(fails: playwright: not found)*
- `npm run check:api` *(fails: fetch failed)*
- `npm run check:cors` *(fails: fetch failed)*
- `npm run check:app` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689dd7e1678c83279083649143d5aa4f