### PR TITLE
feat: add admin moderation and reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ NEXT_PUBLIC_SHOW_LOGOUT_ALL=false
 # Job alerts (optional)
 ALERTS_DIGEST_SECRET=change-me
 NEXT_PUBLIC_ENABLE_ALERTS=true
+
+# Admin features
+NEXT_PUBLIC_ENABLE_REPORTS=true
+NEXT_PUBLIC_ENABLE_ADMIN=true
+ADMIN_EMAILS=you@quickgig.ph,moderator@quickgig.ph

--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ Vercel Cron setup:
 Create an alert from the **Create Alert from filters** button on `/jobs` and
 manage them in `/settings/alerts`.
 
+## Reports & Admin Moderation
+
+- `NEXT_PUBLIC_ENABLE_REPORTS` — show reporting UI on jobs and profiles.
+- `NEXT_PUBLIC_ENABLE_ADMIN` — enable admin links in the UI.
+- `ADMIN_EMAILS` — comma-separated allowlist of email addresses treated as admins.
+
+Admin pages live under `/admin` and expect the following backend endpoints
+(see `src/config/api.ts`):
+
+- `GET ${API.adminSummary}` – dashboard counts
+- `GET ${API.adminJobsPending}` – pending jobs
+- `POST ${API.adminJobApprove(id)}` – approve job
+- `POST ${API.adminJobReject(id)}` – reject job
+- `GET ${API.adminReportsList}` – list reports
+- `POST ${API.adminReportResolve(id)}` – resolve report
+- `GET ${API.adminUsersList}` – list users
+- `POST ${API.adminUserBan(id)}` – ban user
+- `POST ${API.adminUserUnban(id)}` – unban user
+- `GET ${API.adminAuditList}` – audit log
+
+Logged-in users can report a job or profile via a small **Report** link, which
+sends `{ type:'job'|'user', targetId, reason, details? }` to
+`${API.reportCreate}`.
+
 ## Authentication
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,7 @@ import { env } from './src/config/env';
 
 const protectedPaths = ['/dashboard', '/settings/profile', '/settings/account'];
 const employerPaths = ['/employer'];
+const adminPaths = ['/admin'];
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -31,6 +32,24 @@ export function middleware(req: NextRequest) {
     }
   }
 
+  if (adminPaths.some((p) => pathname.startsWith(p))) {
+    if (!token) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/';
+      return NextResponse.redirect(url);
+    }
+    const role = req.cookies.get('role')?.value || '';
+    const email = req.cookies.get('email')?.value || '';
+    const isAdmin =
+      ['admin', 'moderator', 'staff'].includes(role.toLowerCase()) ||
+      (email && env.ADMIN_EMAILS.includes(email));
+    if (!isAdmin) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/';
+      return NextResponse.redirect(url);
+    }
+  }
+
   return NextResponse.next();
 }
 
