### PR TITLE
feat: improve SEO metadata and UX polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ NEXT_PUBLIC_ENABLE_APPLY=false
 RESEND_API_KEY=
 NOTIFY_FROM="QuickGig <noreply@quickgig.ph>"
 NOTIFY_ADMIN_EMAIL=admin@quickgig.ph
+NEXT_PUBLIC_SITE_URL=https://quickgig.ph

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ BASE=https://quickgig.ph node tools/check_root.mjs
 BASE=https://api.quickgig.ph npm run check:api
 ```
 
+## SEO & Sitemap
+
+- `NEXT_PUBLIC_SITE_URL` sets the canonical base URL.
+- Use the `canonical()` helper in `src/lib/canonical.ts` to build canonical links.
+- `/sitemap.xml` and `/robots.txt` are served from `app/sitemap.ts` and `app/robots.ts`.
+- Job detail pages embed [JSON-LD](https://schema.org/JobPosting); verify with Google's [Rich Results Test](https://search.google.com/test/rich-results).
+
 ## Production routing
 - `https://quickgig.ph` → 308 to `https://app.quickgig.ph`
 - `https://www.quickgig.ph` → 308 to `https://app.quickgig.ph`

--- a/src/app/applications/loading.tsx
+++ b/src/app/applications/loading.tsx
@@ -1,0 +1,14 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="p-4 space-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="border rounded p-4 space-y-2">
+          <Skeleton className="h-6 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/applications/metadata.ts
+++ b/src/app/applications/metadata.ts
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/canonical';
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: { canonical: canonical('/applications') },
+  };
+}

--- a/src/app/applications/page.tsx
+++ b/src/app/applications/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export default function ApplicationsPage() {
+  return (
+    <main className="p-4">
+      <p>Applications page coming soon.</p>
+    </main>
+  );
+}

--- a/src/app/employer/jobs/loading.tsx
+++ b/src/app/employer/jobs/loading.tsx
@@ -1,0 +1,14 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="p-4 space-y-4">
+      {Array.from({ length: 2 }).map((_, i) => (
+        <div key={i} className="border rounded p-4 space-y-2">
+          <Skeleton className="h-6 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/employer/loading.tsx
+++ b/src/app/employer/loading.tsx
@@ -1,0 +1,11 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="p-4 space-y-4">
+      <Skeleton className="h-6 w-1/3" />
+      <Skeleton className="h-4 w-1/2" />
+      <Skeleton className="h-4 w-full" />
+    </main>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error }: { error: Error }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="p-4 text-center space-y-4">
+      <h1 className="text-2xl font-bold">Something went wrong</h1>
+      <p>Please try again later.</p>
+      <Link href="/jobs" className="text-sky-600 underline">Back to jobs</Link>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,6 +122,12 @@ input:focus, textarea:focus, select:focus {
   }
 }
 
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .qg-container {

--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+import type { Job } from '@/types/jobs';
+import ApplyButton from './apply-button';
+
+export default function JobsClient() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await api.get<Job[]>(API.jobs, {
+          params: { status: 'active', page: 1, limit: 20 },
+        });
+        setJobs(res.data);
+      } catch {
+        setError('Failed to load jobs');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="p-4">
+        <p>Loading jobs...</p>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="p-4">
+        <p>{error}</p>
+      </main>
+    );
+  }
+
+  if (!jobs.length) {
+    return (
+      <main className="p-4">
+        <p>No jobs found.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      {jobs.map((job) => (
+        <div
+          key={job.id}
+          className="border rounded p-4 flex justify-between items-center"
+        >
+          <div>
+            <h2 className="font-semibold">
+              <Link href={`/jobs/${job.id}`}>{job.title}</Link>
+            </h2>
+            <p className="text-sm text-gray-600">
+              {job.company} · {job.location} · {job.rate}
+            </p>
+          </div>
+          <ApplyButton jobId={String(job.id)} title={job.title} />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/jobs/[id]/loading.tsx
+++ b/src/app/jobs/[id]/loading.tsx
@@ -1,0 +1,11 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="p-4 space-y-4">
+      <Skeleton className="h-8 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+      <Skeleton className="h-20 w-full" />
+    </main>
+  );
+}

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { API } from '@/config/api';
 import { env } from '@/config/env';
+import { canonical } from '@/lib/canonical';
+import { SEO } from '@/config/seo';
 import ApplyButton from '../apply-button';
 import type { Job } from '@/types/jobs';
 
@@ -23,12 +25,12 @@ export async function generateMetadata({ params }: JobPageProps) {
     return {
       title: job.title,
       description: job.description,
-      alternates: { canonical: `/jobs/${params.id}` },
+      alternates: { canonical: canonical(`/jobs/${params.id}`) },
     };
   } catch {
     return {
       title: 'Job not found',
-      alternates: { canonical: `/jobs/${params.id}` },
+      alternates: { canonical: canonical(`/jobs/${params.id}`) },
     };
   }
 }
@@ -53,6 +55,9 @@ export default async function JobPage({ params }: JobPageProps) {
     );
   }
 
+  const employmentType = (job as any).employmentType;
+  const datePosted = (job as any).datePosted || new Date().toISOString();
+
   return (
     <main className="p-4 space-y-4">
       <div>
@@ -75,6 +80,24 @@ export default async function JobPage({ params }: JobPageProps) {
           ))}
         </ul>
       ) : null}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'JobPosting',
