### PR TITLE
feat: add profile and company settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ NEXT_PUBLIC_ENABLE_SAVED_API=false
 RESEND_API_KEY=
 NOTIFY_FROM="QuickGig <noreply@quickgig.ph>"
 NOTIFY_ADMIN_EMAIL=admin@quickgig.ph
+
+# UI flags (optional)
+NEXT_PUBLIC_SHOW_LOGOUT_ALL=false

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Use the “Saved only” filter on the Jobs page to view saved jobs.
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.
 
+## Profiles & Settings
+
+New routes:
+
+- `/settings/profile` – edit applicant profile and manage resume uploads (PDF, 10 MB max)
+- `/settings/account` – change password and request a reset link
+- `/u/[id]` – public applicant profile
+- `/c/[slug]` – public company page
+
+Uploads are proxied via `/api/upload/resume` and `/api/upload/logo`, forwarding multipart bodies to the backend with auth cookies.
+Backend endpoints for these features are defined in [`src/config/api.ts`](src/config/api.ts).
+
 ## Development
 
 Run the development server and visit the branded home page at

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { env } from './src/config/env';
 
-const protectedPaths = ['/dashboard', '/profile', '/account'];
+const protectedPaths = ['/dashboard', '/settings/profile', '/settings/account'];
 const employerPaths = ['/employer'];
 
 export function middleware(req: NextRequest) {
@@ -37,8 +37,8 @@ export function middleware(req: NextRequest) {
 export const config = {
   matcher: [
     '/dashboard/:path*',
-    '/profile/:path*',
-    '/account/:path*',
+    '/settings/profile/:path*',
+    '/settings/account/:path*',
     '/employer/:path*',
   ],
 };

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,3 +1,0 @@
-export default function AccountPage() {
-  return <main className="p-4">Account</main>;
-}

--- a/src/app/api/upload/logo/route.ts
+++ b/src/app/api/upload/logo/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+async function forward(req: NextRequest, target: string) {
+  try {
+    const form = await req.formData();
+    const res = await fetch(`${env.API_URL}${target}`, {
+      method: 'POST',
+      body: form,
+      headers: {
+        cookie: req.headers.get('cookie') || '',
+      },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) {
+      return NextResponse.json({ ok: true, url: data.url || data.path });
+    }
+    return NextResponse.json({ ok: false, message: data.message || 'Upload failed' });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  return forward(req, API.uploadLogo);
+}

--- a/src/app/api/upload/resume/route.ts
+++ b/src/app/api/upload/resume/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+async function forward(req: NextRequest, target: string) {
+  try {
+    const form = await req.formData();
+    const res = await fetch(`${env.API_URL}${target}`, {
+      method: 'POST',
+      body: form,
+      headers: {
+        cookie: req.headers.get('cookie') || '',
+      },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) {
+      return NextResponse.json({ ok: true, url: data.url || data.path });
+    }
+    return NextResponse.json({ ok: false, message: data.message || 'Upload failed' });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  return forward(req, API.uploadResume);
+}

--- a/src/app/c/[slug]/page.tsx
+++ b/src/app/c/[slug]/page.tsx
@@ -1,0 +1,48 @@
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import Link from 'next/link';
+
+async function fetchCompany(slug: string) {
+  const res = await fetch(`${env.API_URL}${API.publicCompany(slug)}`, { cache: 'no-store' });
+  if (!res.ok) return null;
+  return res.json().catch(() => null);
+}
+
+export default async function PublicCompanyPage({ params }: { params: { slug: string } }) {
+  const data = await fetchCompany(params.slug);
+  if (!data) return <main className="p-4">Company not found</main>;
+  return (
+    <main className="p-4 space-y-4 max-w-3xl">
+      {data.logo && <img src={data.logo} alt={`${data.name} logo`} className="max-h-32" />}
+      <h1 className="text-2xl font-semibold">{data.companyName || data.name}</h1>
+      {data.website && (
+        <a href={data.website} className="text-qg-accent" target="_blank" rel="noopener noreferrer">
+          {data.website}
+        </a>
+      )}
+      {data.about && <p>{data.about}</p>}
+      {Array.isArray(data.jobs) && data.jobs.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold">Jobs</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {data.jobs.map((j: { id: string | number; title?: string; name?: string }) => (
+              <li key={j.id}>
+                <Link href={`/jobs/${j.id}`} className="text-qg-accent">
+                  {j.title || j.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const data = await fetchCompany(params.slug);
+  return {
+    title: data?.name ? `${data.name} — QuickGig Company` : 'QuickGig Company',
+    alternates: { canonical: `/c/${params.slug}` },
+  };
+}

--- a/src/app/employer/company/page.tsx
+++ b/src/app/employer/company/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Input, Textarea, Select } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+import { toast } from '@/lib/toast';
+
+const sizeOptions = [
+  { value: '1-10', label: '1-10' },
+  { value: '11-50', label: '11-50' },
+  { value: '51-200', label: '51-200' },
+  { value: '200+', label: '200+' },
+];
+
+export default function EmployerCompanyPage() {
+  const [data, setData] = useState({
+    companyName: '',
+    slug: '',
+    website: '',
+    location: '',
+    about: '',
+    size: '',
+    industry: '',
+  });
+  const [logo, setLogo] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get(API.companyGet);
+        const d = res.data || {};
+        setData({
+          companyName: d.companyName || d.name || '',
+          slug: d.slug || '',
+          website: d.website || '',
+          location: d.location || '',
+          about: d.about || '',
+          size: d.size || '',
+          industry: d.industry || '',
+        });
+        if (d.logo) setLogo(d.logo);
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, []);
+
+  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setData({ ...data, [field]: e.target.value });
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await api.post(API.companyUpdate, data);
+      toast('Company saved');
+    } catch {
+      toast('Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      toast('File too large (max 10 MB)');
+      return;
+    }
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/upload/logo', { method: 'POST', body: formData });
+      const json = await res.json();
+      if (json.ok) {
+        setLogo(json.url || '');
+        toast('Logo uploaded');
+      } else {
+        toast(json.message || 'Upload failed');
+      }
+    } catch {
+      toast('Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Company</h1>
+      <form onSubmit={handleSave} className="space-y-4">
+        <Input label="Name" value={data.companyName} onChange={handleChange('companyName')} />
+        <Input label="Slug" value={data.slug} onChange={handleChange('slug')} />
+        <Input label="Website" value={data.website} onChange={handleChange('website')} />
+        <Input label="Location" value={data.location} onChange={handleChange('location')} />
+        <Select
+          label="Size"
+          value={data.size}
+          onChange={handleChange('size')}
+          options={sizeOptions}
+          placeholder="Select size"
+        />
+        <Input label="Industry" value={data.industry} onChange={handleChange('industry')} />
+        <Textarea label="About" value={data.about} onChange={handleChange('about')} />
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </form>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Logo</h2>
+        {logo && <img src={logo} alt="Company logo" className="max-h-32" />}
+        <input type="file" accept=".pdf,.png,.jpg,.jpeg" onChange={handleUpload} />
+        {uploading && <p>Uploading...</p>}
+      </div>
+    </main>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,3 +1,0 @@
-export default function ProfilePage() {
-  return <main className="p-4">Profile</main>;
-}

--- a/src/app/reset/page.tsx
+++ b/src/app/reset/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+import { toast } from '@/lib/toast';
+
+export default function ResetPage() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await api.post(API.requestPasswordReset, { email });
+      toast('If that email exists, a reset link has been sent.');
+    } catch (err) {
+      console.warn('password reset', err);
+      toast('If that email exists, a reset link has been sent.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6 max-w-md">
+      <h1 className="text-xl font-semibold">Reset Password</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          type="email"
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Sending...' : 'Send reset link'}
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
+
+export default function AccountSettingsPage() {
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await api.post(API.changePassword, { current, next });
+      toast('Password changed');
+      setCurrent('');
+      setNext('');
+    } catch {
+      toast('Failed to change password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLogoutAll = async () => {
+    try {
+      await api.post('/auth/logoutAll.php', {});
+      toast('Logged out of all devices');
+    } catch {
+      toast('Failed to log out');
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6 max-w-md">
+      <h1 className="text-xl font-semibold">Account Settings</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          type="password"
+          label="Current Password"
+          value={current}
+          onChange={(e) => setCurrent(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          label="New Password"
+          value={next}
+          onChange={(e) => setNext(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Saving...' : 'Change Password'}
+        </Button>
+      </form>
+      <Link href="/reset" className="text-qg-accent">
+        Request password reset
+      </Link>
+      {env.NEXT_PUBLIC_SHOW_LOGOUT_ALL && (
+        <Button variant="secondary" onClick={handleLogoutAll}>
+          Log out of all devices
+        </Button>
+      )}
+    </main>
+  );
+}

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Input, Textarea } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { api } from '@/lib/apiClient';
+import { API } from '@/config/api';
+import { toast } from '@/lib/toast';
+
+interface ProfileData {
+  name: string;
+  headline: string;
+  location: string;
+  phone: string;
+  skills: string;
+  bio: string;
+  resumeUrl?: string;
+  resumeName?: string;
+}
+
+export default function ProfileSettingsPage() {
+  const [data, setData] = useState<ProfileData>({
+    name: '',
+    headline: '',
+    location: '',
+    phone: '',
+    skills: '',
+    bio: '',
+  });
+  const [resume, setResume] = useState<{ name: string; url?: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get(API.me);
+        const d = res.data || {};
+        setData({
+          name: d.name || '',
+          headline: d.headline || '',
+          location: d.location || '',
+          phone: d.phone || '',
+          skills: Array.isArray(d.skills) ? d.skills.join(', ') : d.skills || '',
+          bio: d.bio || '',
+        });
+        if (d.resumeUrl || d.resume) {
+          setResume({ name: d.resumeName || 'Resume', url: d.resumeUrl || d.resume });
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, []);
+
+  const handleChange = (field: keyof ProfileData) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setData({ ...data, [field]: e.target.value });
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await api.post(API.updateProfile, {
+        ...data,
+        skills: data.skills
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      });
+      toast('Profile saved');
+    } catch {
+      toast('Failed to save profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      toast('File too large (max 10 MB)');
+      return;
+    }
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/upload/resume', { method: 'POST', body: formData });
+      const json = await res.json();
+      if (json.ok) {
+        setResume({ name: file.name, url: json.url });
+        toast('Resume uploaded');
+      } else {
+        toast(json.message || 'Upload failed');
+      }
+    } catch {
+      toast('Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    try {
+      await api.post(API.deleteResume, {});
+      setResume(null);
+      toast('Resume removed');
+    } catch {
+      toast('Failed to remove resume');
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-6 max-w-2xl">
+      <h1 className="text-xl font-semibold">Profile Settings</h1>
+      <form onSubmit={handleSave} className="space-y-4">
+        <Input label="Name" value={data.name} onChange={handleChange('name')} />
+        <Input label="Headline" value={data.headline} onChange={handleChange('headline')} />
+        <Input label="Location" value={data.location} onChange={handleChange('location')} />
+        <Input label="Phone" value={data.phone} onChange={handleChange('phone')} />
+        <Input
+          label="Skills (comma separated)"
+          value={data.skills}
+          onChange={handleChange('skills')}
+        />
+        <Textarea label="Bio" value={data.bio} onChange={handleChange('bio')} />
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </form>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Resume</h2>
+        {resume ? (
+          <div className="space-y-2">
+            <p>{resume.name}</p>
+            {resume.url && (
+              <a
+                href={resume.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-qg-accent"
+              >
+                View
+              </a>
+            )}
+            <div className="space-x-2">
+              <label className="text-qg-accent cursor-pointer">
+                <span>Replace</span>
+                <input type="file" accept=".pdf" className="hidden" onChange={handleUpload} />
+              </label>
+              <button type="button" onClick={handleRemove} className="text-red-600">
+                Remove
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <input type="file" accept=".pdf" onChange={handleUpload} />
+          </div>
+        )}
+        {uploading && <p>Uploading...</p>}
+      </div>
+    </main>
+  );
+}

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -1,0 +1,53 @@
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { cookies } from 'next/headers';
+
+async function fetchUser(id: string) {
+  const path = id === 'me' ? API.me : API.publicUser(id);
+  const res = await fetch(`${env.API_URL}${path}`, {
+    headers: { cookie: cookies().toString() },
+    cache: 'no-store',
+  });
+  if (!res.ok) return null;
+  return res.json().catch(() => null);
+}
+
+export default async function PublicProfilePage({ params }: { params: { id: string } }) {
+  const data = await fetchUser(params.id);
+  if (!data) return <main className="p-4">Profile not found</main>;
+  return (
+    <main className="p-4 space-y-4 max-w-2xl">
+      <h1 className="text-2xl font-semibold">{data.name}</h1>
+      {data.headline && <p className="text-gray-600">{data.headline}</p>}
+      {data.location && <p>{data.location}</p>}
+      {Array.isArray(data.skills) && data.skills.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {data.skills.map((s: string) => (
+            <li key={s} className="px-2 py-1 bg-gray-200 rounded">
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+      {data.bio && <p>{data.bio}</p>}
+      {data.resumeUrl && (
+        <a
+          href={data.resumeUrl}
+          className="text-qg-accent"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Download Resume
+        </a>
+      )}
+    </main>
+  );
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }) {
+  const data = await fetchUser(params.id);
+  if (data?.name) {
+    return { title: `${data.name} — QuickGig Profile` };
+  }
+  return { title: 'QuickGig Profile' };
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -70,6 +70,12 @@ const Navigation: React.FC = () => {
                 </button>
                 <div className="absolute hidden group-hover:block bg-qg-navy-light rounded-qg-md mt-2 min-w-[150px]">
                   <Link
+                    href="/employer/company"
+                    className="block px-4 py-2 qg-navbar-link hover:bg-qg-navy"
+                  >
+                    Company
+                  </Link>
+                  <Link
                     href="/employer/jobs"
                     className="block px-4 py-2 qg-navbar-link hover:bg-qg-navy"
                   >
@@ -127,7 +133,7 @@ const Navigation: React.FC = () => {
                 
                 <div className="flex items-center space-x-3 ml-4 pl-4 border-l border-qg-navy-light">
                   <Link
-                    href="/profile"
+                    href="/settings/profile"
                     className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
                   >
                     <User className="w-4 h-4 mr-2" />
@@ -219,6 +225,14 @@ const Navigation: React.FC = () => {
                   {user?.isEmployer && (
                     <>
                       <Link
+                        href="/employer/company"
+                        className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <Briefcase className="w-5 h-5 mr-3" />
+                        Company
+                      </Link>
+                      <Link
                         href="/employer/jobs"
                         className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
                         onClick={() => setIsMenuOpen(false)}
@@ -253,7 +267,7 @@ const Navigation: React.FC = () => {
                     Payment (Beta)
                   </Link>
                   <Link
-                    href="/profile"
+                    href="/settings/profile"
                     className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
                     onClick={() => setIsMenuOpen(false)}
                   >

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -12,6 +12,16 @@ export const API = {
   createJob: '/employer/jobs/create.php',
   updateJob: (id: number | string) => `/employer/jobs/update.php?id=${id}`,
   toggleJob: (id: number | string) => `/employer/jobs/toggle.php?id=${id}`,
+  updateProfile: '/user/profile/update.php',
+  uploadResume: '/user/profile/uploadResume.php',
+  deleteResume: '/user/profile/deleteResume.php',
+  changePassword: '/auth/changePassword.php',
+  requestPasswordReset: '/auth/requestPasswordReset.php',
+  companyGet: '/employer/company/get.php',
+  companyUpdate: '/employer/company/update.php',
+  uploadLogo: '/employer/company/uploadLogo.php',
+  publicUser: (id: string | number) => `/public/user.php?id=${id}`,
+  publicCompany: (slug: string) => `/public/company.php?slug=${encodeURIComponent(slug)}`,
 };
 
 export type JobFilters = {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,6 +8,8 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_APPLY ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_SAVED_API:
     String(process.env.NEXT_PUBLIC_ENABLE_SAVED_API ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_SHOW_LOGOUT_ALL:
+    String(process.env.NEXT_PUBLIC_SHOW_LOGOUT_ALL ?? 'false').toLowerCase() === 'true',
   RESEND_API_KEY: process.env.RESEND_API_KEY || '',
   NOTIFY_FROM: process.env.NOTIFY_FROM || 'QuickGig <noreply@quickgig.ph>',
   NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',


### PR DESCRIPTION
## Summary
- centralize API paths and add profile/company endpoints
- implement profile, company, and account settings with upload proxies
- add public user/company pages and document new routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2a6ff9788327be11ec98e042e07e