### PR TITLE
feat: add job alerts with cron endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ NOTIFY_ADMIN_EMAIL=admin@quickgig.ph
 
 # UI flags (optional)
 NEXT_PUBLIC_SHOW_LOGOUT_ALL=false
+
+# Job alerts (optional)
+ALERTS_DIGEST_SECRET=change-me
+NEXT_PUBLIC_ENABLE_ALERTS=true

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ backend provides the endpoints, saved jobs are also synced via:
 
 Use the “Saved only” filter on the Jobs page to view saved jobs.
 
+## Job Alerts
+
+Turn on with `NEXT_PUBLIC_ENABLE_ALERTS=true` and optionally set
+`ALERTS_DIGEST_SECRET` if the backend checks a shared secret. Backend
+endpoints expected (see `src/config/api.ts`):
+
+- `GET ${API.alertsList}` – list my alerts
+- `POST ${API.alertsCreate}` – create `{ name, filters, frequency, email }`
+- `PATCH ${API.alertsUpdate(id)}` – update an alert
+- `POST ${API.alertsDelete(id)}` – delete an alert
+- `POST ${API.alertsToggle(id)}` – toggle email notifications
+- `POST ${API.alertsRunDigest}` – trigger digest (optional)
+
+Vercel Cron setup:
+
+- Path: `/api/cron/job-alerts`
+- Method: `POST`
+- Schedule: `0 1 * * *` (daily 01:00 UTC) or `0 17 * * *`
+
+Create an alert from the **Create Alert from filters** button on `/jobs` and
+manage them in `/settings/alerts`.
+
 ## Authentication
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.