+            title: job.title,
+            description: job.description,
+            hiringOrganization: { '@type': 'Organization', name: job.company || SEO.siteName },
+            datePosted,
+            jobLocation: {
+              '@type': 'Place',
+              address: { '@type': 'PostalAddress', addressCountry: 'PH' },
+            },
+            ...(employmentType ? { employmentType } : {}),
+          }),
+        }}
+      />
     </main>
   );
 }

--- a/src/app/jobs/loading.tsx
+++ b/src/app/jobs/loading.tsx
@@ -1,0 +1,14 @@
+import Skeleton from '@/components/Skeleton';
+
+export default function Loading() {
+  return (
+    <main className="p-4 space-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="border rounded p-4 space-y-2">
+          <Skeleton className="h-6 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,75 +1,13 @@
-'use client';
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/canonical';
+import JobsClient from './JobsClient';
 
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { api } from '@/lib/apiClient';
-import { API } from '@/config/api';
-import type { Job } from '@/types/jobs';
-import ApplyButton from './apply-button';
+export function generateMetadata(): Metadata {
+  return {
+    alternates: { canonical: canonical('/jobs') },
+  };
+}
 
 export default function JobsPage() {
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await api.get<Job[]>(API.jobs, {
-          params: { status: 'active', page: 1, limit: 20 },
-        });
-        setJobs(res.data);
-      } catch {
-        setError('Failed to load jobs');
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, []);
-
-  if (loading) {
-    return (
-      <main className="p-4">
-        <p>Loading jobs...</p>
-      </main>
-    );
-  }
-
-  if (error) {
-    return (
-      <main className="p-4">
-        <p>{error}</p>
-      </main>
-    );
-  }
-
-  if (!jobs.length) {
-    return (
-      <main className="p-4">
-        <p>No jobs found.</p>
-      </main>
-    );
-  }
-
-  return (
-    <main className="p-4 space-y-4">
-      {jobs.map((job) => (
-        <div
-          key={job.id}
-          className="border rounded p-4 flex justify-between items-center"
-        >
-          <div>
-            <h2 className="font-semibold">
-              <Link href={`/jobs/${job.id}`}>{job.title}</Link>
-            </h2>
-            <p className="text-sm text-gray-600">
-              {job.company} · {job.location} · {job.rate}
-            </p>
-          </div>
-          <ApplyButton jobId={String(job.id)} title={job.title} />
-        </div>
-      ))}
-    </main>
-  );
+  return <JobsClient />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import "./globals.css";
 import { AuthProvider } from "../context/AuthContext";
@@ -6,46 +7,27 @@ import { SocketProvider } from "../context/SocketContext";
 import Navigation from "../components/Navigation";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { ToastProvider } from "../components/ToastProvider";
+import { SEO } from "@/config/seo";
 
 export const metadata: Metadata = {
-  title: "QuickGig.ph - Find Gigs Fast in the Philippines",
-  description: "Kahit saan sa Pinas, may gig para sa'yo! Connect with opportunities and talent across the Philippines. Find work or hire skilled professionals quickly and easily.",
-  keywords: "freelance, gigs, Philippines, work, jobs, hiring, talent, remote work, Filipino freelancers",
-  authors: [{ name: "QuickGig.ph Team" }],
-  creator: "QuickGig.ph",
-  publisher: "QuickGig.ph",
-  formatDetection: {
-    email: false,
-    address: false,
-    telephone: false,
+  metadataBase: new URL(SEO.siteUrl),
+  title: {
+    default: SEO.defaultTitle,
+    template: `%s | ${SEO.siteName}`,
   },
-  metadataBase: new URL('https://quickgig.ph'),
-  alternates: {
-    canonical: '/',
-  },
+  description: SEO.defaultDescription,
   openGraph: {
-    title: "QuickGig.ph - Find Gigs Fast in the Philippines",
-    description: "Kahit saan sa Pinas, may gig para sa'yo! Connect with opportunities and talent across the Philippines.",
-    url: 'https://quickgig.ph',
-    siteName: 'QuickGig.ph',
-    images: [
-      {
-        url: '/logo-main.png',
-        width: 1200,
-        height: 630,
-        alt: 'QuickGig.ph - Filipino Freelance Platform',
-      },
-    ],
-    locale: 'en_PH',
-    type: 'website',
+    title: SEO.defaultTitle,
+    description: SEO.defaultDescription,
+    url: SEO.siteUrl,
+    siteName: SEO.siteName,
   },
   twitter: {
     card: 'summary_large_image',
-    title: "QuickGig.ph - Find Gigs Fast in the Philippines",
-    description: "Kahit saan sa Pinas, may gig para sa'yo!",
-    images: ['/logo-main.png'],
-    creator: '@QuickGigPH',
+    site: SEO.twitter.site,
+    creator: SEO.twitter.creator,
   },
+  themeColor: '#0ea5e9',
   icons: {
     icon: [
       { url: '/favicon.png', sizes: '32x32', type: 'image/png' },
@@ -57,20 +39,6 @@ export const metadata: Metadata = {
     shortcut: '/favicon.png',
   },
   manifest: '/manifest.json',
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
-    },
-  },
-  verification: {
-    google: 'your-google-verification-code',
-  },
 };
 
 export default function RootLayout({
@@ -81,6 +49,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth">
       <head>
+        <meta name="theme-color" content="#0ea5e9" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
@@ -97,8 +66,7 @@ export default function RootLayout({
               <div className="qg-container">
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
                   <div className="col-span-1 md:col-span-2">
-                    {/* eslint-disable-next-line @next/next/no-img-element -- logo placeholder */}
-                    <img src="/logo-horizontal.png" alt="QuickGig.ph" className="h-8 mb-4" />
+                    <Image src="/logo-horizontal.png" alt="QuickGig.ph" width={160} height={32} className="h-8 mb-4 w-auto" />
                     <p className="text-fg opacity-70 mb-4">
                       Ang pinakamabilis na paraan para makahanap ng trabaho at talent sa Pilipinas.
                     </p>

--- a/src/app/login/metadata.ts
+++ b/src/app/login/metadata.ts
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/canonical';
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: { canonical: canonical('/login') },
+  };
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="p-4 text-center space-y-4">
+      <h1 className="text-2xl font-bold">Page not found</h1>
+      <p>The page you are looking for does not exist.</p>
+      <Link href="/jobs" className="text-sky-600 underline">Back to jobs</Link>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from 'next';
+import { canonical } from '@/lib/canonical';
 import HomePageClient from './HomePageClient';
 
-export const metadata: Metadata = {
-  title: 'QuickGig',
-  description: 'Gigs and talent, matched fast.',
-};
+export function generateMetadata(): Metadata {
+  return {
+    alternates: { canonical: canonical('/') },
+  };
+}
 
-export default async function Page() {
+export default function Page() {
   return <HomePageClient />;
 }
 

--- a/src/app/payment/page.tsx
+++ b/src/app/payment/page.tsx
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import Image from 'next/image';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,8 +18,7 @@ export default function PaymentPage() {
   return (
     <main className="p-4 flex flex-col items-center space-y-4">
       <h1 className="text-2xl font-bold">Payment</h1>
-      {/* eslint-disable-next-line @next/next/no-img-element -- static asset */}
-      <img src={qrSrc} alt="GCash QR" className="w-full max-w-xs h-auto" />
+      <Image src={qrSrc} alt="GCash QR" width={300} height={300} className="w-full max-w-xs h-auto" />
       <p className="text-center">Scan QR in GCash, then send proof via Support.</p>
       <a
         href="mailto:support@quickgig.ph?subject=GCash%20Payment%20Proof"

--- a/src/app/register/metadata.ts
+++ b/src/app/register/metadata.ts
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+import { canonical } from '@/lib/canonical';
+
+export function generateMetadata(): Metadata {
+  return {
+    alternates: { canonical: canonical('/register') },
+  };
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next';
+import { SEO } from '@/config/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    host: SEO.siteUrl,
+    sitemap: `${SEO.siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next';
+import { SEO } from '@/config/seo';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const routes = ['/', '/jobs', '/login', '/register'];
+  const urls: MetadataRoute.Sitemap = routes.map((route) => ({
+    url: `${SEO.siteUrl}${route === '/' ? '' : route}`,
+    lastModified: new Date(),
+  }));
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/jobs/list.php?page=1&limit=100`);
+    const data = await res.json();
+    if (Array.isArray(data)) {
+      for (const job of data) {
+        if (job?.id) {
+          urls.push({ url: `${SEO.siteUrl}/jobs/${job.id}`, lastModified: new Date() });
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return urls;
+}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  className?: string;
+}
+
+export default function Skeleton({ className }: Props) {
+  return (
+    <div className={`relative overflow-hidden bg-gray-200 rounded ${className}`}>
+      <div className="absolute inset-0 -translate-x-full animate-[shimmer_1.5s_infinite] bg-gradient-to-r from-transparent via-white/60 to-transparent" />
+    </div>
+  );
+}

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -1,0 +1,8 @@
+export const SEO = {
+  siteName: 'QuickGig',
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://quickgig.ph',
+  defaultTitle: 'QuickGig — Find and hire pros, fast',
+  defaultDescription:
+    'Hire skilled professionals or find gigs anywhere in the Philippines—quickly and reliably with QuickGig.',
+  twitter: { site: '@quickgigph', creator: '@quickgigph' },
+};

--- a/src/lib/canonical.ts
+++ b/src/lib/canonical.ts
@@ -1,0 +1,6 @@
+import { SEO } from '@/config/seo';
+export function canonical(path = '') {
+  const base = SEO.siteUrl.replace(/\/$/, '');
+  const cleaned = ('/' + String(path || '')).replace(/\/+$/, '');
+  return `${base}${cleaned === '/' ? '' : cleaned}`;
+}


### PR DESCRIPTION
## Summary
- add reusable SEO config and canonical helper
- generate sitemap/robots and default metadata
- show skeleton loaders and friendly error pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f20b9d5588327886a7bde85908ca7