### PR TITLE
Fix build: use fetch-based optional notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ JWT_COOKIE_NAME=auth_token
 
 # Feature flags
 NEXT_PUBLIC_ENABLE_APPLY=false
+RESEND_API_KEY=
+NOTIFY_FROM="QuickGig <noreply@quickgig.ph>"
+NOTIFY_ADMIN_EMAIL=admin@quickgig.ph

--- a/README.md
+++ b/README.md
@@ -121,8 +121,13 @@ Set these in Vercel → Project → Settings → Environment Variables:
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_ENABLE_APPLY` – enable Apply buttons for jobs
 - `EMPLOYER_EMAILS` – comma-separated list of emails with employer access in dev
+- `RESEND_API_KEY` – Resend API key to enable email notifications
+- `NOTIFY_FROM` – from address for notifications (e.g., `QuickGig <noreply@quickgig.ph>`)
+- `NOTIFY_ADMIN_EMAIL` – fallback email for employer alerts
 
 To enable the Apply flow in production, set `NEXT_PUBLIC_ENABLE_APPLY=true` in your Vercel project settings.
+
+Notifications are optional. Configure `RESEND_API_KEY` and `NOTIFY_FROM` in Vercel to enable email delivery. If these keys are unset, notification requests are skipped and a warning is logged.
 
 API endpoints live in [`src/config/api.ts`](src/config/api.ts); edit them if your backend paths differ.
 

--- a/src/app/api/notify/application/route.ts
+++ b/src/app/api/notify/application/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { sendMail } from '@/server/mailer';
+import { env } from '@/config/env';
+
+export async function POST(req: Request) {
+  const { applicantEmail, applicantName, employerEmail, jobTitle } = await req.json();
+  const safeJob = String(jobTitle || 'your application');
+  const toEmployer = employerEmail || env.NOTIFY_ADMIN_EMAIL;
+
+  if (applicantEmail) {
+    await sendMail({
+      to: applicantEmail,
+      subject: `We received your application for ${safeJob}`,
+      html: `<p>Hi ${applicantName || ''},</p><p>Thanks for applying for <b>${safeJob}</b>. We’ll be in touch.</p>`,
+    }).catch(() => {});
+  }
+
+  if (toEmployer) {
+    await sendMail({
+      to: toEmployer,
+      subject: `New application for ${safeJob}`,
+      html: `<p>You have a new application for <b>${safeJob}</b>.</p>`,
+    }).catch(() => {});
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/jobs/apply-button.tsx
+++ b/src/app/jobs/apply-button.tsx
@@ -52,7 +52,19 @@ export default function ApplyButton({ jobId, title }: ApplyProps) {
     setLoading(true);
     setError(null);
     try {
-      await api.post(API.apply, { jobId, name, email, phone, note });
+      const res = await api.post(API.apply, { jobId, name, email, phone, note });
+      const appId = (res.data && (res.data.id || res.data.applicationId)) || undefined;
+      void fetch('/api/notify/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          applicantEmail: email,
+          applicantName: name,
+          employerEmail: undefined,
+          jobTitle: title,
+          applicationId: appId,
+        }),
+      }).catch(() => {});
       toast('Application submitted');
       setSubmitted(true);
     } catch (err) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,10 @@ export const env = {
     process.env.NEXT_PUBLIC_ENABLE_APPLY !== undefined
       ? String(process.env.NEXT_PUBLIC_ENABLE_APPLY).toLowerCase() === 'true'
       : process.env.NODE_ENV !== 'production',
+  RESEND_API_KEY: process.env.RESEND_API_KEY || '',
+  NOTIFY_FROM:
+    process.env.NOTIFY_FROM || 'QuickGig <noreply@quickgig.ph>',
+  NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/server/mailer.ts
+++ b/src/server/mailer.ts
@@ -1,0 +1,31 @@
+import { env } from '@/config/env';
+
+type SendArgs = { to: string; subject: string; html: string };
+
+export async function sendMail({ to, subject, html }: SendArgs) {
+  if (!env.RESEND_API_KEY) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[notify] RESEND_API_KEY missing, skipping email to', to);
+    }
+    return { ok: true, skipped: 'email' as const };
+  }
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: env.NOTIFY_FROM,
+      to,
+      subject,
+      html,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    console.warn('[notify] email send failed', res.status, text);
+    return { ok: false as const, status: res.status, body: text };
+  }
+  return { ok: true as const };
+}


### PR DESCRIPTION
## Summary
- add optional notification env vars
- use internal fetch-based mailer helper
- trigger non-blocking notification route on apply

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f17920d3c8327b6f0f1e208c3f94f