### PR TITLE
feat(jobs): fetch & render jobs from API with fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:appassets": "node tools/check_app_assets.mjs",
     "check:app:soft": "node tools/check_live_app.mjs || true",
     "check:dns:app": "node tools/check_dns_app.mjs",
+    "check:jobs": "node tools/check_jobs_api.mjs || true",
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",

--- a/src/app/find-work/page.tsx
+++ b/src/app/find-work/page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { fetchJobs } from '@/lib/api';
+import { Card, CardContent, CardFooter, CardHeader, CardTag } from '@/components/ui/Card';
+import Button from '@/components/ui/Button';
+import type { Job } from '../../../types/jobs';
+
+export const dynamic = 'force-dynamic';
+
+export default async function FindWorkPage() {
+  let jobs: Job[] = [];
+  try {
+    jobs = await fetchJobs();
+  } catch (err) {
+    console.error('fetchJobs error:', err);
+  }
+
+  if (!jobs.length) {
+    return (
+      <main className="p-4">
+        <Card>
+          <p>Walang jobs ngayon—try again</p>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      {jobs.map((job) => (
+        <Card key={job.id} padding="md">
+          <CardHeader>{job.title}</CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-600">
+              {job.company} · {job.location} · {job.rate}
+            </p>
+            {job.tags && (
+              <div className="flex flex-wrap gap-2 mt-2">
+                {job.tags.map((tag) => (
+                  <CardTag key={tag}>{tag}</CardTag>
+                ))}
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <span className="text-sm text-gray-500">
+              Posted {new Date(job.postedAt).toLocaleDateString()}
+            </span>
+            <Link href={`/jobs/${job.id}`}>
+              <Button size="sm">Apply</Button>
+            </Link>
+          </CardFooter>
+        </Card>
+      ))}
+    </main>
+  );
+}

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,0 +1,12 @@
+interface JobPageProps {
+  params: { id: string };
+}
+
+export default function JobPage({ params }: JobPageProps) {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl mb-4">Job {params.id}</h1>
+      <p>Details coming soon.</p>
+    </main>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { safeJsonParse } from './json';
+import type { Job } from '../../types/jobs';
 
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph';
@@ -93,5 +94,9 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   const json = safeJsonParse<T>(res.body);
   if (!json.ok) throw json.error;
   return json.value as T;
+}
+
+export async function fetchJobs(): Promise<Job[]> {
+  return apiFetch<Job[]>('/jobs');
 }
 

--- a/tools/check_jobs_api.mjs
+++ b/tools/check_jobs_api.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const BASE = (process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph').replace(/\/$/, '');
+
+(async () => {
+  try {
+    const res = await fetch(BASE + '/jobs');
+    const data = await res.json();
+    if (Array.isArray(data)) {
+      console.log('Jobs API OK');
+      process.exit(0);
+    }
+    console.error('Unexpected response:', data);
+    process.exit(1);
+  } catch (err) {
+    console.error('Jobs check failed:', err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+})();

--- a/types/jobs.ts
+++ b/types/jobs.ts
@@ -1,0 +1,9 @@
+export interface Job {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  rate: string;
+  postedAt: string;
+  tags?: string[];
+}


### PR DESCRIPTION
## Summary
- add jobs API fetcher and Job type
- server-render /find-work with job cards and empty-state fallback
- add jobs API check script for optional CI visibility

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run check:jobs` *(fails: Jobs check failed: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689de112ed9c8327afc29389e3c151ac