### PR TITLE
feat: wire auth + jobs API and add payment beta page

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,21 +108,20 @@ This repo hosts the Next.js frontend for QuickGig.
 - `/` serves the app directly. Legacy `/app` paths redirect to `/`.
 
 ## Environment
-Set these in `.env.local` for local development and in Vercel under
-**Settings → Environment Variables**:
+Copy `.env.example` to `.env.local` for local development:
 
-- `NEXT_PUBLIC_API_URL` – backend API base URL exposed to the client. Defaults to `http://localhost:3001`.
-- `API_URL` – server-side base URL for the backend API
+```bash
+cp .env.example .env.local && npm run dev
+```
+
+Set these in Vercel → Project → Settings → Environment Variables:
+
+- `NEXT_PUBLIC_API_URL` – backend API base URL exposed to the client
+- `API_URL` – server-side base URL for the backend
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_ENABLE_APPLY` – enable Apply buttons for jobs
-- `NEXT_PUBLIC_FACEBOOK_APP_ID` – Facebook app ID for login and chat
-  widgets. Optional.
-- `NEXT_PUBLIC_FACEBOOK_PAGE_ID` – Facebook page ID for the Messenger
-  chat plugin. Optional.
-- `NEXT_PUBLIC_ENV` – environment name used in logs (`local`, `preview`,
-  `production`).
-- `BASE` – base URL for scripts and smoke tests. Optional and not
-  exposed to the client.
+
+API endpoints live in [`src/config/api.ts`](src/config/api.ts); edit them if your backend paths differ.
 
 ## Cookies & Auth
 The API sets a session cookie (e.g., `qg_session`) with:

--- a/docs/api-cors.md
+++ b/docs/api-cors.md
@@ -1,0 +1,25 @@
+# API CORS setup (PHP)
+
+```php
+<?php
+$allowed = [
+    'https://quickgig.ph',
+    'https://app.quickgig.ph',
+];
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if (preg_match('#^https://quickgig-frontend-.*\.vercel\.app$#', $origin)) {
+    $allowed[] = $origin;
+}
+if (in_array($origin, $allowed, true)) {
+    header("Access-Control-Allow-Origin: $origin");
+    header('Vary: Origin');
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization');
+    header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+}
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit; // preflight
+}
+?>
+```

--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -11,15 +11,22 @@ export async function POST(req: NextRequest) {
     body: JSON.stringify(body),
   });
   const data = await res.json();
-  if (res.ok && data.token) {
-    const response = NextResponse.json({ ok: true });
-    response.cookies.set(env.JWT_COOKIE_NAME, data.token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 7,
-    });
-    return response;
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status });
   }
-  return NextResponse.json(data, { status: res.status });
+  const token = data.token || data.accessToken || data.jwt;
+  if (!token) {
+    return NextResponse.json(
+      { message: data.message || 'Missing token' },
+      { status: 400 },
+    );
+  }
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(env.JWT_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return response;
 }

--- a/src/app/api/session/me/route.ts
+++ b/src/app/api/session/me/route.ts
@@ -7,8 +7,13 @@ export async function GET(req: NextRequest) {
   const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;
   if (!token) return NextResponse.json({ ok: false }, { status: 401 });
 
+  const headers: Record<string, string> = {
+    Cookie: `${env.JWT_COOKIE_NAME}=${token}`,
+  };
+  headers.Authorization = `Bearer ${token}`;
+
   const res = await fetch(`${env.API_URL}${API.me}`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers,
     cache: 'no-store',
   });
   const data = await res.json();

--- a/src/app/api/session/register/route.ts
+++ b/src/app/api/session/register/route.ts
@@ -11,15 +11,22 @@ export async function POST(req: NextRequest) {
     body: JSON.stringify(body),
   });
   const data = await res.json();
-  if (res.ok && data.token) {
-    const response = NextResponse.json({ ok: true });
-    response.cookies.set(env.JWT_COOKIE_NAME, data.token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 7,
-    });
-    return response;
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status });
   }
-  return NextResponse.json(data, { status: res.status });
+  const token = data.token || data.accessToken || data.jwt;
+  if (!token) {
+    return NextResponse.json(
+      { message: data.message || 'Missing token' },
+      { status: 400 },
+    );
+  }
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(env.JWT_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return response;
 }

--- a/src/app/jobs/apply-button.tsx
+++ b/src/app/jobs/apply-button.tsx
@@ -1,8 +1,9 @@
 'use client';
 import { useState } from 'react';
-import apiClient from '@/lib/apiClient';
+import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
 
 export default function ApplyButton({ jobId }: { jobId: string }) {
   const [open, setOpen] = useState(false);
@@ -14,12 +15,9 @@ export default function ApplyButton({ jobId }: { jobId: string }) {
 
   if (!env.NEXT_PUBLIC_ENABLE_APPLY) {
     return (
-      <button
-        className="bg-yellow-400 rounded px-3 py-1"
-        onClick={() => alert('Applications are handled manually during beta.')}
-      >
-        Apply
-      </button>
+      <span className="text-sm text-gray-500">
+        Applications handled manually during beta.
+      </span>
     );
   }
 
@@ -27,8 +25,11 @@ export default function ApplyButton({ jobId }: { jobId: string }) {
     e.preventDefault();
     setLoading(true);
     try {
-      await apiClient.post(API.apply, { jobId, name, email, phone, note });
+      await api.post(API.apply, { jobId, name, email, phone, note });
+      toast('Application submitted');
       setOpen(false);
+    } catch {
+      toast('Failed to submit application');
     } finally {
       setLoading(false);
     }

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,23 +1,48 @@
-import apiClient from '@/lib/apiClient';
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import type { Job } from '../../../types/jobs';
 import ApplyButton from './apply-button';
 
-export const dynamic = 'force-dynamic';
+export default function JobsPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-async function fetchJobs(): Promise<Job[]> {
-  try {
-    const res = await apiClient.get(API.jobs, {
-      params: { status: 'active', page: 1, limit: 20 },
-    });
-    return res.data as Job[];
-  } catch {
-    return [];
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await api.get<Job[]>(API.jobs, {
+          params: { status: 'active', page: 1, limit: 20 },
+        });
+        setJobs(res.data);
+      } catch {
+        setError('Failed to load jobs');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="p-4">
+        <p>Loading jobs...</p>
+      </main>
+    );
   }
-}
 
-export default async function JobsPage() {
-  const jobs = await fetchJobs();
+  if (error) {
+    return (
+      <main className="p-4">
+        <p>{error}</p>
+      </main>
+    );
+  }
+
   if (!jobs.length) {
     return (
       <main className="p-4">
@@ -25,13 +50,19 @@ export default async function JobsPage() {
       </main>
     );
   }
+
   return (
     <main className="p-4 space-y-4">
-      {jobs.map((job: Job) => (
-        <div key={job.id} className="border rounded p-4 flex justify-between items-center">
+      {jobs.map((job) => (
+        <div
+          key={job.id}
+          className="border rounded p-4 flex justify-between items-center"
+        >
           <div>
             <h2 className="font-semibold">{job.title}</h2>
-            <p className="text-sm text-gray-600">{job.company} · {job.location} · {job.rate}</p>
+            <p className="text-sm text-gray-600">
+              {job.company} · {job.location} · {job.rate}
+            </p>
           </div>
           <ApplyButton jobId={job.id} />
         </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,7 +20,8 @@ export default function LoginPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
       });
-      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Login failed');
       router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');

--- a/src/app/payment/page.tsx
+++ b/src/app/payment/page.tsx
@@ -1,10 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+
 export default function PaymentPage() {
+  const qrPath = path.join(process.cwd(), 'public', 'gcash-qr.png');
+  const hasQr = fs.existsSync(qrPath);
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Payment</h1>
-      <p>Upload proof of payment via support while gateway is being integrated.</p>
-      {/* eslint-disable-next-line @next/next/no-img-element -- placeholder */}
-      <img src="/gcash-qr.png" alt="GCash QR" className="max-w-xs" />
+      {hasQr ? (
+        // eslint-disable-next-line @next/next/no-img-element -- placeholder
+        <img
+          src="/gcash-qr.png"
+          alt="GCash QR"
+          className="max-w-xs w-full h-auto"
+        />
+      ) : (
+        <div className="max-w-sm border rounded p-4 bg-white/70 space-y-4">
+          <p>No QR uploaded yet. Email or upload proof of payment while the gateway is in beta.</p>
+          <a
+            href="mailto:support@quickgig.ph"
+            className="inline-block bg-yellow-400 px-4 py-2 rounded"
+          >
+            Upload Proof
+          </a>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -21,7 +21,8 @@ export default function RegisterPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email, password }),
       });
-      if (!res.ok) throw new Error('Registration failed');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Registration failed');
       router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');

--- a/src/app/system/env/page.tsx
+++ b/src/app/system/env/page.tsx
@@ -21,7 +21,7 @@ export default function EnvPage() {
             <span className="font-mono">{key}</span>: {value ? (
               <span>{value}</span>
             ) : (
-              <span className="rounded bg-yellow-200 px-1 text-yellow-800">missing</span>
+              <span className="rounded bg-red-200 px-1 text-red-800">missing</span>
             )}
           </li>
         ))}

--- a/src/components/FacebookLogin.tsx
+++ b/src/components/FacebookLogin.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect } from 'react';
 import { initFacebook } from '@/lib/facebook';
-import { env } from '@/config/env';
 import Button from '@/components/ui/Button';
 
 interface FacebookLoginProps {
@@ -18,11 +17,12 @@ export default function FacebookLogin({
   variant = 'primary',
   size = 'md',
 }: FacebookLoginProps) {
+  const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID;
   useEffect(() => {
-    if (env.NEXT_PUBLIC_FACEBOOK_APP_ID) {
-      initFacebook(env.NEXT_PUBLIC_FACEBOOK_APP_ID);
+    if (appId) {
+      initFacebook(appId);
     }
-  }, []);
+  }, [appId]);
 
   const handleClick = () => {
     if (onLoginError) onLoginError('Facebook login not implemented');

--- a/src/components/MessengerChat.tsx
+++ b/src/components/MessengerChat.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { env } from '@/config/env';
 
 interface MessengerChatProps {
   pageId?: string;
@@ -23,8 +22,8 @@ declare global {
 }
 
 export default function MessengerChat({
-  pageId = env.NEXT_PUBLIC_FACEBOOK_PAGE_ID,
-  appId = env.NEXT_PUBLIC_FACEBOOK_APP_ID,
+  pageId = process.env.NEXT_PUBLIC_FACEBOOK_PAGE_ID,
+  appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID,
   themeColor = '#00B272',
   loggedInGreeting = 'Kumusta! Paano ka namin matutulungan sa QuickGig.ph?',
   loggedOutGreeting = 'Kumusta! May tanong ka ba tungkol sa QuickGig.ph? Message mo kami!',
@@ -138,10 +137,10 @@ export default function MessengerChat({
 }
 
 // Simplified version for specific pages
-export function MessengerChatSimple({ 
+export function MessengerChatSimple({
   className = '',
-  minimized = true 
-}: { 
+  minimized = true
+}: {
   className?: string;
   minimized?: boolean;
 }) {
@@ -158,10 +157,10 @@ export function MessengerChatSimple({
 }
 
 // Chat button for manual trigger
-export function MessengerChatButton({ 
+export function MessengerChatButton({
   className = '',
   text = 'Chat with us'
-}: { 
+}: {
   className?: string;
   text?: string;
 }) {
@@ -184,4 +183,3 @@ export function MessengerChatButton({
     </button>
   );
 }
-

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/context/AuthContext';
 import NotificationDropdown from './NotificationDropdown';
 import WalletDisplay from './WalletDisplay';
 import Button from './ui/Button';
-import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home } from 'lucide-react';
+import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard } from 'lucide-react';
 
 const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
@@ -101,6 +101,14 @@ const Navigation: React.FC = () => {
                 >
                   <MessageCircle className="w-4 h-4 mr-2" />
                   Messages
+                </Link>
+
+                <Link
+                  href="/payment"
+                  className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                >
+                  <CreditCard className="w-4 h-4 mr-2" />
+                  Payment (Beta)
                 </Link>
                 
                 {/* Notification Dropdown */}
@@ -226,6 +234,14 @@ const Navigation: React.FC = () => {
                   >
                     <MessageCircle className="w-5 h-5 mr-3" />
                     Messages
+                  </Link>
+                  <Link
+                    href="/payment"
+                    className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    <CreditCard className="w-5 h-5 mr-3" />
+                    Payment (Beta)
                   </Link>
                   <Link
                     href="/profile"

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,7 +1,7 @@
 export const API = {
-  login: '/auth/login',
-  register: '/auth/register',
-  me: '/auth/me',
-  jobs: '/jobs',           // GET ?status=active&page=1&limit=20
-  apply: '/applications',  // POST application payload
+  login: '/auth/login.php',
+  register: '/auth/register.php',
+  me: '/auth/me.php',
+  jobs: '/jobs/list.php',            // supports ?status=active&page&limit
+  apply: '/applications/create.php', // POST application payload
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,21 +1,21 @@
-// Environment variable handling
-function getEnv(key: string, fallback?: string) {
-  const value = process.env[key];
-  if (!value && process.env.NODE_ENV === 'development') {
-    console.warn(`Missing environment variable ${key}${fallback ? ", using fallback '" + fallback + "'" : ''}`);
-  }
-  return value ?? fallback ?? '';
-}
-
 export const env = {
-  NEXT_PUBLIC_API_URL: getEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3001'),
-  API_URL: getEnv('API_URL', getEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3001')),
-  JWT_COOKIE_NAME: getEnv('JWT_COOKIE_NAME', 'auth_token'),
-  NEXT_PUBLIC_FACEBOOK_APP_ID: getEnv('NEXT_PUBLIC_FACEBOOK_APP_ID'),
-  NEXT_PUBLIC_FACEBOOK_PAGE_ID: getEnv('NEXT_PUBLIC_FACEBOOK_PAGE_ID'),
-  NEXT_PUBLIC_ENV: getEnv('NEXT_PUBLIC_ENV', 'local'),
+  NEXT_PUBLIC_API_URL:
+    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
+  API_URL:
+    process.env.API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    'http://localhost:3001',
+  JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME || 'auth_token',
   NEXT_PUBLIC_ENABLE_APPLY:
-    getEnv('NEXT_PUBLIC_ENABLE_APPLY', 'false').toLowerCase() === 'true',
+    String(process.env.NEXT_PUBLIC_ENABLE_APPLY ?? 'false').toLowerCase() ===
+    'true',
 };
-
-export type Env = typeof env;
+// In dev, warn about missing values (never throw in production)
+if (process.env.NODE_ENV !== 'production') {
+  if (!process.env.NEXT_PUBLIC_API_URL && !process.env.API_URL) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[env] NEXT_PUBLIC_API_URL / API_URL not set. Using http://localhost:3001'
+    );
+  }
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,47 +1,8 @@
 import axios from 'axios';
 import { env } from '@/config/env';
 
-let serverCookies: (() => { get: (name: string) => { value: string } | undefined }) | undefined;
-if (typeof window === 'undefined') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-  serverCookies = require('next/headers').cookies;
-}
-
-const apiClient = axios.create({
+export const api = axios.create({
   baseURL: env.API_URL,
   withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
 });
-
-apiClient.interceptors.request.use((config) => {
-  let token: string | undefined;
-  if (typeof window === 'undefined') {
-    try {
-      token = serverCookies?.().get(env.JWT_COOKIE_NAME)?.value;
-    } catch {}
-  } else {
-    const match = document.cookie.match(new RegExp(`${env.JWT_COOKIE_NAME}=([^;]+)`));
-    if (match) token = match[1];
-  }
-  if (token) {
-    config.headers = config.headers || {};
-    config.headers['Authorization'] = `Bearer ${token}`;
-  }
-  return config;
-});
-
-apiClient.interceptors.response.use(
-  (res) => res,
-  async (error) => {
-    if (error.response?.status === 401) {
-      try {
-        await fetch('/api/session/logout', { method: 'POST' });
-      } catch {}
-      if (typeof window !== 'undefined') {
-        window.location.href = '/login';
-      }
-    }
-    return Promise.reject(error);
-  }
-);
-
-export default apiClient;

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -1,5 +1,4 @@
-import { env } from '@/config/env';
-
 export function report(error: unknown, context?: string) {
-  console.error('[error]', { env: env.NEXT_PUBLIC_ENV, context, error });
+  // eslint-disable-next-line no-console
+  console.error('[error]', { env: process.env.NEXT_PUBLIC_ENV, context, error });
 }


### PR DESCRIPTION
## Summary
- centralize backend API paths and env handling
- proxy auth session routes with httpOnly cookies
- add jobs listing, GCash payment placeholder, and navbar payment link

## Testing
- `npm run build`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f03fe4e288327af9752c79181780e