### PR TITLE
Connect frontend to backend API (auth, jobs, env)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,9 @@
-# Base URL for the backend API (defaults to http://localhost:3001)
-NEXT_PUBLIC_API_BASE=http://localhost:3001
+# Backend base URLs
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+API_URL=https://api.quickgig.ph
 
-# Facebook app ID for login and chat widgets (optional)
-NEXT_PUBLIC_FACEBOOK_APP_ID=
+# Auth
+JWT_COOKIE_NAME=auth_token
 
-# Facebook page ID for Messenger chat (optional)
-NEXT_PUBLIC_FACEBOOK_PAGE_ID=
-
-# Environment name used in logs (local|preview|production)
-NEXT_PUBLIC_ENV=local
-
-# Base URL for scripts and smoke tests (optional)
-# BASE=http://localhost:3000
+# Feature flags
+NEXT_PUBLIC_ENABLE_APPLY=false

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
 2. Copy `.env.example` to `.env.local` and adjust as needed. Sensible
    defaults are included for local development:
    ```env
-   NEXT_PUBLIC_API_BASE=http://localhost:3001
-   NEXT_PUBLIC_ENV=local
-   ```
+NEXT_PUBLIC_API_URL=http://localhost:3001
+API_URL=http://localhost:3001
+JWT_COOKIE_NAME=auth_token
+NEXT_PUBLIC_ENABLE_APPLY=false
+NEXT_PUBLIC_ENV=local
+```
 
 To verify the live API locally, run:
 
@@ -30,9 +33,7 @@ BASE=https://api.quickgig.ph node tools/check_live_api.mjs
 
 ## Authentication
 
-The app communicates with an external API using the `/src/lib/api.ts` helper. When `auth` is set on a request, a JWT token stored in `localStorage` is sent in the `Authorization` header. If the backend issues HttpOnly cookies, they are included automatically.
-
-Tokens are managed through `/src/lib/auth.ts`, and basic route protection is available via `/src/lib/withAuth.tsx`.
+Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.
 
 ## Development
 
@@ -60,7 +61,7 @@ BASE=https://app.quickgig.ph npm run test:e2e:smoke
 ## Deployment
 
 Deployment is handled via the Vercel GitHub integration. Ensure the
-  `NEXT_PUBLIC_API_BASE` environment variable is set in your Vercel project
+  `NEXT_PUBLIC_API_URL` environment variable is set in your Vercel project
 settings.
 
 Login, signup, and other protected pages call the external API at
@@ -76,10 +77,10 @@ Login, signup, and other protected pages call the external API at
 
 ### Smoke checks
 
-  The app defaults to a local API if `NEXT_PUBLIC_API_BASE` is unset:
+  The app defaults to a local API if `NEXT_PUBLIC_API_URL` is unset:
 
 ```env