@@ -40,5 +59,6 @@ export const config = {
     '/settings/profile/:path*',
     '/settings/account/:path*',
     '/employer/:path*',
+    '/admin/:path*',
   ],
 };

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+
+interface AuditItem {
+  at: string;
+  actor: string;
+  action: string;
+  target: string;
+  meta?: unknown;
+}
+
+export default function AdminAuditPage() {
+  const [items, setItems] = useState<AuditItem[] | null>(null);
+  const [view, setView] = useState<AuditItem | null>(null);
+
+  useEffect(() => {
+    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminAuditList}`)
+      .then((r) => r.json())
+      .then((d) => setItems((d.items as AuditItem[]) || d))
+      .catch(() => setItems([]));
+  }, []);
+
+  if (!items) return <main className="p-4">Loading...</main>;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Audit Log</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Time</th>
+            <th className="border px-2 py-1">Actor</th>
+            <th className="border px-2 py-1">Action</th>
+            <th className="border px-2 py-1">Target</th>
+            <th className="border px-2 py-1">Meta</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((i, idx) => (
+            <tr key={idx}>
+              <td className="border px-2 py-1">{i.at}</td>
+              <td className="border px-2 py-1">{i.actor}</td>
+              <td className="border px-2 py-1">{i.action}</td>
+              <td className="border px-2 py-1">{i.target}</td>
+              <td className="border px-2 py-1">
+                {i.meta ? (
+                  <button
+                    className="text-blue-600"
+                    onClick={() => setView(i)}
+                  >
+                    View
+                  </button>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {view && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white p-4 rounded max-w-md w-full">
+            <pre className="text-xs overflow-auto max-h-96">
+              {JSON.stringify(view.meta, null, 2)}
+            </pre>
+            <button
+              onClick={() => setView(null)}
+              className="mt-2 px-3 py-1 border rounded"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
+
+interface Job {
+  id: string | number;
+  title: string;
+  company?: string;
+  submittedAt?: string;
+}
+
+export default function AdminJobsPage() {
+  const [jobs, setJobs] = useState<Job[] | null>(null);
+
+  const load = () => {
+    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobsPending}`)
+      .then((r) => r.json())
+      .then((d) => setJobs((d.jobs as Job[]) || d))
+      .catch(() => setJobs([]));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const notify = (to?: string, subject = '', html = '') => {
+    if (!to) return;
+    fetch('/api/notify/moderation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toEmail: to, subject, html }),
+    }).catch(() => {});
+  };
+
+  const approve = async (id: string | number) => {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobApprove(id)}`, {
+      method: 'POST',
+    });
+    const data = await res.json().catch(() => ({}));
+    notify(data.email, 'Job approved', 'Your job was approved.');
+    toast('Job approved');
+    load();
+  };
+
+  const reject = async (id: string | number) => {
+    const reason = prompt('Reason (optional)') || '';
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobReject(id)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason }),
+    });
+    const data = await res.json().catch(() => ({}));
+    notify(data.email, 'Job rejected', 'Your job was rejected.');
+    toast('Job rejected');
+    load();
+  };
+
+  if (!jobs) return <main className="p-4">Loading...</main>;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Pending Jobs</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">Title</th>
+            <th className="border px-2 py-1 text-left">Company</th>
+            <th className="border px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((j) => (
+            <tr key={j.id}>
+              <td className="border px-2 py-1">{j.title}</td>
+              <td className="border px-2 py-1">{j.company}</td>
+              <td className="border px-2 py-1 space-x-2">
+                <button
+                  onClick={() => approve(j.id)}
+                  className="text-green-600"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => reject(j.id)}
+                  className="text-red-600"
+                >
+                  Reject
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}
+

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,200 +1,48 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
 
-interface DashboardStats {
-  totalUsers: number;
-  totalJobs: number;
-  totalTransactions: number;
-  totalRevenue: number;
-  recentActivity: Array<{ type: string; message: string; time: string }>;
+interface Summary {
+  counts?: { pendingJobs?: number; reports?: number; users?: number };
 }
 
-const AdminDashboard: React.FC = () => {
-  const router = useRouter();
-  const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState<DashboardStats | null>(null);
+export default function AdminDashboard() {
+  const [summary, setSummary] = useState<Summary | null>(null);
 
   useEffect(() => {
-    // Simulate loading stats
-    setTimeout(() => {
-      setStats({
-        totalUsers: 1250,
-        totalJobs: 450,
-        totalTransactions: 150,
-        totalRevenue: 15000,
-        recentActivity: [
-          { type: 'user_registered', message: 'New user registered: Maria Santos', time: '2 minutes ago' },
-          { type: 'job_posted', message: 'New job posted: Web Developer', time: '5 minutes ago' },
-          { type: 'payment_received', message: 'Payment received: ₱100', time: '10 minutes ago' },
-        ]
-      });
-      setLoading(false);
-    }, 1000);
+    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminSummary}`)
+      .then((r) => r.json())
+      .then(setSummary)
+      .catch(() => setSummary({}));
   }, []);
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading dashboard...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-6">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
-              <p className="text-gray-600">QuickGig.ph Platform Management</p>
-            </div>
-            <button
-              onClick={() => router.push('/')}
-              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-            >
-              View Site
-            </button>
-          </div>
-        </div>
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Link href="/admin/jobs" className="border rounded p-4 block">
+          <p className="text-sm">Pending Jobs</p>
+          <p className="text-2xl font-semibold">
+            {summary?.counts?.pendingJobs ?? 0}
+          </p>
+        </Link>
+        <Link href="/admin/reports" className="border rounded p-4 block">
+          <p className="text-sm">Open Reports</p>
+          <p className="text-2xl font-semibold">
+            {summary?.counts?.reports ?? 0}
+          </p>
+        </Link>
+        <Link href="/admin/users" className="border rounded p-4 block">
+          <p className="text-sm">Banned Users</p>
+          <p className="text-2xl font-semibold">
+            {summary?.counts?.users ?? 0}
+          </p>
+        </Link>
       </div>
