### PR TITLE
feat: add basic in-app messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ New routes:
 Uploads are proxied via `/api/upload/resume` and `/api/upload/logo`, forwarding multipart bodies to the backend with auth cookies.
 Backend endpoints for these features are defined in [`src/config/api.ts`](src/config/api.ts).
 
+## Messaging
+
+- `/messages` – inbox listing conversations
+- `/messages/[id]` – thread view
+
+Expected backend endpoints (configure in `src/config/api.ts`):
+- `GET ${API.conversationsMine}`
+- `GET ${API.conversationById(id)}`
+- `GET ${API.conversationForApplication(appId)}`
+- `POST ${API.sendMessage(id)}` with `{ text }`
+- `POST ${API.startConversation}` with `{ appId, toUserId?, firstMessage? }`
+- `POST ${API.markRead(id)}`
+
+Threads poll for new messages every 6–8 s (backing off when unfocused). The navbar unread badge polls the conversation list about every 30–60 s.
+Email notifications for new messages are optional and use `/api/notify/message` when `RESEND_API_KEY` is set.
+
+
 ## Development
 
 Run the development server and visit the branded home page at

--- a/src/app/api/msg/[id]/read/route.ts
+++ b/src/app/api/msg/[id]/read/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const res = await fetch(`${env.API_URL}${API.markRead(params.id)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') || '',
+      },
+      body: '{}',
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/app/api/msg/[id]/route.ts
+++ b/src/app/api/msg/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const res = await fetch(`${env.API_URL}${API.conversationById(params.id)}`, {
+      headers: {
+        cookie: req.headers.get('cookie') || '',
+      },
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/app/api/msg/[id]/send/route.ts
+++ b/src/app/api/msg/[id]/send/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await req.text();
+    const res = await fetch(`${env.API_URL}${API.sendMessage(params.id)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') || '',
+      },
+      body,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/app/api/msg/list/route.ts
+++ b/src/app/api/msg/list/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function GET(req: NextRequest) {
+  try {
+    const res = await fetch(`${env.API_URL}${API.conversationsMine}`, {
+      headers: {
+        cookie: req.headers.get('cookie') || '',
+      },
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/app/api/msg/start/route.ts
+++ b/src/app/api/msg/start/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.text();
+    const res = await fetch(`${env.API_URL}${API.startConversation}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') || '',
+      },
+      body,
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/app/api/notify/message/route.ts
+++ b/src/app/api/notify/message/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { sendMail } from '@/server/mailer';
+
+export async function POST(req: Request) {
+  const { toEmail, toName, jobTitle } = await req.json();
+  if (toEmail) {
+    await sendMail({
+      to: toEmail,
+      subject: `New message on QuickGig about ${jobTitle || ''}`,
+      html: `<p>Hi ${toName || ''},</p><p>You have a new message about <b>${jobTitle || 'a job'}</b>.</p>`,
+    }).catch(() => {});
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/messages/[id]/page.tsx
+++ b/src/app/messages/[id]/page.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import Button from '@/components/ui/Button';
+import { usePolling } from '@/lib/usePolling';
+
+interface Msg {
+  id: string | number;
+  text: string;
+  fromMe?: boolean;
+  createdAt?: string;
+}
+
+interface Meta {
+  toEmail?: string;
+  toName?: string;
+  jobTitle?: string;
+  jobId?: string | number;
+}
+
+export default function ThreadPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [meta, setMeta] = useState<Meta>({});
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const liveRef = useRef<HTMLDivElement>(null);
+
+  const load = () => {
+    fetch(`/api/msg/${id}`)
+      .then((r) => r.json())
+      .then((d) => {
+        setMessages(d.messages || []);
+        setMeta({
+          toEmail: d.otherEmail,
+          toName: d.otherName,
+          jobTitle: d.jobTitle,
+          jobId: d.jobId,
+        });
+      })
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    load();
+    fetch(`/api/msg/${id}/read`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' }).catch(
+      () => {},
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  usePolling<{ messages?: Msg[] }>(`/api/msg/${id}`, 7000, (d) => {
+    const list = (d.messages || []) as Msg[];
+    const diff = list.length - messages.length;
+    setMessages(list);
+    if (diff > 0 && liveRef.current) {
+      liveRef.current.textContent = `${diff} new message${diff > 1 ? 's' : ''}`;
+    }
+  });
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const send = async () => {
+    if (!text.trim()) return;
+    setSending(true);
+    await fetch(`/api/msg/${id}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    })
+      .then((r) => r.json())
+      .then(() => {
+        if (liveRef.current) {
+          liveRef.current.textContent = 'Message sent';
+        }
+        setText('');
+        load();
+        void fetch('/api/notify/message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            toEmail: meta.toEmail,
+            toName: meta.toName,
+            jobTitle: meta.jobTitle,
+          }),
+        }).catch(() => {});
+      })
+      .catch(() => {})
+      .finally(() => setSending(false));
+  };
+
+  return (
+    <main className="p-4 flex flex-col h-[80vh]">
+      <div className="mb-2">
+        <Link href="/messages" className="text-qg-accent text-sm">
+          &larr; Back
+        </Link>
+      </div>
+      <div className="mb-4 flex justify-between items-center">
+        <div className="font-medium">{meta.toName || 'Conversation'}</div>
+        {meta.jobId && (
+          <Link href={`/jobs/${meta.jobId}`} className="text-sm text-qg-accent underline">
+            {meta.jobTitle || 'Job'}
+          </Link>
+        )}
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {messages.length === 0 ? (
+          <p>Say hello to start the conversation.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {messages.map((m) => (
+              <div
+                key={m.id}
+                className={`max-w-[80%] px-3 py-2 rounded text-sm ${
+                  m.fromMe ? 'ml-auto bg-qg-accent text-white' : 'bg-gray-200'
+                }`}
+              >
+                <div>{m.text}</div>
+                {m.createdAt && (
+                  <div className="text-xs text-gray-500">
+                    {new Date(m.createdAt).toLocaleTimeString()}
+                  </div>
+                )}
+              </div>
+            ))}
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+      <div className="mt-4">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          maxLength={1000}
+          className="w-full border rounded p-2 mb-2"
+          rows={3}
+        />
+        <Button onClick={send} disabled={sending || !text.trim()}>
+          Send
+        </Button>
+      </div>
+      <div aria-live="polite" className="sr-only" ref={liveRef} />
+    </main>
+  );
+}

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/Input';
+
+interface Conv {
+  id: string | number;
+  otherName?: string;
+  jobTitle?: string;
+  lastMessage?: string;
+  updatedAt?: string;
+  unread?: number;
+}
+
+export default function MessagesPage() {
+  const [list, setList] = useState<Conv[]>([]);
+  const [q, setQ] = useState('');
+
+  useEffect(() => {
+    fetch('/api/msg/list')
+      .then((r) => r.json())
+      .then((d) => setList(d.conversations || d.data || []))
+      .catch(() => {});
+  }, []);
+
+  const filtered = list.filter((c) => {
+    const hay = `${c.otherName || ''} ${c.jobTitle || ''}`.toLowerCase();
+    return hay.includes(q.toLowerCase());
+  });
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl mb-4">Messages</h1>
+      <Input
+        placeholder="Search"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        className="mb-4"
+      />
+      {filtered.length === 0 ? (
+        <p>No conversations yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((c) => (
+            <li key={c.id}>
+              <Link
+                href={`/messages/${c.id}`}
+                className="block border rounded p-3 hover:bg-qg-navy-light"
+              >
+                <div className="font-medium">{c.otherName || 'Unknown'}</div>
+                {c.jobTitle && (
+                  <div className="text-sm text-gray-500">{c.jobTitle}</div>
+                )}
+                {c.lastMessage && (
+                  <div className="text-sm truncate">{c.lastMessage}</div>
+                )}
+                <div className="flex justify-between text-xs text-gray-500 mt-1">
+                  <span>
+                    {c.updatedAt ? new Date(c.updatedAt).toLocaleString() : ''}
+                  </span>
+                  {c.unread ? (
+                    <span className="bg-qg-accent text-white rounded-full px-2">
+                      {c.unread}
+                    </span>
+                  ) : null}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/components/MessageButton.tsx
+++ b/src/components/MessageButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from './ui/Button';
+
+export default function MessageButton({ appId }: { appId: string | number }) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const start = async () => {
+    setLoading(true);
+    const res = await fetch('/api/msg/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appId }),
+    })
+      .then((r) => r.json())
+      .catch(() => ({ ok: false }));
+    setLoading(false);
+    if (res?.id || res?.conversationId) {
+      router.push(`/messages/${res.id || res.conversationId}`);
+    }
+  };
+
+  return (
+    <Button onClick={start} disabled={loading}>
+      Message
+    </Button>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
 import NotificationDropdown from './NotificationDropdown';
+import { usePolling } from '@/lib/usePolling';
 import WalletDisplay from './WalletDisplay';
 import Button from './ui/Button';
 import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard } from 'lucide-react';
@@ -14,6 +15,14 @@ const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
   const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const [unread, setUnread] = useState(0);
+  usePolling(pathname.startsWith('/messages/') ? null : "/api/msg/list", 45000, (d: unknown) => {
+    const data = d as { conversations?: { unread?: number }[]; data?: { unread?: number }[] };
+    const list = data.conversations || data.data || [];
+    const total = list.reduce((sum: number, c: { unread?: number }) => sum + (c.unread || 0), 0);
+    setUnread(total);
+  });
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 
@@ -111,10 +120,10 @@ const Navigation: React.FC = () => {
                 )}
                 <Link
                   href="/messages"
-                  className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                  className="relative qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
                 >
                   <MessageCircle className="w-4 h-4 mr-2" />
-                  Messages
+                  Messages{unread > 0 && (<span className="ml-1 bg-qg-accent text-white rounded-full px-2 text-xs">{unread}</span>)}
                 </Link>
 
                 <Link
@@ -252,11 +261,11 @@ const Navigation: React.FC = () => {
                   )}
                   <Link
                     href="/messages"
-                    className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                    className="relative qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
                     onClick={() => setIsMenuOpen(false)}
                   >
                     <MessageCircle className="w-5 h-5 mr-3" />
-                    Messages
+                    Messages{unread > 0 && (<span className="ml-1 bg-qg-accent text-white rounded-full px-2 text-xs">{unread}</span>)}
                   </Link>
                   <Link
                     href="/payment"

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -22,6 +22,12 @@ export const API = {
   uploadLogo: '/employer/company/uploadLogo.php',
   publicUser: (id: string | number) => `/public/user.php?id=${id}`,
   publicCompany: (slug: string) => `/public/company.php?slug=${encodeURIComponent(slug)}`,
+  conversationsMine: '/messages/conversations.php',
+  conversationById: (id: string | number) => `/messages/show.php?id=${id}`,
+  conversationForApplication: (appId: string | number) => `/messages/byApplication.php?appId=${appId}`,
+  sendMessage: (id: string | number) => `/messages/send.php?id=${id}`,
+  startConversation: '/messages/start.php',
+  markRead: (id: string | number) => `/messages/markRead.php?id=${id}`,
 };
 
 export type JobFilters = {

--- a/src/lib/usePolling.ts
+++ b/src/lib/usePolling.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+export function usePolling<T = unknown>(url: string | null, ms: number, onData: (data: T) => void) {
+  useEffect(() => {
+    if (!url || ms <= 0) return;
+    let timer: NodeJS.Timeout;
+    let controller: AbortController | null = null;
+    let interval = ms;
+
+    const fetchData = () => {
+      controller?.abort();
+      controller = new AbortController();
+      fetch(url, { signal: controller.signal })
+        .then((r) => r.json() as Promise<T>)
+        .then((d) => onData(d))
+        .catch(() => {});
+    };
+
+    fetchData();
+    timer = setInterval(fetchData, interval);
+
+    const handleVis = () => {
+      clearInterval(timer);
+      interval = document.hidden ? ms * 4 : ms;
+      timer = setInterval(fetchData, interval);
+    };
+    document.addEventListener('visibilitychange', handleVis);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVis);
+      controller?.abort();
+      clearInterval(timer);
+    };
+  }, [url, ms, onData]);
+}

--- a/src/pages/api/msg/[id].ts
+++ b/src/pages/api/msg/[id].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  const { id } = req.query;
+  try {
+    const r = await fetch(`${env.API_URL}${API.conversationById(String(id))}`, {
+      headers: { cookie: req.headers.cookie || '' },
+    });
+    const data = await r.json().catch(() => ({}));
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/pages/api/msg/[id]/read.ts
+++ b/src/pages/api/msg/[id]/read.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  const { id } = req.query;
+  try {
+    const r = await fetch(`${env.API_URL}${API.markRead(String(id))}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.cookie || '',
+      },
+      body: '{}',
+    });
+    const data = await r.json().catch(() => ({}));
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/pages/api/msg/[id]/send.ts
+++ b/src/pages/api/msg/[id]/send.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  const { id } = req.query;
+  try {
+    const r = await fetch(`${env.API_URL}${API.sendMessage(String(id))}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.cookie || '',
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await r.json().catch(() => ({}));
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/pages/api/msg/list.ts
+++ b/src/pages/api/msg/list.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  try {
+    const r = await fetch(`${env.API_URL}${API.conversationsMine}`, {
+      headers: { cookie: req.headers.cookie || '' },
+    });
+    const data = await r.json().catch(() => ({}));
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/pages/api/msg/start.ts
+++ b/src/pages/api/msg/start.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  try {
+    const r = await fetch(`${env.API_URL}${API.startConversation}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.cookie || '',
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await r.json().catch(() => ({}));
+    res.status(r.status).json(data);
+  } catch (err) {
+    res.json({ ok: false, message: (err as Error).message });
+  }
+}

--- a/src/pages/api/notify/message.ts
+++ b/src/pages/api/notify/message.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { sendMail } from '@/server/mailer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, message: 'Method not allowed' });
+  }
+  const { toEmail, toName, jobTitle } = req.body || {};
+  if (toEmail) {
+    await sendMail({
+      to: toEmail,
+      subject: `New message on QuickGig about ${jobTitle || ''}`,
+      html: `<p>Hi ${toName || ''},</p><p>You have a new message about <b>${jobTitle || 'a job'}</b>.</p>`,
+    }).catch(() => {});
+  }
+  res.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add API config & proxy routes for conversations and messages
- build messages inbox and thread pages with polling and send/notify support
- show unread message badge in navbar with periodic polling

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f2dab8e008327ad4bd3510b05f87f