### PR TITLE
Add employer dashboard with job management

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,18 @@ Set these in Vercel → Project → Settings → Environment Variables:
 - `API_URL` – server-side base URL for the backend
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_ENABLE_APPLY` – enable Apply buttons for jobs
+- `EMPLOYER_EMAILS` – comma-separated list of emails with employer access in dev
 
 To enable the Apply flow in production, set `NEXT_PUBLIC_ENABLE_APPLY=true` in your Vercel project settings.
 
 API endpoints live in [`src/config/api.ts`](src/config/api.ts); edit them if your backend paths differ.
+
+### Employer API
+
+- `GET /employer/jobs/list.php`
+- `POST /employer/jobs/create.php`
+- `PATCH /employer/jobs/update.php?id={id}`
+- `POST /employer/jobs/toggle.php?id={id}` with `{ published: boolean }`
 
 ## Cookies & Auth
 The API sets a session cookie (e.g., `qg_session`) with:

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,19 +3,42 @@ import type { NextRequest } from 'next/server';
 import { env } from './src/config/env';
 
 const protectedPaths = ['/dashboard', '/profile', '/account'];
+const employerPaths = ['/employer'];
 
 export function middleware(req: NextRequest) {
-  if (protectedPaths.some((p) => req.nextUrl.pathname.startsWith(p))) {
-    const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;
+  const { pathname } = req.nextUrl;
+  const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;
+
+  if (protectedPaths.some((p) => pathname.startsWith(p))) {
     if (!token) {
       const url = req.nextUrl.clone();
       url.pathname = '/login';
       return NextResponse.redirect(url);
     }
   }
+
+  if (employerPaths.some((p) => pathname.startsWith(p))) {
+    if (!token) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+    const isEmployer = req.cookies.get('isEmployer')?.value === 'true';
+    if (!isEmployer) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/';
+      return NextResponse.redirect(url);
+    }
+  }
+
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*', '/profile/:path*', '/account/:path*'],
+  matcher: [
+    '/dashboard/:path*',
+    '/profile/:path*',
+    '/account/:path*',
+    '/employer/:path*',
+  ],
 };

--- a/src/app/api/session/me/route.ts
+++ b/src/app/api/session/me/route.ts
@@ -17,5 +17,24 @@ export async function GET(req: NextRequest) {
     cache: 'no-store',
   });
   const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+
+  let isEmployer: boolean | undefined = data.isEmployer;
+  if (typeof isEmployer !== 'boolean' && data.user?.role) {
+    isEmployer = data.user.role === 'Employer';
+  }
+  if (typeof isEmployer !== 'boolean' && data.user?.email) {
+    isEmployer = env.EMPLOYER_EMAILS.includes(data.user.email);
+  }
+  if (typeof isEmployer !== 'boolean') {
+    isEmployer = false;
+  }
+  data.isEmployer = isEmployer;
+
+  const response = NextResponse.json(data, { status: res.status });
+  if (data.user?.role) {
+    response.cookies.set('role', data.user.role);
+  }
+  response.cookies.set('isEmployer', String(isEmployer));
+
+  return response;
 }

--- a/src/app/employer/jobs/[id]/edit/page.tsx
+++ b/src/app/employer/jobs/[id]/edit/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import JobForm, { JobFormData } from '@/components/JobForm';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+
+interface PageProps {
+  params: { id: string };
+}
+
+interface JobDetail extends Partial<JobFormData> {
+  published?: boolean;
+}
+
+export default function EditJobPage({ params }: PageProps) {
+  const router = useRouter();
+  const [initial, setInitial] = useState<JobFormData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await api.get<JobDetail>(API.jobById(params.id));
+        setInitial({
+          title: res.data.title || '',
+          description: res.data.description || '',
+          location: res.data.location || '',
+          payRange: res.data.payRange || '',
+          tags: res.data.tags || [],
+          published: res.data.published ?? false,
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [params.id]);
+
+  const handleSubmit = async (data: JobFormData) => {
+    await api.patch(API.updateJob(params.id), data);
+    router.push('/employer/jobs');
+  };
+
+  if (loading || !initial) return <main className="p-4">Loading...</main>;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Edit Job</h1>
+      <JobForm initial={initial} onSubmit={handleSubmit} />
+    </main>
+  );
+}

--- a/src/app/employer/jobs/new/page.tsx
+++ b/src/app/employer/jobs/new/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import JobForm, { JobFormData } from '@/components/JobForm';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+
+export default function NewJobPage() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: JobFormData) => {
+    await api.post(API.createJob, data);
+    router.push('/employer/jobs');
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Post a Job</h1>
+      <JobForm onSubmit={handleSubmit} />
+    </main>
+  );
+}

--- a/src/app/employer/jobs/page.tsx
+++ b/src/app/employer/jobs/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+
+interface MyJob {
+  id: number | string;
+  title: string;
+  published: boolean;
+  updatedAt: string;
+}
+
+export default function EmployerJobsPage() {
+  const [jobs, setJobs] = useState<MyJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const res = await api.get<MyJob[]>(API.myJobs);
+      setJobs(res.data);
+    } catch {
+      setError('Failed to load jobs');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const toggle = async (id: number | string, published: boolean) => {
+    try {
+      await api.post(API.toggleJob(id), { published: !published });
+      await load();
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) return <main className="p-4">Loading...</main>;
+  if (error) return <main className="p-4">{error}</main>;
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-semibold mb-4">My Jobs</h1>
+      <table className="min-w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">Title</th>
+            <th className="p-2 text-left">Status</th>
+            <th className="p-2 text-left">Updated</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.id} className="border-b">
+              <td className="p-2">{job.title}</td>
+              <td className="p-2">{job.published ? 'Published' : 'Draft'}</td>
+              <td className="p-2">{new Date(job.updatedAt).toLocaleDateString()}</td>
+              <td className="p-2 space-x-2">
+                <Link
+                  href={`/employer/jobs/${job.id}/edit`}
+                  className="text-qg-accent"
+                >
+                  Edit
+                </Link>
+                <button
+                  onClick={() => toggle(job.id, job.published)}
+                  className="text-qg-accent"
+                >
+                  {job.published ? 'Unpublish' : 'Publish'}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function EmployerPage() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Employer Dashboard</h1>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <Link href="/employer/jobs" className="text-qg-accent">
+            My Jobs
+          </Link>
+        </li>
+        <li>
+          <Link href="/employer/jobs/new" className="text-qg-accent">
+            Post a Job
+          </Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/src/components/JobForm.tsx
+++ b/src/components/JobForm.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface JobFormData {
+  title: string;
+  description: string;
+  location: string;
+  payRange: string;
+  tags: string[];
+  published: boolean;
+}
+
+interface JobFormProps {
+  initial?: JobFormData;
+  onSubmit: (data: JobFormData) => Promise<void>;
+}
+
+export default function JobForm({ initial, onSubmit }: JobFormProps) {
+  const [title, setTitle] = useState(initial?.title || '');
+  const [description, setDescription] = useState(initial?.description || '');
+  const [location, setLocation] = useState(initial?.location || '');
+  const [payRange, setPayRange] = useState(initial?.payRange || '');
+  const [tags, setTags] = useState(initial?.tags?.join(', ') || '');
+  const [published, setPublished] = useState(initial?.published || false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await onSubmit({
+        title,
+        description,
+        location,
+        payRange,
+        tags: tags
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean),
+        published,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to submit';
+      setError(message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Title</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full border rounded p-2"
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Description</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full border rounded p-2 h-32"
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Location</label>
+        <input
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          className="w-full border rounded p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Pay Range</label>
+        <input
+          type="text"
+          value={payRange}
+          onChange={(e) => setPayRange(e.target.value)}
+          className="w-full border rounded p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Tags (comma separated)</label>
+        <input
+          type="text"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          className="w-full border rounded p-2"
+        />
+      </div>
+      <div className="flex items-center space-x-2">
+        <input
+          id="published"
+          type="checkbox"
+          checked={published}
+          onChange={(e) => setPublished(e.target.checked)}
+        />
+        <label htmlFor="published">Published</label>
+      </div>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button
+        type="submit"
+        className="bg-qg-accent text-white px-4 py-2 rounded"
+      >
+        {initial ? 'Update Job' : 'Create Job'}
+      </button>
+    </form>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -60,13 +60,30 @@ const Navigation: React.FC = () => {
               <Briefcase className="w-4 h-4 mr-2" />
               Find Work
             </Link>
-            <Link
-              href="/post-job"
-              className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-            >
-              <Plus className="w-4 h-4 mr-2" />
-              Post Job
-            </Link>
+            {user?.isEmployer && (
+              <div className="relative group">
+                <button
+                  className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                >
+                  <Briefcase className="w-4 h-4 mr-2" />
+                  Employer
+                </button>
+                <div className="absolute hidden group-hover:block bg-qg-navy-light rounded-qg-md mt-2 min-w-[150px]">
+                  <Link
+                    href="/employer/jobs"
+                    className="block px-4 py-2 qg-navbar-link hover:bg-qg-navy"
+                  >
+                    Jobs
+                  </Link>
+                  <Link
+                    href="/employer/jobs/new"
+                    className="block px-4 py-2 qg-navbar-link hover:bg-qg-navy"
+                  >
+                    Post a Job
+                  </Link>
+                </div>
+              </div>
+            )}
 
             {isAuthenticated ? (
               <div className="flex items-center space-x-2 ml-4 pl-4 border-l border-qg-navy-light">
@@ -84,15 +101,6 @@ const Navigation: React.FC = () => {
                   >
                     <Settings className="w-4 h-4 mr-2" />
                     Admin
-                  </Link>
-                )}
-                {user?.role === 'Employer' && (
-                  <Link
-                    href="/my-jobs"
-                    className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                  >
-                    <Briefcase className="w-4 h-4 mr-2" />
-                    My Jobs
                   </Link>
                 )}
                 <Link
@@ -186,15 +194,6 @@ const Navigation: React.FC = () => {
                 <Briefcase className="w-5 h-5 mr-3" />
                 Find Work
               </Link>
-              <Link
-                href="/post-job"
-                className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                <Plus className="w-5 h-5 mr-3" />
-                Post Job
-              </Link>
-
               {isAuthenticated ? (
                 <>
                   <div className="border-t border-qg-navy-light my-4 pt-4">
@@ -217,15 +216,25 @@ const Navigation: React.FC = () => {
                       Admin Dashboard
                     </Link>
                   )}
-                  {user?.role === 'Employer' && (
-                    <Link
-                      href="/my-jobs"
-                      className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      <Briefcase className="w-5 h-5 mr-3" />
-                      My Jobs
-                    </Link>
+                  {user?.isEmployer && (
+                    <>
+                      <Link
+                        href="/employer/jobs"
+                        className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <Briefcase className="w-5 h-5 mr-3" />
+                        Employer Jobs
+                      </Link>
+                      <Link
+                        href="/employer/jobs/new"
+                        className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <Plus className="w-5 h-5 mr-3" />
+                        Post a Job
+                      </Link>
+                    </>
                   )}
                   <Link
                     href="/messages"

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -5,4 +5,8 @@ export const API = {
   jobs: '/jobs/list.php', // GET list
   jobById: (id: string | number) => `/jobs/show.php?id=${id}`, // GET details
   apply: '/applications/create.php', // POST application
+  myJobs: '/employer/jobs/list.php', // GET my jobs
+  createJob: '/employer/jobs/create.php', // POST
+  updateJob: (id: number | string) => `/employer/jobs/update.php?id=${id}`, // PATCH
+  toggleJob: (id: number | string) => `/employer/jobs/toggle.php?id=${id}`, // POST { published: boolean }
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,8 @@ export const env = {
     process.env.NEXT_PUBLIC_API_URL ||
     'http://localhost:3001',
   JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME || 'auth_token',
+  EMPLOYER_EMAILS:
+    process.env.EMPLOYER_EMAILS?.split(',').map((e) => e.trim()).filter(Boolean) || [],
   NEXT_PUBLIC_ENABLE_APPLY:
     process.env.NEXT_PUBLIC_ENABLE_APPLY !== undefined
       ? String(process.env.NEXT_PUBLIC_ENABLE_APPLY).toLowerCase() === 'true'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface User {
   email: string;
   phone: string;
   role: 'Job Seeker' | 'Employer' | 'Admin';
+  isEmployer?: boolean;
   ticketBalance?: number;
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary
- extend API config and environment to support employer job endpoints and developer email allowlist
- persist employer role in session, protect `/employer` routes, and surface employer menu in navigation
- add employer pages for listing, creating, editing, and toggling job publish status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f0f78ddc48327a6f399c8b68daad8