-
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center">
-              <div className="p-2 bg-blue-100 rounded-lg">
-                <span className="text-blue-600 text-xl">👥</span>
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Total Users</p>
-                <p className="text-2xl font-bold text-gray-900">{stats?.totalUsers}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center">
-              <div className="p-2 bg-green-100 rounded-lg">
-                <span className="text-green-600 text-xl">💼</span>
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Total Jobs</p>
-                <p className="text-2xl font-bold text-gray-900">{stats?.totalJobs}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center">
-              <div className="p-2 bg-purple-100 rounded-lg">
-                <span className="text-purple-600 text-xl">💳</span>
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Transactions</p>
-                <p className="text-2xl font-bold text-gray-900">{stats?.totalTransactions}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center">
-              <div className="p-2 bg-yellow-100 rounded-lg">
-                <span className="text-yellow-600 text-xl">₱</span>
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Revenue</p>
-                <p className="text-2xl font-bold text-gray-900">₱{stats?.totalRevenue?.toLocaleString()}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Quick Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <button
-            onClick={() => router.push('/admin/users')}
-            className="bg-white rounded-lg shadow p-6 text-left hover:shadow-lg transition-shadow"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900">Manage Users</h3>
-                <p className="text-gray-600">View and manage user accounts</p>
-              </div>
-              <span className="text-2xl">👥</span>
-            </div>
-          </button>
-
-          <button
-            onClick={() => router.push('/admin/transactions')}
-            className="bg-white rounded-lg shadow p-6 text-left hover:shadow-lg transition-shadow"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900">Transactions</h3>
-                <p className="text-gray-600">Monitor payment transactions</p>
-              </div>
-              <span className="text-2xl">💳</span>
-            </div>
-          </button>
-
-          <button
-            onClick={() => router.push('/admin/analytics')}
-            className="bg-white rounded-lg shadow p-6 text-left hover:shadow-lg transition-shadow"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900">Analytics</h3>
-                <p className="text-gray-600">View sales and performance data</p>
-              </div>
-              <span className="text-2xl">📊</span>
-            </div>
-          </button>
-        </div>
-
-        {/* Recent Activity */}
-        <div className="bg-white rounded-lg shadow">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-lg font-semibold text-gray-900">Recent Activity</h2>
-          </div>
-          <div className="p-6">
-            <div className="space-y-4">
-              {stats?.recentActivity?.map((activity: { message: string; time: string }, index: number) => (
-                <div key={index} className="flex items-center space-x-3">
-                  <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
-                  <div className="flex-1">
-                    <p className="text-gray-900">{activity.message}</p>
-                    <p className="text-sm text-gray-500">{activity.time}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        {/* Platform Status */}
-        <div className="mt-8 bg-green-50 border border-green-200 rounded-lg p-6">
-          <div className="flex items-center">
-            <div className="w-3 h-3 bg-green-500 rounded-full mr-3"></div>
-            <div>
-              <h3 className="text-lg font-semibold text-green-800">Platform Status: LIVE</h3>
-              <p className="text-green-700">
-                QuickGig.ph is fully operational with Facebook integration, payment gateways, and all core features.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    </main>
   );
-};
-
-export default AdminDashboard;
+}
 

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
+
+interface Report {
+  id: string | number;
+  type: string;
+  target?: string;
+  reason: string;
+  submittedBy?: string;
+  createdAt?: string;
+  userId?: string | number;
+}
+
+export default function AdminReportsPage() {
+  const [reports, setReports] = useState<Report[] | null>(null);
+
+  const load = () => {
+    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminReportsList}`)
+      .then((r) => r.json())
+      .then((d) => setReports((d.reports as Report[]) || d))
+      .catch(() => setReports([]));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const notify = (to?: string, subject = '', html = '') => {
+    if (!to) return;
+    fetch('/api/notify/moderation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toEmail: to, subject, html }),
+    }).catch(() => {});
+  };
+
+  const act = async (id: string | number, action: 'dismiss' | 'remove' | 'ban', userId?: string | number) => {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminReportResolve(id)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (action === 'ban' && userId) {
+      const banRes = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUserBan(userId)}`, {
+        method: 'POST',
+      });
+      const banData = await banRes.json().catch(() => ({}));
+      notify(banData.email || data.email, 'Account banned', 'Your account was banned.');
+    }
+    toast('Report updated');
+    load();
+  };
+
+  if (!reports) return <main className="p-4">Loading...</main>;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Reports</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Type</th>
+            <th className="border px-2 py-1">Target</th>
+            <th className="border px-2 py-1">Reason</th>
+            <th className="border px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {reports.map((r) => (
+            <tr key={r.id}>
+              <td className="border px-2 py-1">{r.type}</td>
+              <td className="border px-2 py-1">{r.target}</td>
+              <td className="border px-2 py-1">{r.reason}</td>
+              <td className="border px-2 py-1 space-x-2">
+                <button onClick={() => act(r.id, 'dismiss')} className="text-gray-600">
+                  Dismiss
+                </button>
+                <button onClick={() => act(r.id, 'remove')} className="text-red-600">
+                  Remove
+                </button>
+                <button onClick={() => act(r.id, 'ban', r.userId)} className="text-red-800">
+                  Ban
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}
+

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,204 +1,125 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
 