-  NEXT_PUBLIC_API_BASE=http://localhost:3001
+  NEXT_PUBLIC_API_URL=http://localhost:3001
 ```
 
 Verify the production root and API:
@@ -110,8 +111,10 @@ This repo hosts the Next.js frontend for QuickGig.
 Set these in `.env.local` for local development and in Vercel under
 **Settings → Environment Variables**:
 
-- `NEXT_PUBLIC_API_BASE` – base URL for the backend API. Defaults to
-  `http://localhost:3001`.
+- `NEXT_PUBLIC_API_URL` – backend API base URL exposed to the client. Defaults to `http://localhost:3001`.
+- `API_URL` – server-side base URL for the backend API
+- `JWT_COOKIE_NAME` – name of the auth cookie
+- `NEXT_PUBLIC_ENABLE_APPLY` – enable Apply buttons for jobs
 - `NEXT_PUBLIC_FACEBOOK_APP_ID` – Facebook app ID for login and chat
   widgets. Optional.
 - `NEXT_PUBLIC_FACEBOOK_PAGE_ID` – Facebook page ID for the Messenger

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { env } from './src/config/env';
+
+const protectedPaths = ['/dashboard', '/profile', '/account'];
+
+export function middleware(req: NextRequest) {
+  if (protectedPaths.some((p) => req.nextUrl.pathname.startsWith(p))) {
+    const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;
+    if (!token) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/profile/:path*', '/account/:path*'],
+};

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -36,7 +36,7 @@ export default function HomePageClient() {
             Gigs and talent, matched fast.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/signup">
+            <Link href="/register">
               <Button
                 size="lg"
                 variant="secondary"

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,3 @@
+export default function AccountPage() {
+  return <main className="p-4">Account</main>;
+}

--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const res = await fetch(`${env.API_URL}${API.login}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (res.ok && data.token) {
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(env.JWT_COOKIE_NAME, data.token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 7,
+    });
+    return response;
+  }
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/session/logout/route.ts
+++ b/src/app/api/session/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/config/env';
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(env.JWT_COOKIE_NAME, '', {
+    httpOnly: true,
+    expires: new Date(0),
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+  return res;
+}

--- a/src/app/api/session/me/route.ts
+++ b/src/app/api/session/me/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;
+  if (!token) return NextResponse.json({ ok: false }, { status: 401 });
+
+  const res = await fetch(`${env.API_URL}${API.me}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/session/register/route.ts
+++ b/src/app/api/session/register/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const res = await fetch(`${env.API_URL}${API.register}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (res.ok && data.token) {
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(env.JWT_COOKIE_NAME, data.token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 7,
+    });
+    return response;
+  }
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <main className="p-4">Dashboard</main>;
+}

--- a/src/app/jobs/apply-button.tsx
+++ b/src/app/jobs/apply-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+import { useState } from 'react';
+import apiClient from '@/lib/apiClient';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+
+export default function ApplyButton({ jobId }: { jobId: string }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [note, setNote] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!env.NEXT_PUBLIC_ENABLE_APPLY) {
+    return (
+      <button
+        className="bg-yellow-400 rounded px-3 py-1"
+        onClick={() => alert('Applications are handled manually during beta.')}
+      >
+        Apply
+      </button>
+    );
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await apiClient.post(API.apply, { jobId, name, email, phone, note });
+      setOpen(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button className="bg-yellow-400 rounded px-3 py-1" onClick={() => setOpen(true)}>
+        Apply
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <form onSubmit={submit} className="bg-white p-4 rounded space-y-2 w-80">
+            <h2 className="text-lg font-semibold">Apply</h2>
+            <input className="w-full border p-1" placeholder="Name" value={name} onChange={e=>setName(e.target.value)} required />
+            <input className="w-full border p-1" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required />
+            <input className="w-full border p-1" placeholder="Phone" value={phone} onChange={e=>setPhone(e.target.value)} />
+            <textarea className="w-full border p-1" placeholder="Note" value={note} onChange={e=>setNote(e.target.value)} />
+            <div className="flex justify-end space-x-2 pt-2">
+              <button type="button" className="px-3 py-1" onClick={() => setOpen(false)} disabled={loading}>Cancel</button>
+              <button type="submit" className="bg-yellow-400 px-3 py-1 rounded" disabled={loading}>
+                {loading ? 'Sending...' : 'Submit'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,0 +1,41 @@
+import apiClient from '@/lib/apiClient';
+import { API } from '@/config/api';
+import type { Job } from '../../../types/jobs';
+import ApplyButton from './apply-button';
+
+export const dynamic = 'force-dynamic';
+
+async function fetchJobs(): Promise<Job[]> {
+  try {
+    const res = await apiClient.get(API.jobs, {
+      params: { status: 'active', page: 1, limit: 20 },
+    });
+    return res.data as Job[];
+  } catch {
+    return [];
+  }
+}
+
+export default async function JobsPage() {
+  const jobs = await fetchJobs();
+  if (!jobs.length) {
+    return (
+      <main className="p-4">
+        <p>No jobs found.</p>
+      </main>
+    );
+  }
+  return (
+    <main className="p-4 space-y-4">
+      {jobs.map((job: Job) => (
+        <div key={job.id} className="border rounded p-4 flex justify-between items-center">
+          <div>
+            <h2 className="font-semibold">{job.title}</h2>
+            <p className="text-sm text-gray-600">{job.company} · {job.location} · {job.rate}</p>
+          </div>
+          <ApplyButton jobId={job.id} />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { apiFetch } from '@/lib/api';
-import { saveToken } from '@/lib/auth';
-import { User } from '@/types';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -18,15 +15,13 @@ export default function LoginPage() {
     if (!email || !password) { setError('Email and password are required'); return; }
     setLoading(true);
     try {
-      const data = await apiFetch<{ token?: string; user?: User }>('/auth/login', {
+      const res = await fetch('/api/session/login', {
         method: 'POST',
-        body: JSON.stringify({ email, password })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
       });
-
-      if (data.token) saveToken(data.token);
-      if (data.user) localStorage.setItem('user', JSON.stringify(data.user));
-
-      router.push('/');
+      if (!res.ok) throw new Error('Login failed');
+      router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');
     } finally {
@@ -53,7 +48,7 @@ export default function LoginPage() {
             {loading ? 'Signing in…' : 'Login'}
           </button>
         </form>
-        <p className="text-sm mt-3">No account? <a className="text-sky-600 font-semibold" href="/signup">Sign up</a></p>
+        <p className="text-sm mt-3">No account? <a className="text-sky-600 font-semibold" href="/register">Sign up</a></p>
       </div>
     </div>
   );

--- a/src/app/payment/page.tsx
+++ b/src/app/payment/page.tsx
@@ -1,0 +1,10 @@
+export default function PaymentPage() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Payment</h1>
+      <p>Upload proof of payment via support while gateway is being integrated.</p>
+      {/* eslint-disable-next-line @next/next/no-img-element -- placeholder */}
+      <img src="/gcash-qr.png" alt="GCash QR" className="max-w-xs" />
+    </main>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+  return <main className="p-4">Profile</main>;
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,14 +1,11 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { apiFetch } from '@/lib/api';
 
-export default function SignupPage() {
+export default function RegisterPage() {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
-  const [role, setRole] = useState<'Job Seeker' | 'Employer'>('Job Seeker');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -16,14 +13,16 @@ export default function SignupPage() {
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    if (!name || !email || !phone || !password) { setError('Please fill in all required fields'); return; }
+    if (!name || !email || !password) { setError('All fields are required'); return; }
     setLoading(true);
     try {
-      await apiFetch('/auth/register', {
+      const res = await fetch('/api/session/register', {
         method: 'POST',
-        body: JSON.stringify({ name, email, phone, role, password })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
       });
-      router.push('/login?register=success');
+      if (!res.ok) throw new Error('Registration failed');
+      router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
     } finally {
@@ -33,11 +32,11 @@ export default function SignupPage() {
 
   return (
     <div className="qg-container py-12">
-      <div className="max-w-xl mx-auto bg-white/70 rounded-2xl p-6 shadow">
-        <h1 className="text-2xl font-bold mb-2">Create your account</h1>
-        <p className="text-sm text-gray-600 mb-4">Join QuickGig in minutes.</p>
+      <div className="max-w-md mx-auto bg-white/70 rounded-2xl p-6 shadow">
+        <h1 className="text-2xl font-bold mb-2">Register</h1>
+        <p className="text-sm text-gray-600 mb-4">Create your QuickGig account.</p>
         {error && <div className="bg-red-100 text-red-700 border border-red-200 rounded-lg p-3 mb-3">{error}</div>}
-        <form onSubmit={onSubmit} className="grid grid-cols-1 gap-3">
+        <form onSubmit={onSubmit} className="space-y-3">
           <div>
             <label className="block text-sm font-medium mb-1">Full name</label>
             <input className="w-full border rounded-lg p-2" value={name} onChange={e=>setName(e.target.value)} required />
@@ -45,17 +44,6 @@ export default function SignupPage() {
           <div>
             <label className="block text-sm font-medium mb-1">Email</label>
             <input className="w-full border rounded-lg p-2" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Phone</label>
-            <input className="w-full border rounded-lg p-2" value={phone} onChange={e=>setPhone(e.target.value)} required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Role</label>
-            <select className="w-full border rounded-lg p-2" value={role} onChange={e=>setRole(e.target.value as 'Job Seeker' | 'Employer')}>
-              <option value="Job Seeker">Job Seeker</option>
-              <option value="Employer">Employer</option>
-            </select>
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Password</label>

--- a/src/auth/getUser.ts
+++ b/src/auth/getUser.ts
@@ -1,0 +1,18 @@
+import { cookies } from 'next/headers';
+import type { User } from '@/types';
+
+export async function getUser(): Promise<User | null> {
+  const cookie = cookies().toString();
+  const base = process.env.NEXT_PUBLIC_SITE_URL
+    || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+  try {
+    const res = await fetch(`${base}/api/session/me`, {
+      headers: { Cookie: cookie },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as User;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
@@ -11,13 +12,15 @@ import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home }
 
 const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
+  const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     setIsMenuOpen(false);
+    router.push("/");
   };
 
   return (
@@ -67,6 +70,13 @@ const Navigation: React.FC = () => {
 
             {isAuthenticated ? (
               <div className="flex items-center space-x-2 ml-4 pl-4 border-l border-qg-navy-light">
+                  <Link
+                    href="/dashboard"
+                    className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                  >
+                    <Home className="w-4 h-4 mr-2" />
+                    Dashboard
+                  </Link>
                 {user?.role === 'Admin' && (
                   <Link
                     href="/admin"
@@ -127,7 +137,7 @@ const Navigation: React.FC = () => {
                     Login
                   </Button>
                 </Link>
-                <Link href="/signup">
+                <Link href="/register">
                   <Button variant="secondary" size="sm">
                     Sign Up
                   </Button>
@@ -184,6 +194,10 @@ const Navigation: React.FC = () => {
                       Kumusta, <span className="font-medium text-fg">{user?.name}</span>
                     </div>
                   </div>
+                    <Link href="/dashboard" className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent" onClick={() => setIsMenuOpen(false)}>
+                      <Home className="w-5 h-5 mr-3" />
+                      Dashboard
+                    </Link>
                   
                   {user?.role === 'Admin' && (
                     <Link
@@ -239,7 +253,7 @@ const Navigation: React.FC = () => {
                       Login
                     </Button>
                   </Link>
-                  <Link href="/signup" onClick={() => setIsMenuOpen(false)}>
+                  <Link href="/register" onClick={() => setIsMenuOpen(false)}>
                     <Button variant="secondary" className="w-full">
                       Sign Up
                     </Button>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,7 @@
+export const API = {
+  login: '/auth/login',
+  register: '/auth/register',
+  me: '/auth/me',
+  jobs: '/jobs',           // GET ?status=active&page=1&limit=20
+  apply: '/applications',  // POST application payload
+};

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,20 +1,21 @@
-// Centralized environment variable handling
-function getEnv(key: string, fallback = ''): string {
+// Environment variable handling
+function getEnv(key: string, fallback?: string) {
   const value = process.env[key];
   if (!value && process.env.NODE_ENV === 'development') {
-    const msg = fallback
-      ? `Missing environment variable ${key}, using fallback '${fallback}'.`
-      : `Missing environment variable ${key}.`;
-    console.warn(msg);
+    console.warn(`Missing environment variable ${key}${fallback ? ", using fallback '" + fallback + "'" : ''}`);
   }
-  return value || fallback;
+  return value ?? fallback ?? '';
 }
 
 export const env = {
-  NEXT_PUBLIC_API_BASE: getEnv('NEXT_PUBLIC_API_BASE', 'http://localhost:3001'),
+  NEXT_PUBLIC_API_URL: getEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3001'),
+  API_URL: getEnv('API_URL', getEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3001')),
+  JWT_COOKIE_NAME: getEnv('JWT_COOKIE_NAME', 'auth_token'),
   NEXT_PUBLIC_FACEBOOK_APP_ID: getEnv('NEXT_PUBLIC_FACEBOOK_APP_ID'),
   NEXT_PUBLIC_FACEBOOK_PAGE_ID: getEnv('NEXT_PUBLIC_FACEBOOK_PAGE_ID'),
   NEXT_PUBLIC_ENV: getEnv('NEXT_PUBLIC_ENV', 'local'),
-} as const;
+  NEXT_PUBLIC_ENABLE_APPLY:
+    getEnv('NEXT_PUBLIC_ENABLE_APPLY', 'false').toLowerCase() === 'true',
+};
 
 export type Env = typeof env;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,8 +2,8 @@
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
-import { apiFetch } from '@/lib/api';
-import { saveToken, clearAuth, getToken } from '@/lib/auth';
+import apiClient from '@/lib/apiClient';
+import { API } from '@/config/api';
 
 interface AuthContextType {
   user: User | null;
@@ -13,7 +13,6 @@ interface AuthContextType {
   logout: () => Promise<void>;
   updateUser: (data: UpdateUserData) => Promise<void>;
   isAuthenticated: boolean;
-  token: string | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -34,96 +33,38 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const initAuth = async () => {
-      const token = getToken();
-      const savedUser = localStorage.getItem('user');
-      if (token && savedUser) {
-        setUser(JSON.parse(savedUser));
-      } else if (token) {
-        try {
-          const response = await apiFetch<{ user?: User }>('/user/me', {
-            headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-            credentials: 'include',
-          });
-          if (response.user) {
-            localStorage.setItem('user', JSON.stringify(response.user));
-            setUser(response.user);
-          }
-        } catch {
-          clearAuth();
-          localStorage.removeItem('user');
-          setUser(null);
-        }
-      }
-      setLoading(false);
-    };
+  const fetchMe = async () => {
+    try {
+      const res = await apiClient.get(API.me);
+      setUser(res.data as User);
+    } catch {
+      setUser(null);
+    }
+  };
 
-    initAuth();
+  useEffect(() => {
+    fetchMe().finally(() => setLoading(false));
   }, []);
 
   const login = async (data: LoginData) => {
-    try {
-      const response = await apiFetch<{ token?: string; user?: User }>('/auth/login', {
-        method: 'POST',
-        body: JSON.stringify(data),
-      });
-      if (response.token) saveToken(response.token);
-      if (response.user) {
-        localStorage.setItem('user', JSON.stringify(response.user));
-        setUser(response.user);
-      }
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : 'Login failed');
-    }
+    await apiClient.post(API.login, data);
+    await fetchMe();
   };
 
   const signup = async (data: SignupData) => {
-    try {
-      const response = await apiFetch<{ token?: string; user?: User }>('/auth/register', {
-        method: 'POST',
-        body: JSON.stringify(data),
-      });
-      if (response.token) saveToken(response.token);
-      if (response.user) {
-        localStorage.setItem('user', JSON.stringify(response.user));
-        setUser(response.user);
-      }
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : 'Signup failed');
-    }
+    await apiClient.post(API.register, data);
+    await fetchMe();
   };
 
   const logout = async () => {
-    try {
-      const token = getToken();
-      await apiFetch('/auth/logout', {
-        method: 'POST',
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        credentials: 'include',
-      });
-    } catch {}
-    clearAuth();
-    localStorage.removeItem('user');
+    await fetch('/api/session/logout', { method: 'POST' });
     setUser(null);
   };
 
   const updateUser = async (data: UpdateUserData) => {
-    try {
-      const token = getToken();
-      const response = await apiFetch<{ user?: User }>('/user/update', {
-        method: 'PUT',
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        credentials: 'include',
-        body: JSON.stringify(data),
-      });
-      const updatedUser = response.user;
-      if (updatedUser) {
-        localStorage.setItem('user', JSON.stringify(updatedUser));
-        setUser(updatedUser);
-      }
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : 'Update failed');
+    const res = await apiClient.put<{ user?: User }>("/user/update", data);
+    if (res.data.user) {
+      setUser(res.data.user);
     }
   };
 
@@ -135,9 +76,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     logout,
     updateUser,
     isAuthenticated: !!user,
-    token: getToken(),
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
-

--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -30,17 +30,11 @@ interface SocketProviderProps {
 export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
-  const { user, token, isAuthenticated } = useAuth();
+  const { user, isAuthenticated } = useAuth();
 
   useEffect(() => {
-    if (isAuthenticated && token && user) {
-      // Initialize socket connection
-      const newSocket = io(API_BASE, {
-        auth: {
-          token: token,
-        },
-        transports: ['websocket', 'polling'],
-      });
+    if (isAuthenticated && user) {
+      const newSocket = io(API_BASE, { withCredentials: true, transports: ['websocket', 'polling'] });
 
       newSocket.on('connect', () => {
         console.log('Connected to server');
@@ -72,7 +66,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
         setIsConnected(false);
       }
     }
-  }, [isAuthenticated, token, user, socket]);
+  }, [isAuthenticated, user, socket]);
 
   const joinChat = (chatRoomId: string) => {
     if (socket && isConnected) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,7 @@ import { report } from './report';
 import { env } from '@/config/env';
 import type { Job } from '../../types/jobs';
 
-export const API_BASE = env.NEXT_PUBLIC_API_BASE;
+export const API_BASE = env.NEXT_PUBLIC_API_URL;
 
 export function get(path: string, init?: RequestInit) {
   return fetch(`${API_BASE}${path}`, { ...init, method: 'GET' });

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { env } from '@/config/env';
+
+let serverCookies: (() => { get: (name: string) => { value: string } | undefined }) | undefined;
+if (typeof window === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  serverCookies = require('next/headers').cookies;
+}
+
+const apiClient = axios.create({
+  baseURL: env.API_URL,
+  withCredentials: true,
+});
+
+apiClient.interceptors.request.use((config) => {
+  let token: string | undefined;
+  if (typeof window === 'undefined') {
+    try {
+      token = serverCookies?.().get(env.JWT_COOKIE_NAME)?.value;
+    } catch {}
+  } else {
+    const match = document.cookie.match(new RegExp(`${env.JWT_COOKIE_NAME}=([^;]+)`));
+    if (match) token = match[1];
+  }
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    if (error.response?.status === 401) {
+      try {
+        await fetch('/api/session/logout', { method: 'POST' });
+      } catch {}
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/tools/check_api.mjs
+++ b/tools/check_api.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const BASE = (process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph').replace(/\/$/, '');
+const BASE = (process.env.NEXT_PUBLIC_API_URL || 'https://api.quickgig.ph').replace(/\/$/, '');
 
 (async () => {
   try {

--- a/tools/check_jobs_api.mjs
+++ b/tools/check_jobs_api.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const BASE = (process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph').replace(/\/$/, '');
+const BASE = (process.env.NEXT_PUBLIC_API_URL || 'https://api.quickgig.ph').replace(/\/$/, '');
 
 (async () => {
   try {

--- a/tools/check_links.mjs
+++ b/tools/check_links.mjs
@@ -4,7 +4,7 @@ if (!base) {
   process.exit(0);
 }
 
-const paths = ['/', '/find-work', '/post-job', '/login', '/signup'];
+const paths = ['/', '/find-work', '/post-job', '/login', '/register'];
 
 const fetchImpl = globalThis.fetch;
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/tools/check_live_api.mjs
+++ b/tools/check_live_api.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const BASE = process.env.BASE || process.env.NEXT_PUBLIC_API_BASE || 'https://api.quickgig.ph';
+const BASE = process.env.BASE || process.env.NEXT_PUBLIC_API_URL || 'https://api.quickgig.ph';
 const TIMEOUT = 10000;
 
 function trim(str) {


### PR DESCRIPTION
## Summary
- add environment scaffolding and sample variables
- proxy auth session routes and axios client with cookie handling
- implement login/register flow, protected middleware, jobs list with optional apply
- add payment placeholder and document env vars

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689effbdcb1c832785a8c7c466649351