### PR TITLE
feat: add job details and apply flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Set these in Vercel → Project → Settings → Environment Variables:
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_ENABLE_APPLY` – enable Apply buttons for jobs
 
+To enable the Apply flow in production, set `NEXT_PUBLIC_ENABLE_APPLY=true` in your Vercel project settings.
+
 API endpoints live in [`src/config/api.ts`](src/config/api.ts); edit them if your backend paths differ.
 
 ## Cookies & Auth

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,12 +1,80 @@
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import ApplyButton from '../apply-button';
+import type { Job } from '@/types/jobs';
+
 interface JobPageProps {
   params: { id: string };
 }
 
-export default function JobPage({ params }: JobPageProps) {
+async function fetchJob(id: string): Promise<Job> {
+  const res = await fetch(`${env.API_URL}${API.jobById(id)}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error(String(res.status));
+  }
+  return res.json();
+}
+
+export async function generateMetadata({ params }: JobPageProps) {
+  try {
+    const job = await fetchJob(params.id);
+    return {
+      title: job.title,
+      description: job.description,
+      alternates: { canonical: `/jobs/${params.id}` },
+    };
+  } catch {
+    return {
+      title: 'Job not found',
+      alternates: { canonical: `/jobs/${params.id}` },
+    };
+  }
+}
+
+export default async function JobPage({ params }: JobPageProps) {
+  let job: Job;
+  try {
+    job = await fetchJob(params.id);
+  } catch (err) {
+    const status = Number((err as Error).message);
+    if (status === 404) {
+      return (
+        <main className="p-4">
+          <p>Job not found.</p>
+        </main>
+      );
+    }
+    return (
+      <main className="p-4">
+        <p>Failed to load job.</p>
+      </main>
+    );
+  }
+
   return (
-    <main className="p-4">
-      <h1 className="text-xl mb-4">Job {params.id}</h1>
-      <p>Details coming soon.</p>
+    <main className="p-4 space-y-4">
+      <div>
+        <h1 className="text-xl font-semibold">{job.title}</h1>
+        <p className="text-sm text-gray-600">
+          {job.company} · {job.location} · {job.rate}
+        </p>
+      </div>
+      <ApplyButton jobId={String(job.id)} title={job.title} />
+      <p>{job.description}</p>
+      {job.tags?.length ? (
+        <ul className="flex flex-wrap gap-2">
+          {job.tags.map((tag) => (
+            <li
+              key={tag}
+              className="bg-gray-100 px-2 py-1 rounded text-sm"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </main>
   );
 }

--- a/src/app/jobs/apply-button.tsx
+++ b/src/app/jobs/apply-button.tsx
@@ -1,17 +1,29 @@
 'use client';
 import { useState } from 'react';
+import axios from 'axios';
 import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
 
-export default function ApplyButton({ jobId }: { jobId: string }) {
+interface ApplyProps {
+  jobId: string;
+  title: string;
+}
+
+export default function ApplyButton({ jobId, title }: ApplyProps) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [note, setNote] = useState('');
   const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showFallback, setShowFallback] = useState(false);
+
+  const emailInvalid =
+    email !== '' && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email);
 
   if (!env.NEXT_PUBLIC_ENABLE_APPLY) {
     return (
@@ -21,15 +33,44 @@ export default function ApplyButton({ jobId }: { jobId: string }) {
     );
   }
 
+  const reset = () => {
+    setName('');
+    setEmail('');
+    setPhone('');
+    setNote('');
+    setError(null);
+    setShowFallback(false);
+    setSubmitted(false);
+  };
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!name || !email || emailInvalid) {
+      setError('Please provide your name and a valid email.');
+      return;
+    }
     setLoading(true);
+    setError(null);
     try {
       await api.post(API.apply, { jobId, name, email, phone, note });
       toast('Application submitted');
-      setOpen(false);
-    } catch {
-      toast('Failed to submit application');
+      setSubmitted(true);
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response) {
+        const status = err.response.status;
+        if (status === 401) {
+          window.location.href = '/login';
+          return;
+        }
+        if ([404, 500, 501].includes(status)) {
+          setError('Unable to submit application.');
+          setShowFallback(true);
+        } else {
+          setError('Failed to submit application');
+        }
+      } else {
+        setError('Failed to submit application');
+      }
     } finally {
       setLoading(false);
     }
@@ -37,26 +78,102 @@ export default function ApplyButton({ jobId }: { jobId: string }) {
 
   return (
     <>
-      <button className="bg-yellow-400 rounded px-3 py-1" onClick={() => setOpen(true)}>
+      <button
+        className="bg-yellow-400 rounded px-3 py-1"
+        onClick={() => {
+          setOpen(true);
+          reset();
+        }}
+      >
         Apply
       </button>
       {open && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-          <form onSubmit={submit} className="bg-white p-4 rounded space-y-2 w-80">
-            <h2 className="text-lg font-semibold">Apply</h2>
-            <input className="w-full border p-1" placeholder="Name" value={name} onChange={e=>setName(e.target.value)} required />
-            <input className="w-full border p-1" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required />
-            <input className="w-full border p-1" placeholder="Phone" value={phone} onChange={e=>setPhone(e.target.value)} />
-            <textarea className="w-full border p-1" placeholder="Note" value={note} onChange={e=>setNote(e.target.value)} />
-            <div className="flex justify-end space-x-2 pt-2">
-              <button type="button" className="px-3 py-1" onClick={() => setOpen(false)} disabled={loading}>Cancel</button>
-              <button type="submit" className="bg-yellow-400 px-3 py-1 rounded" disabled={loading}>
-                {loading ? 'Sending...' : 'Submit'}
+          {submitted ? (
+            <div className="bg-white p-4 rounded space-y-4 w-80 text-center">
+              <p>Application submitted!</p>
+              <button
+                className="bg-gray-200 px-3 py-1 rounded cursor-not-allowed"
+                disabled
+              >
+                View my applications (soon)
+              </button>
+              <button className="px-3 py-1" onClick={() => setOpen(false)}>
+                Close
               </button>
             </div>
-          </form>
+          ) : (
+            <form
+              onSubmit={submit}
+              className="bg-white p-4 rounded space-y-2 w-80"
+            >
+              <h2 className="text-lg font-semibold">Apply</h2>
+              <input
+                className="w-full border p-1"
+                placeholder="Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+              <input
+                className="w-full border p-1"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+              {emailInvalid && (
+                <p className="text-sm text-red-500">Enter a valid email.</p>
+              )}
+              <input
+                className="w-full border p-1"
+                placeholder="Phone"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+              />
+              <textarea
+                className="w-full border p-1"
+                placeholder="Note"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+              />
+              {error && (
+                <p className="text-sm text-red-500">
+                  {error}{' '}
+                  {showFallback && (
+                    <a
+                      href={`mailto:?subject=${encodeURIComponent(
+                        `Application for ${title}`,
+                      )}`}
+                      className="underline"
+                    >
+                      Apply via email
+                    </a>
+                  )}
+                </p>
+              )}
+              <div className="flex justify-end space-x-2 pt-2">
+                <button
+                  type="button"
+                  className="px-3 py-1"
+                  onClick={() => setOpen(false)}
+                  disabled={loading}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="bg-yellow-400 px-3 py-1 rounded"
+                  disabled={loading || emailInvalid}
+                >
+                  {loading ? 'Sending...' : 'Submit'}
+                </button>
+              </div>
+            </form>
+          )}
         </div>
       )}
     </>
   );
 }
+

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
-import type { Job } from '../../../types/jobs';
+import type { Job } from '@/types/jobs';
 import ApplyButton from './apply-button';
 
 export default function JobsPage() {
@@ -59,12 +60,14 @@ export default function JobsPage() {
           className="border rounded p-4 flex justify-between items-center"
         >
           <div>
-            <h2 className="font-semibold">{job.title}</h2>
+            <h2 className="font-semibold">
+              <Link href={`/jobs/${job.id}`}>{job.title}</Link>
+            </h2>
             <p className="text-sm text-gray-600">
               {job.company} · {job.location} · {job.rate}
             </p>
           </div>
-          <ApplyButton jobId={job.id} />
+          <ApplyButton jobId={String(job.id)} title={job.title} />
         </div>
       ))}
     </main>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -2,6 +2,7 @@ export const API = {
   login: '/auth/login.php',
   register: '/auth/register.php',
   me: '/auth/me.php',
-  jobs: '/jobs/list.php',            // supports ?status=active&page&limit
-  apply: '/applications/create.php', // POST application payload
+  jobs: '/jobs/list.php', // GET list
+  jobById: (id: string | number) => `/jobs/show.php?id=${id}`, // GET details
+  apply: '/applications/create.php', // POST application
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,8 +7,9 @@ export const env = {
     'http://localhost:3001',
   JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME || 'auth_token',
   NEXT_PUBLIC_ENABLE_APPLY:
-    String(process.env.NEXT_PUBLIC_ENABLE_APPLY ?? 'false').toLowerCase() ===
-    'true',
+    process.env.NEXT_PUBLIC_ENABLE_APPLY !== undefined
+      ? String(process.env.NEXT_PUBLIC_ENABLE_APPLY).toLowerCase() === 'true'
+      : process.env.NODE_ENV !== 'production',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/types/jobs.ts
+++ b/src/types/jobs.ts
@@ -1,0 +1,9 @@
+export interface Job {
+  id: string | number;
+  title: string;
+  company: string;
+  location: string;
+  rate?: string;
+  description: string;
+  tags?: string[];
+}


### PR DESCRIPTION
## Summary
- add job details route with metadata and canonical
- implement apply modal with API-first + email fallback
- expose APPLY env defaulting to true in dev and document

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f068c9b4883279256c8506f3ba5c6