-interface AdminUserRow {
-  id: string;
+interface UserRow {
+  id: string | number;
   name: string;
   email: string;
-  role: string;
-  ticketBalance: number;
-  createdAt: string;
-  authProvider: string;
+  status?: string;
+  joined?: string;
 }
 
-const AdminUsersPage: React.FC = () => {
-  const router = useRouter();
-  const [loading, setLoading] = useState(true);
-  const [users, setUsers] = useState<AdminUserRow[]>([]);
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState<UserRow[] | null>(null);
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('active');
+
+  const load = () => {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (status) params.set('status', status);
+    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUsersList}?${params.toString()}`)
+      .then((r) => r.json())
+      .then((d) => setUsers((d.users as UserRow[]) || d))
+      .catch(() => setUsers([]));
+  };
 
   useEffect(() => {
-    // Simulate loading users
-    setTimeout(() => {
-      setUsers([
-        {
-          id: '1',
-          name: 'Maria Santos',
-          email: 'maria@example.com',
-          role: 'Job Seeker',
-          ticketBalance: 5,
-          createdAt: '2024-01-15',
-          authProvider: 'local'
-        },
-        {
-          id: '2',
-          name: 'Juan Dela Cruz',
-          email: 'juan@example.com',
-          role: 'Employer',
-          ticketBalance: 10,
-          createdAt: '2024-01-20',
-          authProvider: 'facebook'
-        },
-        {
-          id: '3',
-          name: 'Anna Reyes',
-          email: 'anna@example.com',
-          role: 'Job Seeker',
-          ticketBalance: 3,
-          createdAt: '2024-02-01',
-          authProvider: 'local'
-        }
-      ]);
-      setLoading(false);
-    }, 1000);
-  }, []);
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading users...</p>
-        </div>
-      </div>
-    );
-  }
+  const notify = (to?: string, subject = '', html = '') => {
+    if (!to) return;
+    fetch('/api/notify/moderation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toEmail: to, subject, html }),
+    }).catch(() => {});
+  };
+
+  const ban = async (id: string | number) => {
+    const reason = prompt('Reason (optional)') || '';
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUserBan(id)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason }),
+    });
+    const data = await res.json().catch(() => ({}));
+    notify(data.email, 'Account banned', 'Your account was banned.');
+    toast('User banned');
+    load();
+  };
+
+  const unban = async (id: string | number) => {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUserUnban(id)}`, {
+      method: 'POST',
+    });
+    const data = await res.json().catch(() => ({}));
+    notify(data.email, 'Account unbanned', 'Your account was unbanned.');
+    toast('User unbanned');
+    load();
+  };
+
+  if (!users) return <main className="p-4">Loading...</main>;
 
   return (
-    <div className="min-h-screen bg-gray-50 p-6">
-      <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <button
-            onClick={() => router.push('/admin')}
-            className="flex items-center text-blue-600 hover:text-blue-800 mb-4"
-          >
-            ← Back to Admin Dashboard
-          </button>
-          <h1 className="text-3xl font-bold text-gray-900">User Management</h1>
-          <p className="text-gray-600">Manage user accounts and ticket balances</p>
-        </div>
-
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <div className="flex justify-between items-center">
-              <h2 className="text-lg font-semibold text-gray-900">All Users ({users.length})</h2>
-              <div className="flex space-x-2">
-                <input
-                  type="text"
-                  placeholder="Search users..."
-                  className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <button className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700">
-                  Search
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    User
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Role
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Tickets
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Auth Provider
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Joined
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {users.map((user) => (
-                  <tr key={user.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
-                          <span className="text-blue-600 font-medium">
-                            {user.name.charAt(0)}
-                          </span>
-                        </div>
-                        <div className="ml-4">
-                          <div className="text-sm font-medium text-gray-900">{user.name}</div>
-                          <div className="text-sm text-gray-500">{user.email}</div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                        user.role === 'Admin' 
-                          ? 'bg-red-100 text-red-800'
-                          : user.role === 'Employer'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-blue-100 text-blue-800'
-                      }`}>
-                        {user.role}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      <div className="flex items-center">
-                        <span className="mr-2">🎫</span>
-                        {user.ticketBalance}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      <div className="flex items-center">
-                        {user.authProvider === 'facebook' ? (
-                          <span className="text-blue-600">📘 Facebook</span>
-                        ) : (
-                          <span className="text-gray-600">📧 Email</span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {new Date(user.createdAt).toLocaleDateString()}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                      <div className="flex space-x-2">
-                        <button className="text-blue-600 hover:text-blue-900">
-                          Edit
-                        </button>
-                        <button className="text-green-600 hover:text-green-900">
-                          Add Tickets
-                        </button>
-                        <button className="text-red-600 hover:text-red-900">
-                          Suspend
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div className="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <h3 className="text-lg font-semibold text-blue-800 mb-2">User Management Features</h3>
-          <ul className="text-blue-700 space-y-1">
-            <li>• View all registered users and their details</li>
-            <li>• Manage ticket balances for users</li>
-            <li>• Track authentication providers (Email, Facebook)</li>
-            <li>• Monitor user roles and permissions</li>
-            <li>• Suspend or activate user accounts</li>
-          </ul>
-        </div>
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Users</h1>
+      <div className="flex gap-2">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search"
+          className="border px-2 py-1"
+        />
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="active">Active</option>
+          <option value="banned">Banned</option>
+        </select>
+        <button onClick={load} className="px-3 py-1 border rounded">
+          Go
+        </button>
       </div>
-    </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">Name</th>
+            <th className="border px-2 py-1 text-left">Email</th>
+            <th className="border px-2 py-1">Status</th>
+            <th className="border px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              <td className="border px-2 py-1">{u.name}</td>
+              <td className="border px-2 py-1">{u.email}</td>
+              <td className="border px-2 py-1">{u.status}</td>
+              <td className="border px-2 py-1 space-x-2">
+                {u.status === 'banned' ? (
+                  <button onClick={() => unban(u.id)} className="text-green-600">
+                    Unban
+                  </button>
+                ) : (
+                  <button onClick={() => ban(u.id)} className="text-red-600">
+                    Ban
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
   );
-};
-
-export default AdminUsersPage;
+}
 

--- a/src/app/api/notify/moderation/route.ts
+++ b/src/app/api/notify/moderation/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { sendMail } from '@/server/mailer';
+
+export async function POST(req: Request) {
+  const { toEmail, subject, html } = await req.json().catch(() => ({}));
+  if (!toEmail || !subject || !html) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+  try {
+    await sendMail({ to: toEmail, subject, html });
+  } catch {
+    // ignore
+  }
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/session/me/route.ts
+++ b/src/app/api/session/me/route.ts
@@ -34,6 +34,9 @@ export async function GET(req: NextRequest) {
   if (data.user?.role) {
     response.cookies.set('role', data.user.role);
   }
+  if (data.user?.email) {
+    response.cookies.set('email', data.user.email);
+  }
   response.cookies.set('isEmployer', String(isEmployer));
 
   return response;

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -2,8 +2,10 @@ import { API } from '@/config/api';
 import { env } from '@/config/env';
 import ApplyButton from '../apply-button';
 import SaveJobButton from '@/components/SaveJobButton';
+import ReportButton from '@/components/ReportButton';
 import type { Job } from '@/types/jobs';
 import { canonical } from '@/lib/canonical';
+import { getUser } from '@/auth/getUser';
 
 interface JobPageProps {
   params: { id: string };
@@ -37,6 +39,7 @@ export async function generateMetadata({ params }: JobPageProps) {
 
 export default async function JobPage({ params }: JobPageProps) {
   let job: Job;
+  const user = await getUser();
   try {
     job = await fetchJob(params.id);
   } catch (err) {
@@ -79,6 +82,9 @@ export default async function JobPage({ params }: JobPageProps) {
             </li>
           ))}
         </ul>
+      ) : null}
+      {user ? (
+        <ReportButton type="job" targetId={job.id} />
       ) : null}
     </main>
   );

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import { cookies } from 'next/headers';
+import ReportButton from '@/components/ReportButton';
+import { getUser } from '@/auth/getUser';
 
 async function fetchUser(id: string) {
   const path = id === 'me' ? API.me : API.publicUser(id);
@@ -14,6 +16,7 @@ async function fetchUser(id: string) {
 
 export default async function PublicProfilePage({ params }: { params: { id: string } }) {
   const data = await fetchUser(params.id);
+  const me = await getUser();
   if (!data) return <main className="p-4">Profile not found</main>;
   return (
     <main className="p-4 space-y-4 max-w-2xl">
@@ -40,6 +43,7 @@ export default async function PublicProfilePage({ params }: { params: { id: stri
           Download Resume
         </a>
       )}
+      {me ? <ReportButton type="user" targetId={data.id || params.id} /> : null}
     </main>
   );
 }

--- a/src/auth/isAdmin.ts
+++ b/src/auth/isAdmin.ts
@@ -1,0 +1,10 @@
+import { env } from '@/config/env';
+
+export function isAdmin(user?: { role?: string; email?: string } | null) {
+  if (!user) return false;
+  if (user.role && ['admin', 'moderator', 'staff'].includes(user.role.toLowerCase()))
+    return true;
+  if (user.email && env.ADMIN_EMAILS.includes(user.email)) return true;
+  return false;
+}
+

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,6 +10,7 @@ import WalletDisplay from './WalletDisplay';
 import Button from './ui/Button';
 import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard, Bell } from 'lucide-react';
 import { env } from '@/config/env';
+import { isAdmin } from '@/auth/isAdmin';
 
 const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
@@ -101,7 +102,7 @@ const Navigation: React.FC = () => {
                     <Home className="w-4 h-4 mr-2" />
                     Dashboard
                   </Link>
-                {user?.role === 'Admin' && (
+                {isAdmin(user) && env.NEXT_PUBLIC_ENABLE_ADMIN && (
                   <Link
                     href="/admin"
                     className="qg-navbar-link flex items-center px-4 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
@@ -222,7 +223,7 @@ const Navigation: React.FC = () => {
                       Dashboard
                     </Link>
                   
-                  {user?.role === 'Admin' && (
+                  {isAdmin(user) && env.NEXT_PUBLIC_ENABLE_ADMIN && (
                     <Link
                       href="/admin"
                       className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { toast } from '@/lib/toast';
+
+interface Props {
+  targetId: string | number;
+  type: 'job' | 'user';
+}
+
+export default function ReportButton({ targetId, type }: Props) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('Scam');
+  const [details, setDetails] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!env.NEXT_PUBLIC_ENABLE_REPORTS) return null;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await fetch(`${env.NEXT_PUBLIC_API_URL}${API.reportCreate}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, targetId, reason, details }),
+      });
+      toast('Thanks — our moderators will review.');
+      setOpen(false);
+      setReason('Scam');
+      setDetails('');
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="text-sm text-red-600 hover:underline"
+      >
+        Report
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <form
+            onSubmit={submit}
+            className="bg-white rounded p-4 w-full max-w-sm space-y-2"
+          >
+            <h2 className="text-lg font-semibold">Report {type}</h2>
+            <select
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full border px-2 py-1"
+            >
+              <option>Scam</option>
+              <option>Inappropriate</option>
+              <option>Spam</option>
+              <option>Other</option>
+            </select>
+            <textarea
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              placeholder="Details (optional)"
+              className="w-full border px-2 py-1"
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="px-3 py-1 border rounded"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={loading}
+                className="px-3 py-1 bg-red-600 text-white rounded disabled:opacity-50"
+              >
+                Submit
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -33,6 +33,24 @@ export const API = {
   alertsDelete: (id: string | number) => `/alerts/delete.php?id=${id}`,
   alertsToggle: (id: string | number) => `/alerts/toggle.php?id=${id}`,
   alertsRunDigest: '/alerts/runDigest.php',
+
+  // Reports (public)
+  reportCreate: '/reports/create.php', // POST { type:'job'|'user', targetId, reason, details? }
+
+  // Admin moderation
+  adminSummary: '/admin/summary.php', // GET { counts: { pendingJobs, reports, users } }
+  adminJobsPending: '/admin/jobs/pending.php', // GET list of pending jobs
+  adminJobApprove: (id: string | number) => `/admin/jobs/approve.php?id=${id}`, // POST {}
+  adminJobReject: (id: string | number) => `/admin/jobs/reject.php?id=${id}`, // POST { reason? }
+
+  adminReportsList: '/admin/reports/list.php', // GET
+  adminReportResolve: (id: string | number) => `/admin/reports/resolve.php?id=${id}`, // POST { action:'dismiss'|'remove'|'ban' }
+  adminUsersList: '/admin/users/list.php', // GET (supports ?q=&status=active|banned)
+  adminUserBan: (id: string | number) => `/admin/users/ban.php?id=${id}`, // POST { reason? }
+  adminUserUnban: (id: string | number) => `/admin/users/unban.php?id=${id}`, // POST {}
+
+  // Audit
+  adminAuditList: '/admin/audit/list.php', // GET { items:[{at,actor,action,target,meta}] }
 };
 
 export type JobFilters = {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -18,6 +18,14 @@ export const env = {
   ALERTS_DIGEST_SECRET: process.env.ALERTS_DIGEST_SECRET || '',
   NEXT_PUBLIC_ENABLE_ALERTS:
     String(process.env.NEXT_PUBLIC_ENABLE_ALERTS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_REPORTS:
+    String(process.env.NEXT_PUBLIC_ENABLE_REPORTS ?? 'true').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_ADMIN:
+    String(process.env.NEXT_PUBLIC_ENABLE_ADMIN ?? 'true').toLowerCase() === 'true',
+  ADMIN_EMAILS: (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ export interface User {
   name: string;
   email: string;
   phone: string;
-  role: 'Job Seeker' | 'Employer' | 'Admin';
+  role?: string;
   isEmployer?: boolean;
   ticketBalance?: number;
   createdAt?: string;


### PR DESCRIPTION
## Summary
- support reporting and moderation features with new API paths and env flags
- add admin checks and middleware, navigation link, and moderation pages
- include user-facing report modal and email notification route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f386f8a98832799a90d41c12041a6