### PR TITLE
fix(nav+cta): standardize links and add link checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
-    "scan:links": "node tools/scan_links.mjs"
+    "scan:links": "node tools/check_links.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -36,18 +36,24 @@ export default function HomePageClient() {
             Gigs and talent, matched fast.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/login" prefetch={false}>
-              <Button size="lg" variant="secondary" className="text-lg">
-                Open the app
+            <Link href="/signup">
+              <Button
+                size="lg"
+                variant="secondary"
+                className="text-lg"
+                data-cta="signup"
+              >
+                Simulan Na!
               </Button>
             </Link>
-            <Link href="/health-check">
+            <Link href="/find-work">
               <Button
                 size="lg"
                 variant="outline"
                 className="text-lg border-fg text-fg hover:bg-fg hover:text-bg"
+                data-cta="browse-jobs"
               >
-                Health check
+                Browse Jobs
               </Button>
             </Link>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import "./globals.css";
 import { AuthProvider } from "../context/AuthContext";
 import { SocketProvider } from "../context/SocketContext";
@@ -104,17 +105,29 @@ export default function RootLayout({
                   <div>
                     <h3 className="font-heading font-semibold text-fg mb-4">Para sa Freelancers</h3>
                     <ul className="space-y-2 text-fg opacity-70">
-                      <li><a href="/find-work" className="hover:text-qg-accent transition-colors">Find Work</a></li>
-                      <li><a href="/profile" className="hover:text-qg-accent transition-colors">Profile</a></li>
-                      <li><a href="/my-jobs" className="hover:text-qg-accent transition-colors">My Jobs</a></li>
+                      <li>
+                        <Link href="/find-work" className="hover:text-qg-accent transition-colors">Find Work</Link>
+                      </li>
+                      <li>
+                        <Link href="/profile" className="hover:text-qg-accent transition-colors">Profile</Link>
+                      </li>
+                      <li>
+                        <Link href="/my-jobs" className="hover:text-qg-accent transition-colors">My Jobs</Link>
+                      </li>
                     </ul>
                   </div>
                   <div>
                     <h3 className="font-heading font-semibold text-fg mb-4">Para sa Employers</h3>
                     <ul className="space-y-2 text-fg opacity-70">
-                      <li><a href="/post-job" className="hover:text-qg-accent transition-colors">Post Job</a></li>
-                      <li><a href="/buy-tickets" className="hover:text-qg-accent transition-colors">Buy Tickets</a></li>
-                      <li><a href="/messages" className="hover:text-qg-accent transition-colors">Messages</a></li>
+                      <li>
+                        <Link href="/post-job" className="hover:text-qg-accent transition-colors">Post Job</Link>
+                      </li>
+                      <li>
+                        <Link href="/buy-tickets" className="hover:text-qg-accent transition-colors">Buy Tickets</Link>
+                      </li>
+                      <li>
+                        <Link href="/messages" className="hover:text-qg-accent transition-colors">Messages</Link>
+                      </li>
                     </ul>
                   </div>
                 </div>

--- a/tests/link-scan.mjs
+++ b/tests/link-scan.mjs
@@ -1,0 +1,16 @@
+const url = 'https://app.quickgig.ph';
+
+const res = await fetch(url);
+const html = await res.text();
+
+function extract(regex) {
+  return [...html.matchAll(regex)].map(m => m[1]);
+}
+
+const anchors = extract(/<a\s+[^>]*href=["']([^"']+)["']/gi);
+const buttons = extract(/<button\s+[^>]*data-cta=["']([^"']+)["']/gi);
+
+console.log('a[href]');
+for (const href of anchors) console.log(href);
+console.log('\nbutton[data-cta]');
+for (const cta of buttons) console.log(cta);

--- a/tools/check_links.mjs
+++ b/tools/check_links.mjs
@@ -1,0 +1,33 @@
+const base = (process.env.BASE || '').replace(/\/$/, '');
+if (!base) {
+  console.warn('No BASE provided; skipping link check');
+  process.exit(0);
+}
+
+const paths = ['/', '/find-work', '/post-job', '/login', '/signup'];
+
+const fetchImpl = globalThis.fetch;
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+async function head(u) {
+  let last;
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await fetchImpl(u, { method: 'HEAD', redirect: 'manual' });
+    } catch (e) {
+      last = e;
+      await wait(1000 * (i + 1));
+    }
+  }
+  throw last || new Error('fetch failed');
+}
+
+(async () => {
+  for (const p of paths) {
+    const r = await head(base + p);
+    if (r.status >= 200 && r.status < 400) {
+      console.log(`\u2705 ${p} -> ${r.status}`);
+    } else {
+      throw new Error(`${p} -> ${r.status}`);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- update landing hero CTA buttons: "Simulan Na!" → /signup and "Browse Jobs" → /find-work
- convert footer navigation to Next.js `<Link>` for internal routes
- add link checker tool and script to verify key paths

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `BASE=https://quickgig.ph npm run scan:links` *(fails: connect ENETUNREACH 76.76.21.21:443)*
- `node tests/link-scan.mjs` *(fails: connect ENETUNREACH 89.116.53.39:443)*

------
https://chatgpt.com/codex/tasks/task_e_689dde5fbb9483278216a12909272dbf