--- a/src/app/api/cron/job-alerts/route.ts
+++ b/src/app/api/cron/job-alerts/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST() {
+  try {
+    const body = { secret: process.env.ALERTS_DIGEST_SECRET || '' };
+    if (API.alertsRunDigest) {
+      const r = await fetch(`${env.API_URL}${API.alertsRunDigest}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const ok = r.ok;
+      return NextResponse.json({ ok, mode: 'backend', status: r.status });
+    }
+    return NextResponse.json({ ok: true, mode: 'noop' });
+  } catch {
+    return NextResponse.json({ ok: false, error: 'cron-failed' }, { status: 200 });
+  }
+}
+
+export const GET = POST;

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -10,6 +10,8 @@ import ApplyButton from './apply-button';
 import SaveJobButton from '@/components/SaveJobButton';
 import JobsFilters from '@/components/jobs/JobsFilters';
 import { getSavedIds, hydrateSavedIds } from '@/lib/savedJobs';
+import AlertModal from '@/components/alerts/AlertModal';
+import { env } from '@/config/env';
 
 function JobsPageContent() {
   const router = useRouter();
@@ -20,6 +22,7 @@ function JobsPageContent() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [alertOpen, setAlertOpen] = useState(false);
 
   // read filters from URL
   useEffect(() => {
@@ -109,6 +112,16 @@ function JobsPageContent() {
   return (
     <main className="p-4 space-y-4">
       <JobsFilters filters={filters} onChange={setFilters} onClear={clearFilters} />
+      {env.NEXT_PUBLIC_ENABLE_ALERTS && (
+        <div className="flex justify-end">
+          <button
+            className="border px-2 py-1 rounded"
+            onClick={() => setAlertOpen(true)}
+          >
+            Create Alert from filters
+          </button>
+        </div>
+      )}
       {loading ? (
         <div className="space-y-2" aria-busy="true">
           {[...Array(3)].map((_, i) => (
@@ -181,6 +194,14 @@ function JobsPageContent() {
       >
         Copy link
       </button>
+      {env.NEXT_PUBLIC_ENABLE_ALERTS && (
+        <AlertModal
+          open={alertOpen}
+          onClose={() => setAlertOpen(false)}
+          initial={{ filters, email: true, frequency: 'daily' }}
+          onSaved={() => setAlertOpen(false)}
+        />
+      )}
     </main>
   );
 }

--- a/src/app/settings/alerts/page.tsx
+++ b/src/app/settings/alerts/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/apiClient';
+import { API, JobFilters } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
+import Button from '@/components/ui/Button';
+import AlertModal, { AlertData } from '@/components/alerts/AlertModal';
+import { notFound } from 'next/navigation';
+
+interface Alert extends AlertData {
+  id: string | number;
+}
+
+export default function AlertsSettingsPage() {
+  if (!env.NEXT_PUBLIC_ENABLE_ALERTS) notFound();
+
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Alert | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get(API.alertsList);
+        const items = Array.isArray(res.data) ? res.data : res.data?.items || [];
+        setAlerts(items);
+      } catch {
+        toast('Failed to load alerts');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const summary = (f: JobFilters) => {
+    const parts: string[] = [];
+    if (f.q) parts.push(`"${f.q}"`);
+    if (f.location) parts.push(f.location);
+    if (f.category) parts.push(f.category);
+    if (f.type) parts.push(f.type);
+    if (f.remote) parts.push('remote');
+    if (f.minSalary || f.maxSalary)
+      parts.push(`₱${f.minSalary || 0}-${f.maxSalary || ''}`);
+    return parts.join(', ') || 'Any';
+  };
+
+  const handleSaved = (a: AlertData) => {
+    if (!a.id) return;
+    setAlerts((prev) => {
+      const idx = prev.findIndex((p) => p.id === a.id);
+      if (idx >= 0) {
+        const copy = [...prev];
+        copy[idx] = a as Alert;
+        return copy;
+      }
+      return [...prev, a as Alert];
+    });
+  };
+
+  const toggleEmail = async (a: Alert) => {
+    const next = !a.email;
+    setAlerts((prev) => prev.map((p) => (p.id === a.id ? { ...p, email: next } : p)));
+    try {
+      await api.post(API.alertsToggle(a.id), { email: next });
+      toast('Alert updated');
+    } catch {
+      toast('Failed to update');
+      setAlerts((prev) => prev.map((p) => (p.id === a.id ? { ...p, email: a.email } : p)));
+    }
+  };
+
+  const deleteAlert = async (id: string | number) => {
+    if (!confirm('Delete this alert?')) return;
+    const prev = alerts;
+    setAlerts((p) => p.filter((a) => a.id !== id));
+    try {
+      await api.post(API.alertsDelete(id), {});
+      toast('Alert deleted');
+    } catch {
+      toast('Failed to delete');
+      setAlerts(prev);
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-4 max-w-3xl">
+      <h1 className="text-xl font-semibold">Job Alerts</h1>
+      <Button
+        onClick={() => {
+          setEditing(null);
+          setOpen(true);
+        }}
+      >
+        New Alert
+      </Button>
+      {loading ? (
+        <p>Loading...</p>
+      ) : alerts.length === 0 ? (
+        <p>No alerts yet — create one from your current Jobs filters.</p>
+      ) : (
+        <table className="w-full text-sm border">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="p-2">Name</th>
+              <th className="p-2">Filters</th>
+              <th className="p-2">Frequency</th>
+              <th className="p-2">Email</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {alerts.map((a) => (
+              <tr key={a.id} className="border-t">
+                <td className="p-2">{a.name}</td>
+                <td className="p-2">{summary(a.filters)}</td>
+                <td className="p-2 capitalize">{a.frequency}</td>
+                <td className="p-2">
+                  <input
+                    type="checkbox"
+                    checked={a.email}
+                    onChange={() => toggleEmail(a)}
+                  />
+                </td>
+                <td className="p-2 space-x-2">
+                  <button
+                    className="text-qg-accent"
+                    onClick={() => {
+                      setEditing(a);
+                      setOpen(true);
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="text-red-600"
+                    onClick={() => deleteAlert(a.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <AlertModal
+        open={open}
+        onClose={() => setOpen(false)}
+        initial={editing || undefined}
+        onSaved={handleSaved}
+      />
+    </main>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,8 @@ import { useAuth } from '@/context/AuthContext';
 import NotificationDropdown from './NotificationDropdown';
 import WalletDisplay from './WalletDisplay';
 import Button from './ui/Button';
-import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard } from 'lucide-react';
+import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard, Bell } from 'lucide-react';
+import { env } from '@/config/env';
 
 const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
@@ -131,27 +132,36 @@ const Navigation: React.FC = () => {
                 {/* Wallet Display */}
                 <WalletDisplay />
                 
-                <div className="flex items-center space-x-3 ml-4 pl-4 border-l border-qg-navy-light">
-                  <Link
-                    href="/settings/profile"
-                    className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                  >
-                    <User className="w-4 h-4 mr-2" />
-                    <span className="hidden xl:inline">Profile</span>
-                  </Link>
-                  <div className="hidden xl:flex flex-col">
-                    <span className="text-xs text-gray-300">Kumusta,</span>
-                    <span className="text-sm font-medium text-fg">{user?.name}</span>
+                  <div className="flex items-center space-x-3 ml-4 pl-4 border-l border-qg-navy-light">
+                    {env.NEXT_PUBLIC_ENABLE_ALERTS && (
+                      <Link
+                        href="/settings/alerts"
+                        className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                      >
+                        <Bell className="w-4 h-4 mr-2" />
+                        <span className="hidden xl:inline">Alerts</span>
+                      </Link>
+                    )}
+                    <Link
+                      href="/settings/profile"
+                      className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                    >
+                      <User className="w-4 h-4 mr-2" />
+                      <span className="hidden xl:inline">Profile</span>
+                    </Link>
+                    <div className="hidden xl:flex flex-col">
+                      <span className="text-xs text-gray-300">Kumusta,</span>
+                      <span className="text-sm font-medium text-fg">{user?.name}</span>
+                    </div>
+                    <button
+                      onClick={handleLogout}
+                      className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-fg"
+                    >
+                      <LogOut className="w-4 h-4" />
+                      <span className="hidden xl:inline ml-2">Logout</span>
+                    </button>
                   </div>
-                  <button
-                    onClick={handleLogout}
-                    className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-red-600 hover:text-fg"
-                  >
-                    <LogOut className="w-4 h-4" />
-                    <span className="hidden xl:inline ml-2">Logout</span>
-                  </button>
                 </div>
-              </div>
             ) : (
               <div className="flex items-center space-x-3 ml-4 pl-4 border-l border-qg-navy-light">
                 <Link href="/login">
@@ -258,22 +268,32 @@ const Navigation: React.FC = () => {
                     <MessageCircle className="w-5 h-5 mr-3" />
                     Messages
                   </Link>
-                  <Link
-                    href="/payment"
-                    className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                    onClick={() => setIsMenuOpen(false)}
-                  >
-                    <CreditCard className="w-5 h-5 mr-3" />
-                    Payment (Beta)
-                  </Link>
-                  <Link
-                    href="/settings/profile"
-                    className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
-                    onClick={() => setIsMenuOpen(false)}
-                  >
-                    <User className="w-5 h-5 mr-3" />
-                    Profile
-                  </Link>
+                    <Link
+                      href="/payment"
+                      className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      <CreditCard className="w-5 h-5 mr-3" />
+                      Payment (Beta)
+                    </Link>
+                    {env.NEXT_PUBLIC_ENABLE_ALERTS && (
+                      <Link
+                        href="/settings/alerts"
+                        className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <Bell className="w-5 h-5 mr-3" />
+                        Alerts
+                      </Link>
+                    )}
+                    <Link
+                      href="/settings/profile"
+                      className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      <User className="w-5 h-5 mr-3" />
+                      Profile
+                    </Link>
                   
                   <div className="border-t border-qg-navy-light mt-4 pt-4">
                     <button

--- a/src/components/alerts/AlertModal.tsx
+++ b/src/components/alerts/AlertModal.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Input, Select } from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { api } from '@/lib/apiClient';
+import { API, JobFilters } from '@/config/api';
+import { toast } from '@/lib/toast';
+
+export interface AlertData {
+  id?: string | number;
+  name: string;
+  filters: JobFilters;
+  frequency: 'daily' | 'weekly';
+  email: boolean;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initial?: Partial<AlertData>;
+  onSaved?: (data: AlertData) => void;
+}
+
+export default function AlertModal({ open, onClose, initial, onSaved }: Props) {
+  const [name, setName] = useState(initial?.name || '');
+  const [filters, setFilters] = useState<JobFilters>(initial?.filters || {});
+  const [frequency, setFrequency] = useState<'daily' | 'weekly'>(
+    (initial?.frequency as 'daily' | 'weekly') || 'daily'
+  );
+  const [email, setEmail] = useState(initial?.email ?? true);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(initial?.name || '');
+      setFilters(initial?.filters || {});
+      setFrequency((initial?.frequency as 'daily' | 'weekly') || 'daily');
+      setEmail(initial?.email ?? true);
+    }
+  }, [open, initial]);
+
+  if (!open) return null;
+
+  const handleChange = (field: keyof JobFilters) => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value =
+      e.target.type === 'checkbox'
+        ? (e.target as HTMLInputElement).checked
+        : e.target.value;
+    setFilters({ ...filters, [field]: value });
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      toast('Name required');
+      return;
+    }
+    setLoading(true);
+    try {
+      const clean: JobFilters = {
+        q: filters.q || undefined,
+        location: filters.location || undefined,
+        category: filters.category || undefined,
+        type: filters.type || undefined,
+        remote: filters.remote ? true : undefined,
+        minSalary:
+          filters.minSalary !== undefined && filters.minSalary !== null
+            ? Number(filters.minSalary)
+            : undefined,
+        maxSalary:
+          filters.maxSalary !== undefined && filters.maxSalary !== null
+            ? Number(filters.maxSalary)
+            : undefined,
+      };
+      const payload = { name, filters: clean, frequency, email };
+      const res = initial?.id
+        ? await api.patch(API.alertsUpdate(initial.id), payload)
+        : await api.post(API.alertsCreate, payload);
+      toast('Alert saved');
+      onSaved?.(res.data);
+      onClose();
+    } catch {
+      toast('Failed to save alert');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <form onSubmit={submit} className="bg-white p-4 rounded space-y-2 w-full max-w-md">
+        <h2 className="text-lg font-semibold">
+          {initial?.id ? 'Edit Alert' : 'New Alert'}
+        </h2>
+        <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+        <Input
+          label="Keywords"
+          value={filters.q || ''}
+          onChange={handleChange('q')}
+        />
+        <Input
+          label="Location"
+          value={filters.location || ''}
+          onChange={handleChange('location')}
+        />
+        <Input
+          label="Category"
+          value={filters.category || ''}
+          onChange={handleChange('category')}
+        />
+        <Input
+          label="Type"
+          value={filters.type || ''}
+          onChange={handleChange('type')}
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={Boolean(filters.remote)}
+            onChange={handleChange('remote')}
+          />
+          <span>Remote</span>
+        </label>
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            label="Min Salary"
+            value={filters.minSalary ?? ''}
+            onChange={handleChange('minSalary')}
+          />
+          <Input
+            type="number"
+            label="Max Salary"
+            value={filters.maxSalary ?? ''}
+            onChange={handleChange('maxSalary')}
+          />
+        </div>
+        <Select
+          label="Frequency"
+          value={frequency}
+          onChange={(e) => setFrequency(e.target.value as 'daily' | 'weekly')}
+          options={[
+            { value: 'daily', label: 'Daily' },
+            { value: 'weekly', label: 'Weekly' },
+          ]}
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={email}
+            onChange={(e) => setEmail(e.target.checked)}
+          />
+          <span>Email notifications</span>
+        </label>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -27,6 +27,12 @@ export const API = {
   sendMessage: (id: string) => `/messages/send.php?id=${id}`,
   markConversationRead: (id: string) => `/messages/read.php?id=${id}`,
   startConversation: '/messages/start.php',
+  alertsList: '/alerts/list.php',
+  alertsCreate: '/alerts/create.php',
+  alertsUpdate: (id: string | number) => `/alerts/update.php?id=${id}`,
+  alertsDelete: (id: string | number) => `/alerts/delete.php?id=${id}`,
+  alertsToggle: (id: string | number) => `/alerts/toggle.php?id=${id}`,
+  alertsRunDigest: '/alerts/runDigest.php',
 };
 
 export type JobFilters = {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,9 @@ export const env = {
   NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',
   EMPLOYER_EMAILS:
     process.env.EMPLOYER_EMAILS?.split(',').map((e) => e.trim()).filter(Boolean) || [],
+  ALERTS_DIGEST_SECRET: process.env.ALERTS_DIGEST_SECRET || '',
+  NEXT_PUBLIC_ENABLE_ALERTS:
+    String(process.env.NEXT_PUBLIC_ENABLE_ALERTS ?? 'false').toLowerCase() === 'true',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary
- add job-alert API paths and env flags
- create alerts UI with modal, settings page, and jobs page integration
- expose cron route for backend digests and document job alerts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3548f7a88327a39b36914e5ca2a4