### PR TITLE
feat(tests): Playwright smoke (manual+nightly) proving core flows

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -1,0 +1,24 @@
+name: E2E Smoke (Manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      BASE: https://app.quickgig.ph
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm install -g @playwright/test
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e:smoke -- --reporter=html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,25 @@
+name: E2E Smoke (Nightly)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      BASE: https://app.quickgig.ph
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm install -g @playwright/test
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e:smoke -- --reporter=html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test tests/smoke.spec.ts --reporter=list",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/check_links.mjs"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  reporter: 'html',
+  use: {
+    baseURL: process.env.BASE || 'http://localhost:3000',
+  },
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const home = async (page: Page) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'QuickGig' })).toBeVisible();
+  await page.getByRole('link', { name: 'Simulan Na!' }).click();
+  await expect(page).toHaveURL(/\/signup/);
+  await page.goBack();
+  await page.getByRole('link', { name: 'Browse Jobs' }).click();
+  await expect(page).toHaveURL(/\/find-work/);
+};
+
+const checkFindWork = async (page: Page) => {
+  await page.goto('/find-work');
+  const emptyState = page.getByText('Walang jobs ngayon');
+  const jobCard = page.getByRole('button', { name: 'Apply' });
+  await Promise.race([
+    emptyState.waitFor({ state: 'visible' }),
+    jobCard.first().waitFor({ state: 'visible' }),
+  ]);
+};
+
+const postJob = async (page: Page) => {
+  await page.goto('/post-job');
+  await expect(page.locator('form')).toBeVisible();
+};
+
+test('home page headline and CTAs', async ({ page }) => {
+  await home(page);
+});
+
+test('find-work lists jobs or empty state', async ({ page }) => {
+  await checkFindWork(page);
+});
+
+test('post-job form exists', async ({ page }) => {
+  await postJob(page);
+});


### PR DESCRIPTION
## Summary
- add Playwright config and smoke test covering home, find-work, and post-job flows
- expose `test:e2e:smoke` script
- add manual and nightly workflows uploading Playwright HTML report

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@playwright/test')*
- `BASE=https://app.quickgig.ph npm run test:e2e:smoke` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de4ed5a388327870f719845194b84