### PR TITLE
feat: add jobs filters, pagination, and saved jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ JWT_COOKIE_NAME=auth_token
 # Feature flags
 NEXT_PUBLIC_ENABLE_APPLY=false
 
+# Saved jobs via API (optional)
+NEXT_PUBLIC_ENABLE_SAVED_API=false
+
 # Email notifications (optional)
 RESEND_API_KEY=
 NOTIFY_FROM="QuickGig <noreply@quickgig.ph>"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ To verify the live API locally, run:
 BASE=https://api.quickgig.ph node tools/check_live_api.mjs
 ```
 
+## Jobs search & saved jobs
+
+The `/jobs` page offers search, filters and pagination. Filter values are
+reflected in the URL so a pre-filtered view can be shared by copying the link.
+Supported query parameters:
+
+```
+q, location, category, type, remote=1, minSalary, maxSalary,
+sort=recent|salary|relevance, page, limit, saved=1
+```
+
+Job cards include a **Save** button. Saved jobs are stored in `localStorage` by
+default. If the optional `NEXT_PUBLIC_ENABLE_SAVED_API=true` flag is set and the
+backend provides the endpoints, saved jobs are also synced via:
+
+- `GET ${API.savedList}` – hydrate saved IDs
+- `POST ${API.savedToggle(id)}` – toggle saved status
+
+Use the “Saved only” filter on the Jobs page to view saved jobs.
+
 ## Authentication
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import ApplyButton from '../apply-button';
+import SaveJobButton from '@/components/SaveJobButton';
 import type { Job } from '@/types/jobs';
 import { canonical } from '@/lib/canonical';
 
@@ -62,7 +63,10 @@ export default async function JobPage({ params }: JobPageProps) {
           {job.company} · {job.location} · {job.rate}
         </p>
       </div>
-      <ApplyButton jobId={String(job.id)} title={job.title} />
+      <div className="flex items-center gap-2">
+        <ApplyButton jobId={String(job.id)} title={job.title} />
+        <SaveJobButton id={job.id} />
+      </div>
       <p>{job.description}</p>
       {job.tags?.length ? (
         <ul className="flex flex-wrap gap-2">

--- a/src/components/SaveJobButton.tsx
+++ b/src/components/SaveJobButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bookmark, BookmarkCheck } from 'lucide-react';
+import { isSaved, toggle, hydrateSavedIds } from '@/lib/savedJobs';
+
+export default function SaveJobButton({ id }: { id: string | number }) {
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    hydrateSavedIds().then(() => setSaved(isSaved(id)));
+  }, [id]);
+
+  async function handleClick() {
+    const next = await toggle(id);
+    setSaved(next);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={saved ? 'Saved' : 'Save job'}
+      title={saved ? 'Saved' : 'Save job'}
+      className="p-2 rounded hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
+      type="button"
+    >
+      {saved ? (
+        <BookmarkCheck className="w-5 h-5 text-green-600" />
+      ) : (
+        <Bookmark className="w-5 h-5" />
+      )}
+    </button>
+  );
+}

--- a/src/components/jobs/JobsFilters.tsx
+++ b/src/components/jobs/JobsFilters.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { JobFilters } from '@/config/api';
+import { Input } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+
+interface Props {
+  filters: JobFilters;
+  onChange: (f: JobFilters) => void;
+  onClear: () => void;
+}
+
+export function SearchBar({ filters, onChange }: { filters: JobFilters; onChange: (f: JobFilters) => void; }) {
+  const [value, setValue] = useState(filters.q || '');
+  useEffect(() => setValue(filters.q || ''), [filters.q]);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      onChange({ ...filters, q: value, page: 1 });
+    }, 400);
+    return () => clearTimeout(t);
+  }, [value, filters, onChange]);
+  return (
+    <div>
+      <label htmlFor="job-search" className="sr-only">
+        Search jobs
+      </label>
+      <Input
+        id="job-search"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Search jobs"
+      />
+    </div>
+  );
+}
+
+export function FilterPanel({ filters, onChange }: { filters: JobFilters; onChange: (f: JobFilters) => void; }) {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <div>
+        <label htmlFor="location" className="block text-sm">
+          Location
+        </label>
+        <Input
+          id="location"
+          className="w-40"
+          value={filters.location || ''}
+          onChange={(e) => onChange({ ...filters, location: e.target.value, page: 1 })}
+        />
+      </div>
+      <div>
+        <label htmlFor="category" className="block text-sm">
+          Category
+        </label>
+        <Input
+          id="category"
+          className="w-40"
+          value={filters.category || ''}
+          onChange={(e) => onChange({ ...filters, category: e.target.value, page: 1 })}
+        />
+      </div>
+      <div>
+        <label htmlFor="type" className="block text-sm">
+          Type
+        </label>
+        <select
+          id="type"
+          className="border rounded px-2 py-1"
+          value={filters.type || ''}
+          onChange={(e) =>
+            onChange({ ...filters, type: e.target.value || undefined, page: 1 })
+          }
+        >
+          <option value="">Any</option>
+          <option value="full-time">Full-time</option>
+          <option value="part-time">Part-time</option>
+          <option value="contract">Contract</option>
+          <option value="intern">Intern</option>
+          <option value="gig">Gig</option>
+        </select>
+      </div>
+      <div className="flex items-center gap-1 mt-6">
+        <input
+          id="remote"
+          type="checkbox"
+          checked={!!filters.remote}
+          onChange={(e) => onChange({ ...filters, remote: e.target.checked, page: 1 })}
+        />
+        <label htmlFor="remote" className="text-sm">
+          Remote
+        </label>
+      </div>
+      <div>
+        <label htmlFor="minSalary" className="block text-sm">
+          Min Salary
+        </label>
+        <Input
+          id="minSalary"
+          type="number"
+          className="w-32"
+          value={filters.minSalary?.toString() || ''}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              minSalary: e.target.value ? Number(e.target.value) : undefined,
+              page: 1,
+            })
+          }
+        />
+      </div>
+      <div>
+        <label htmlFor="maxSalary" className="block text-sm">
+          Max Salary
+        </label>
+        <Input
+          id="maxSalary"
+          type="number"
+          className="w-32"
+          value={filters.maxSalary?.toString() || ''}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              maxSalary: e.target.value ? Number(e.target.value) : undefined,
+              page: 1,
+            })
+          }
+        />
+      </div>
+      <div className="flex items-center gap-1 mt-6">
+        <input
+          id="savedOnly"
+          type="checkbox"
+          checked={!!filters.savedOnly}
+          onChange={(e) =>
+            onChange({ ...filters, savedOnly: e.target.checked, page: 1 })
+          }
+        />
+        <label htmlFor="savedOnly" className="text-sm">
+          Saved only
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export function SortSelect({ filters, onChange }: { filters: JobFilters; onChange: (f: JobFilters) => void; }) {
+  return (
+    <div>
+      <label htmlFor="sort" className="block text-sm">
+        Sort
+      </label>
+      <select
+        id="sort"
+        className="border rounded px-2 py-1"
+        value={filters.sort || 'recent'}
+        onChange={(e) =>
+          onChange({
+            ...filters,
+            sort: e.target.value as JobFilters['sort'],
+            page: 1,
+          })
+        }
+      >
+        <option value="recent">Recent</option>
+        <option value="salary">Salary</option>
+        <option value="relevance">Relevance</option>
+      </select>
+    </div>
+  );
+}
+
+export function SelectedChips({ filters, onChange }: { filters: JobFilters; onChange: (f: JobFilters) => void; }) {
+  const chips: { key: keyof JobFilters; label: string }[] = [];
+  Object.entries(filters).forEach(([k, v]) => {
+    if (v && !['page', 'limit'].includes(k)) {
+      let label = '';
+      if (k === 'remote') label = 'Remote';
+      else if (k === 'savedOnly') label = 'Saved';
+      else label = `${k}:${v}`;
+      chips.push({ key: k as keyof JobFilters, label });
+    }
+  });
+  if (!chips.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {chips.map((c) => (
+        <button
+          key={c.key as string}
+          className="px-2 py-1 bg-gray-200 rounded text-sm"
+          onClick={() => onChange({ ...filters, [c.key]: undefined, page: 1 })}
+        >
+          {c.label} ×
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ClearAll({ onClear }: { onClear: () => void }) {
+  return (
+    <Button variant="outline" onClick={onClear}>
+      Clear all
+    </Button>
+  );
+}
+
+export default function JobsFilters({ filters, onChange, onClear }: Props) {
+  return (
+    <section className="space-y-4">
+      <SearchBar filters={filters} onChange={onChange} />
+      <FilterPanel filters={filters} onChange={onChange} />
+      <SortSelect filters={filters} onChange={onChange} />
+      <SelectedChips filters={filters} onChange={onChange} />
+      <ClearAll onClear={onClear} />
+    </section>
+  );
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -2,11 +2,45 @@ export const API = {
   login: '/auth/login.php',
   register: '/auth/register.php',
   me: '/auth/me.php',
-  jobs: '/jobs/list.php', // GET list
-  jobById: (id: string | number) => `/jobs/show.php?id=${id}`, // GET details
-  apply: '/applications/create.php', // POST application
-  myJobs: '/employer/jobs/list.php', // GET my jobs
-  createJob: '/employer/jobs/create.php', // POST
-  updateJob: (id: number | string) => `/employer/jobs/update.php?id=${id}`, // PATCH
-  toggleJob: (id: number | string) => `/employer/jobs/toggle.php?id=${id}`, // POST { published: boolean }
+  jobs: '/jobs/list.php',
+  jobById: (id: string | number) => `/jobs/show.php?id=${id}`,
+  // optional saved endpoints (used only if enabled)
+  savedList: '/user/saved/list.php',
+  savedToggle: (id: string | number) => `/user/saved/toggle.php?id=${id}`,
+  apply: '/applications/create.php',
+  myJobs: '/employer/jobs/list.php',
+  createJob: '/employer/jobs/create.php',
+  updateJob: (id: number | string) => `/employer/jobs/update.php?id=${id}`,
+  toggleJob: (id: number | string) => `/employer/jobs/toggle.php?id=${id}`,
 };
+
+export type JobFilters = {
+  q?: string;
+  location?: string;
+  category?: string;
+  type?: 'full-time' | 'part-time' | 'contract' | 'intern' | 'gig' | string;
+  remote?: boolean;
+  minSalary?: number;
+  maxSalary?: number;
+  sort?: 'recent' | 'salary' | 'relevance';
+  page?: number;
+  limit?: number;
+  savedOnly?: boolean;
+};
+
+// Map UI filters -> backend query params (adjust here if backend differs)
+export function mapToJobQuery(f: JobFilters) {
+  return {
+    q: f.q || '',
+    location: f.location || '',
+    category: f.category || '',
+    type: f.type || '',
+    remote: f.remote ? '1' : '',
+    minSalary: f.minSalary != null ? String(f.minSalary) : '',
+    maxSalary: f.maxSalary != null ? String(f.maxSalary) : '',
+    sort: f.sort || 'recent',
+    page: String(f.page ?? 1),
+    limit: String(f.limit ?? 20),
+    saved: f.savedOnly ? '1' : '', // backend may ignore
+  };
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,8 @@ export const env = {
   JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME || 'auth_token',
   NEXT_PUBLIC_ENABLE_APPLY:
     String(process.env.NEXT_PUBLIC_ENABLE_APPLY ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_SAVED_API:
+    String(process.env.NEXT_PUBLIC_ENABLE_SAVED_API ?? 'false').toLowerCase() === 'true',
   RESEND_API_KEY: process.env.RESEND_API_KEY || '',
   NOTIFY_FROM: process.env.NOTIFY_FROM || 'QuickGig <noreply@quickgig.ph>',
   NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -1,0 +1,59 @@
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { api } from './apiClient';
+
+const KEY = 'quickgig_saved_jobs';
+
+export function getSavedIds(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+export function isSaved(id: string | number) {
+  return getSavedIds().includes(String(id));
+}
+
+export function toggleLocal(id: string | number) {
+  const ids = new Set(getSavedIds());
+  const sid = String(id);
+  if (ids.has(sid)) {
+    ids.delete(sid);
+  } else {
+    ids.add(sid);
+  }
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(Array.from(ids)));
+  }
+  return ids.has(sid);
+}
+
+export async function hydrateSavedIds() {
+  if (typeof window === 'undefined') return [];
+  if (env.NEXT_PUBLIC_ENABLE_SAVED_API) {
+    try {
+      const res = await api.get<string[]>(API.savedList);
+      const ids = res.data;
+      localStorage.setItem(KEY, JSON.stringify(ids));
+      return ids;
+    } catch {
+      return getSavedIds();
+    }
+  }
+  return getSavedIds();
+}
+
+export async function toggle(id: string | number) {
+  const saved = toggleLocal(id);
+  if (env.NEXT_PUBLIC_ENABLE_SAVED_API) {
+    try {
+      await api.post(API.savedToggle(id));
+    } catch {
+      // ignore
+    }
+  }
+  return saved;
+}


### PR DESCRIPTION
## Summary
- centralize job API mapping and query helpers
- add URL-synced filters with pagination on jobs page
- support saving jobs locally or via optional API

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f27d3953c8327b50f378e9ac2cf8d