### PR TITLE
ci(step5): prod-only build; smoke dev-only (non-blocking); Next/React in deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,17 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org/
 
-      # Prod-only install (keeps Playwright/dev deps out of builds)
+      # Use public registry
+      - name: Set npm registry
+        run: npm config set registry https://registry.npmjs.org/
+
+      # Clean & install ONLY production deps (no Playwright/dev)
       - name: Install prod deps only
-        run: npm ci --omit=dev --no-audit --no-fund || npm install --omit=dev --no-audit --no-fund
+        run: |
+          rm -rf node_modules
+          npm ci --omit=dev --no-audit --no-fund || npm install --omit=dev --no-audit --no-fund
 
+      # Minimal build (no lint/typecheck in CI build)
       - name: Build
         run: npm run build
-
-      # Optional soft check: surfaces output but never fails the job
-      - name: Verify API (soft)
-        run: |
-          outs=$(npm run --silent check:api 2>&1 || true)
-          echo "${outs}"
-          echo "::notice::${outs//$'\n'/ ' '}"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,28 +1,28 @@
-name: E2E Smoke
+name: E2E Smoke (nightly)
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *' # daily at 03:00 UTC
+    - cron: '0 3 * * *'
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org/
 
-      # Explicitly include dev deps; .npmrc defaults to omit=dev
+      - name: Use public registry
+        run: npm config set registry https://registry.npmjs.org/
+
       - name: Install dev deps (Playwright, types, etc.)
-        run: npm ci --include=dev --no-audit --no-fund || npm install --include=dev --no-audit --no-fund
+        run: |
+          rm -rf node_modules
+          npm ci --include=dev --no-audit --no-fund || npm install --include=dev --no-audit --no-fund
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,16 +6,21 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org/
+
+      - name: Use public registry
+        run: npm config set registry https://registry.npmjs.org/
 
       - name: Install dev deps (Playwright, types, etc.)
-        run: npm ci --include=dev --no-audit --no-fund || npm install --include=dev --no-audit --no-fund
+        run: |
+          rm -rf node_modules
+          npm ci --include=dev --no-audit --no-fund || npm install --include=dev --no-audit --no-fund
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -24,3 +29,11 @@ jobs:
         env:
           BASE: https://app.quickgig.ph
         run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+registry=https://registry.npmjs.org/
+@*:registry=https://registry.npmjs.org/
+omit=dev
+fund=false
+audit=false

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run typecheck && npm run lint:ci && next build",
+    "build": "next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:ci": "eslint . --max-warnings=0",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "check:api": "node tools/check_api.mjs",
     "check:api:soft": "node tools/check_live_api.mjs || true",
     "check:app": "node tools/check_app.mjs",
@@ -50,5 +50,8 @@
   },
   "playwright": {
     "skipBrowserDownload": true
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary
- Add .npmrc to use public npm registry and disable audits/funding
- Simplify Next build script and add Node engine requirement
- CI installs prod deps only; smoke workflows install dev deps, run Playwright smokes, and upload reports

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ec887ef108327bc4843835b817f8c