### PR TITLE
feat: centralize env config and add env viewer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
-NEXT_PUBLIC_API_BASE=
-NEXT_PUBLIC_FACEBOOK_PAGE_ID=CHANGE_ME
-NEXT_PUBLIC_FACEBOOK_APP_ID=CHANGE_ME
-NEXT_PUBLIC_ENABLE_PAYMENTS=false
+# Base URL for the backend API (defaults to http://localhost:3001)
+NEXT_PUBLIC_API_BASE=http://localhost:3001
+
+# Facebook app ID for login and chat widgets (optional)
+NEXT_PUBLIC_FACEBOOK_APP_ID=
+
+# Facebook page ID for Messenger chat (optional)
+NEXT_PUBLIC_FACEBOOK_PAGE_ID=
+
+# Environment name used in logs (local|preview|production)
 NEXT_PUBLIC_ENV=local
-NEXTAUTH_URL=https://quickgig.ph
-NEXTAUTH_SECRET=CHANGE_ME
-JWT_SECRET=CHANGE_ME
+
+# Base URL for scripts and smoke tests (optional)
+# BASE=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env.local` and adjust as needed. The app
-  defaults to the public API if the variable is missing:
+2. Copy `.env.example` to `.env.local` and adjust as needed. Sensible
+   defaults are included for local development:
    ```env
-    NEXT_PUBLIC_API_BASE=https://api.quickgig.ph
-    NEXT_PUBLIC_ENV=local
-    ```
+   NEXT_PUBLIC_API_BASE=http://localhost:3001
+   NEXT_PUBLIC_ENV=local
+   ```
 
 To verify the live API locally, run:
 
@@ -43,6 +43,9 @@ Run the development server and visit the branded home page at
 ```bash
 npm run dev
 ```
+
+During development, `/system/env` displays the public environment values
+with badges for any missing entries.
 
 ## E2E Smoke Tests
 
@@ -73,10 +76,10 @@ Login, signup, and other protected pages call the external API at
 
 ### Smoke checks
 
-  The app defaults to the public API if `NEXT_PUBLIC_API_BASE` is unset:
+  The app defaults to a local API if `NEXT_PUBLIC_API_BASE` is unset:
 
 ```env
-  NEXT_PUBLIC_API_BASE=https://api.quickgig.ph
+  NEXT_PUBLIC_API_BASE=http://localhost:3001
 ```
 
 Verify the production root and API:
@@ -104,8 +107,19 @@ This repo hosts the Next.js frontend for QuickGig.
 - `/` serves the app directly. Legacy `/app` paths redirect to `/`.
 
 ## Environment
-  - `NEXT_PUBLIC_API_BASE=https://api.quickgig.ph`
-  - `NEXT_PUBLIC_ENV=production|preview|local`
+Set these in `.env.local` for local development and in Vercel under
+**Settings → Environment Variables**:
+
+- `NEXT_PUBLIC_API_BASE` – base URL for the backend API. Defaults to
+  `http://localhost:3001`.
+- `NEXT_PUBLIC_FACEBOOK_APP_ID` – Facebook app ID for login and chat
+  widgets. Optional.
+- `NEXT_PUBLIC_FACEBOOK_PAGE_ID` – Facebook page ID for the Messenger
+  chat plugin. Optional.
+- `NEXT_PUBLIC_ENV` – environment name used in logs (`local`, `preview`,
+  `production`).
+- `BASE` – base URL for scripts and smoke tests. Optional and not
+  exposed to the client.
 
 ## Cookies & Auth
 The API sets a session cookie (e.g., `qg_session`) with:

--- a/src/app/system/env/page.tsx
+++ b/src/app/system/env/page.tsx
@@ -1,0 +1,31 @@
+import { env } from '@/config/env';
+import { notFound } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+export default function EnvPage() {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  const entries = Object.entries(env).filter(([key]) =>
+    key.startsWith('NEXT_PUBLIC'),
+  );
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-xl">Environment variables</h1>
+      <ul className="space-y-2">
+        {entries.map(([key, value]) => (
+          <li key={key}>
+            <span className="font-mono">{key}</span>: {value ? (
+              <span>{value}</span>
+            ) : (
+              <span className="rounded bg-yellow-200 px-1 text-yellow-800">missing</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/components/FacebookLogin.tsx
+++ b/src/components/FacebookLogin.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { initFacebook } from '@/lib/facebook';
+import { env } from '@/config/env';
 import Button from '@/components/ui/Button';
 
 interface FacebookLoginProps {
@@ -18,8 +19,8 @@ export default function FacebookLogin({
   size = 'md',
 }: FacebookLoginProps) {
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_FACEBOOK_APP_ID) {
-      initFacebook(process.env.NEXT_PUBLIC_FACEBOOK_APP_ID);
+    if (env.NEXT_PUBLIC_FACEBOOK_APP_ID) {
+      initFacebook(env.NEXT_PUBLIC_FACEBOOK_APP_ID);
     }
   }, []);
 

--- a/src/components/MessengerChat.tsx
+++ b/src/components/MessengerChat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { env } from '@/config/env';
 
 interface MessengerChatProps {
   pageId?: string;
@@ -22,8 +23,8 @@ declare global {
 }
 
 export default function MessengerChat({
-  pageId = process.env.NEXT_PUBLIC_FACEBOOK_PAGE_ID,
-  appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID,
+  pageId = env.NEXT_PUBLIC_FACEBOOK_PAGE_ID,
+  appId = env.NEXT_PUBLIC_FACEBOOK_APP_ID,
   themeColor = '#00B272',
   loggedInGreeting = 'Kumusta! Paano ka namin matutulungan sa QuickGig.ph?',
   loggedOutGreeting = 'Kumusta! May tanong ka ba tungkol sa QuickGig.ph? Message mo kami!',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,20 @@
+// Centralized environment variable handling
+function getEnv(key: string, fallback = ''): string {
+  const value = process.env[key];
+  if (!value && process.env.NODE_ENV === 'development') {
+    const msg = fallback
+      ? `Missing environment variable ${key}, using fallback '${fallback}'.`
+      : `Missing environment variable ${key}.`;
+    console.warn(msg);
+  }
+  return value || fallback;
+}
+
+export const env = {
+  NEXT_PUBLIC_API_BASE: getEnv('NEXT_PUBLIC_API_BASE', 'http://localhost:3001'),
+  NEXT_PUBLIC_FACEBOOK_APP_ID: getEnv('NEXT_PUBLIC_FACEBOOK_APP_ID'),
+  NEXT_PUBLIC_FACEBOOK_PAGE_ID: getEnv('NEXT_PUBLIC_FACEBOOK_PAGE_ID'),
+  NEXT_PUBLIC_ENV: getEnv('NEXT_PUBLIC_ENV', 'local'),
+} as const;
+
+export type Env = typeof env;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,10 @@
 import { safeJsonParse } from './json';
 import { toast } from './toast';
 import { report } from './report';
+import { env } from '@/config/env';
 import type { Job } from '../../types/jobs';
 
-export const API_BASE =
-  process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph';
+export const API_BASE = env.NEXT_PUBLIC_API_BASE;
 
 export function get(path: string, init?: RequestInit) {
   return fetch(`${API_BASE}${path}`, { ...init, method: 'GET' });

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -1,4 +1,5 @@
+import { env } from '@/config/env';
+
 export function report(error: unknown, context?: string) {
-  const env = process.env.NEXT_PUBLIC_ENV || 'local';
-  console.error('[error]', { env, context, error });
+  console.error('[error]', { env: env.NEXT_PUBLIC_ENV, context, error });
 }


### PR DESCRIPTION
## Summary
- centralize env variable handling with defaults and dev warnings
- document environment variables and add sample `.env.example`
- add dev-only `/system/env` page showing public vars

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efd5161708327b8b3a025360c6fa9