### PR TITLE
Harden sitemap and robots with safe fallbacks

### DIFF
--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -2,6 +2,7 @@ import { API } from '@/config/api';
 import { env } from '@/config/env';
 import ApplyButton from '../apply-button';
 import type { Job } from '@/types/jobs';
+import { canonical } from '@/lib/canonical';
 
 interface JobPageProps {
   params: { id: string };
@@ -20,16 +21,16 @@ async function fetchJob(id: string): Promise<Job> {
 export async function generateMetadata({ params }: JobPageProps) {
   try {
     const job = await fetchJob(params.id);
-    return {
-      title: job.title,
-      description: job.description,
-      alternates: { canonical: `/jobs/${params.id}` },
-    };
+      return {
+        title: job.title,
+        description: job.description,
+        alternates: { canonical: canonical(`/jobs/${params.id}`) },
+      };
   } catch {
-    return {
-      title: 'Job not found',
-      alternates: { canonical: `/jobs/${params.id}` },
-    };
+      return {
+        title: 'Job not found',
+        alternates: { canonical: canonical(`/jobs/${params.id}`) },
+      };
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import { SocketProvider } from "../context/SocketContext";
 import Navigation from "../components/Navigation";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { ToastProvider } from "../components/ToastProvider";
+import { SEO } from "@/config/seo";
+import { canonical } from "@/lib/canonical";
 
 export const metadata: Metadata = {
   title: "QuickGig.ph - Find Gigs Fast in the Philippines",
@@ -19,14 +21,14 @@ export const metadata: Metadata = {
     address: false,
     telephone: false,
   },
-  metadataBase: new URL('https://quickgig.ph'),
+  metadataBase: new URL(SEO.siteUrl || 'https://quickgig.ph'),
   alternates: {
-    canonical: '/',
+    canonical: canonical(),
   },
   openGraph: {
     title: "QuickGig.ph - Find Gigs Fast in the Philippines",
     description: "Kahit saan sa Pinas, may gig para sa'yo! Connect with opportunities and talent across the Philippines.",
-    url: 'https://quickgig.ph',
+    url: canonical(),
     siteName: 'QuickGig.ph',
     images: [
       {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+import { SEO } from '@/config/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  const host = (SEO.siteUrl || 'https://quickgig.ph').replace(/[/]$/, '');
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    sitemap: `${host}/sitemap.xml`,
+    host,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,51 @@
+import type { MetadataRoute } from 'next';
+import { SEO } from '@/config/seo';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = (SEO.siteUrl || 'https://quickgig.ph').replace(/[/]$/, '');
+  const urls: MetadataRoute.Sitemap = [
+    { url: `${base}/`, changeFrequency: 'weekly', priority: 1 },
+    { url: `${base}/jobs`, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${base}/login`, priority: 0.3 },
+    { url: `${base}/register`, priority: 0.3 },
+  ];
+
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL || process.env.API_URL || '').replace(/[/]$/, '');
+  if (!apiBase) return urls;
+
+  try {
+    const controller = new AbortController();
+    const to = setTimeout(() => controller.abort(), 2500);
+    const res = await fetch(`${apiBase}/jobs/list.php?page=1&limit=100`, {
+      signal: controller.signal,
+      cache: 'no-store',
+      next: { revalidate: 60 },
+    });
+    clearTimeout(to);
+
+      if (res.ok) {
+        const raw: unknown = await res.json().catch(() => null);
+        const list = Array.isArray(raw)
+          ? raw
+          : Array.isArray((raw as Record<string, unknown>)?.items)
+          ? ((raw as Record<string, unknown>).items as unknown[])
+          : Array.isArray((raw as Record<string, unknown>)?.data)
+          ? ((raw as Record<string, unknown>).data as unknown[])
+          : [];
+        for (const it of list.slice(0, 100)) {
+          const rec = it as Record<string, unknown>;
+          const id = String(rec.id ?? rec.jobId ?? rec.slug ?? '');
+          if (!id) continue;
+          urls.push({
+            url: `${base}/jobs/${encodeURIComponent(id)}`,
+            changeFrequency: 'daily',
+            priority: 0.8,
+          });
+        }
+      }
+  } catch {
+    // swallow and use static urls only
+  }
+
+  return urls;
+}

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -1,0 +1,3 @@
+export const SEO = {
+  siteUrl: (process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || 'https://quickgig.ph'),
+};

--- a/src/lib/canonical.ts
+++ b/src/lib/canonical.ts
@@ -1,0 +1,7 @@
+import { SEO } from '@/config/seo';
+
+export function canonical(path = '') {
+  const base = (SEO.siteUrl || 'https://quickgig.ph').replace(/[/]$/, '');
+  const cleaned = ('/' + (path || '')).replace(/[/]+$/, '');
+  return `${base}${cleaned === '/' ? '' : cleaned}`;
+}


### PR DESCRIPTION
## Summary
- add env-safe canonical helper and wire into metadata
- add static robots and resilient sitemap with API timeout fallback

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f241bf00c83278b7c3c1b3ef3de02