### PR TITLE
feat: add metrics tracking and admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ NEXT_PUBLIC_ENABLE_ALERTS=true
 NEXT_PUBLIC_ENABLE_REPORTS=true
 NEXT_PUBLIC_ENABLE_ADMIN=true
 ADMIN_EMAILS=you@quickgig.ph,moderator@quickgig.ph
+
+# Metrics (optional)
+NEXT_PUBLIC_ENABLE_ANALYTICS=true
+METRICS_SECRET=change-me

--- a/README.md
+++ b/README.md
@@ -97,6 +97,32 @@ Logged-in users can report a job or profile via a small **Report** link, which
 sends `{ type:'job'|'user', targetId, reason, details? }` to
 `${API.reportCreate}`.
 
+## Metrics
+
+- `NEXT_PUBLIC_ENABLE_ANALYTICS` – enable client event tracking
+- `METRICS_SECRET` – optional shared secret for backend validation
+
+Tracked events:
+
+- `view_home` – homepage viewed
+- `view_jobs` – jobs list viewed
+- `view_job` – job detail viewed `{ id }`
+- `signup_success` – registration completed
+- `login_success` – login completed
+- `apply_success` – job application submitted `{ jobId }`
+- `message_send` – message sent `{ conversationId }`
+- `job_post` – employer created a job
+- `job_publish` – employer published a job
+- `alert_create` – job alert created
+
+Backend endpoints (see `src/config/api.ts`):
+
+- `POST ${API.metricsTrack}` – proxy from `/api/metrics/track`
+- `GET ${API.metricsSummary}` – summary counts
+- `GET ${API.metricsTimeseries}` – timeseries data
+
+The frontend never blocks or fails the UI if the metrics backend is absent; `/api/metrics/track` always returns `{ ok: true }`.
+
 ## Authentication
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -6,6 +6,8 @@ import Button from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
 import { Briefcase, MousePointerClick, Shield } from 'lucide-react';
 import { checkHealth } from '@/lib/api';
+import { track } from '@/lib/track';
+import { env } from '@/config/env';
 
 type ApiStatus = 'loading' | 'ok' | 'error';
 
@@ -13,6 +15,7 @@ export default function HomePageClient() {
   const [status, setStatus] = useState<ApiStatus>('loading');
 
   useEffect(() => {
+    if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('view_home');
     checkHealth()
       .then((res) => setStatus(res.ok ? 'ok' : 'error'))
       .catch((err) => {

--- a/src/app/admin/metrics/page.tsx
+++ b/src/app/admin/metrics/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+import MiniSparkline from '@/components/MiniSparkline';
+
+interface Summary {
+  signups?: number;
+  applies?: number;
+  messages?: number;
+  jobPosts?: number;
+  topJobs?: { id: string | number; title: string; views: number }[];
+}
+
+type Series = Record<string, number[]>;
+
+export default function AdminMetricsPage() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [series, setSeries] = useState<Series>({});
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const sRes = await fetch(`${env.API_URL}${API.metricsSummary}?range=7`);
+        const sJson = await sRes.json();
+        setSummary(sJson || {});
+        const metrics = ['signups', 'applies', 'messages', 'job_posts'];
+        const ts: Series = {};
+        await Promise.all(
+          metrics.map(async (m) => {
+            try {
+              const r = await fetch(
+                `${env.API_URL}${API.metricsTimeseries}?metric=${m}&range=30`,
+              );
+              const j = await r.json();
+              ts[m] = Array.isArray(j) ? j : j.values || [];
+            } catch {
+              ts[m] = [];
+            }
+          }),
+        );
+        setSeries(ts);
+      } catch {
+        setError(true);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Metrics</h1>
+      {!summary ? (
+        <p>Backend metrics API not available yet.</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="border rounded p-4">
+              <p className="text-sm">Signups</p>
+              <p className="text-2xl font-semibold">{summary.signups ?? 0}</p>
+              <MiniSparkline data={series.signups || []} className="w-full h-12 mt-2" />
+            </div>
+            <div className="border rounded p-4">
+              <p className="text-sm">Applies</p>
+              <p className="text-2xl font-semibold">{summary.applies ?? 0}</p>
+              <MiniSparkline data={series.applies || []} className="w-full h-12 mt-2" />
+            </div>
+            <div className="border rounded p-4">
+              <p className="text-sm">Messages</p>
+              <p className="text-2xl font-semibold">{summary.messages ?? 0}</p>
+              <MiniSparkline data={series.messages || []} className="w-full h-12 mt-2" />
+            </div>
+            <div className="border rounded p-4">
+              <p className="text-sm">Job Posts</p>
+              <p className="text-2xl font-semibold">{summary.jobPosts ?? 0}</p>
+              <MiniSparkline data={series['job_posts'] || []} className="w-full h-12 mt-2" />
+            </div>
+          </div>
+          {summary.topJobs?.length ? (
+            <div>
+              <h2 className="text-lg font-semibold mt-6 mb-2">Top job views</h2>
+              <table className="min-w-full border text-sm">
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1 text-left">Job</th>
+                    <th className="border px-2 py-1">Views</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.topJobs.map((j) => (
+                    <tr key={j.id}>
+                      <td className="border px-2 py-1">{j.title}</td>
+                      <td className="border px-2 py-1 text-right">{j.views}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </>
+      )}
+      {error && <p className="text-sm text-red-600">Backend metrics API not available yet</p>}
+    </main>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -22,7 +22,7 @@ export default function AdminDashboard() {
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Admin Dashboard</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
         <Link href="/admin/jobs" className="border rounded p-4 block">
           <p className="text-sm">Pending Jobs</p>
           <p className="text-2xl font-semibold">
@@ -40,6 +40,9 @@ export default function AdminDashboard() {
           <p className="text-2xl font-semibold">
             {summary?.counts?.users ?? 0}
           </p>
+        </Link>
+        <Link href="/admin/metrics" className="border rounded p-4 block">
+          <p className="text-sm">Metrics</p>
         </Link>
       </div>
     </main>

--- a/src/app/api/metrics/track/route.ts
+++ b/src/app/api/metrics/track/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { env } from '@/config/env';
+import { API } from '@/config/api';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const ua = req.headers.get('user-agent') || '';
+    const ip = req.headers.get('x-forwarded-for') || req.ip || '';
+    const fwd = await fetch(`${env.API_URL}${API.metricsTrack}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...body, ua, ip, secret: env.METRICS_SECRET }),
+    });
+    return NextResponse.json({ ok: fwd.ok }, { status: 200 });
+  } catch {
+    return NextResponse.json({ ok: true, skipped: 'backend' }, { status: 200 });
+  }
+}
+
+export const GET = POST;

--- a/src/app/employer/jobs/new/page.tsx
+++ b/src/app/employer/jobs/new/page.tsx
@@ -4,12 +4,15 @@ import { useRouter } from 'next/navigation';
 import JobForm, { JobFormData } from '@/components/JobForm';
 import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 export default function NewJobPage() {
   const router = useRouter();
 
   const handleSubmit = async (data: JobFormData) => {
     await api.post(API.createJob, data);
+    if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('job_post');
     router.push('/employer/jobs');
   };
 

--- a/src/app/employer/jobs/page.tsx
+++ b/src/app/employer/jobs/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 interface MyJob {
   id: number | string;
@@ -36,6 +38,7 @@ export default function EmployerJobsPage() {
     try {
       await api.post(API.toggleJob(id), { published: !published });
       await load();
+      if (!published && env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('job_publish');
     } catch {
       // ignore
     }

--- a/src/app/jobs/[id]/TrackView.tsx
+++ b/src/app/jobs/[id]/TrackView.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+import { track } from '@/lib/track';
+import { env } from '@/config/env';
+
+export default function TrackView({ id }: { id: string | number }) {
+  useEffect(() => {
+    if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('view_job', { id });
+  }, [id]);
+  return null;
+}

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -6,6 +6,7 @@ import ReportButton from '@/components/ReportButton';
 import type { Job } from '@/types/jobs';
 import { canonical } from '@/lib/canonical';
 import { getUser } from '@/auth/getUser';
+import TrackView from './TrackView';
 
 interface JobPageProps {
   params: { id: string };
@@ -60,6 +61,7 @@ export default async function JobPage({ params }: JobPageProps) {
 
   return (
     <main className="p-4 space-y-4">
+      <TrackView id={job.id} />
       <div>
         <h1 className="text-xl font-semibold">{job.title}</h1>
         <p className="text-sm text-gray-600">

--- a/src/app/jobs/apply-button.tsx
+++ b/src/app/jobs/apply-button.tsx
@@ -5,6 +5,7 @@ import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
+import { track } from '@/lib/track';
 
 interface ApplyProps {
   jobId: string;
@@ -67,6 +68,8 @@ export default function ApplyButton({ jobId, title }: ApplyProps) {
       }).catch(() => {});
       toast('Application submitted');
       setSubmitted(true);
+      if (env.NEXT_PUBLIC_ENABLE_ANALYTICS)
+        track('apply_success', { jobId });
     } catch (err) {
       if (axios.isAxiosError(err) && err.response) {
         const status = err.response.status;

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -12,6 +12,7 @@ import JobsFilters from '@/components/jobs/JobsFilters';
 import { getSavedIds, hydrateSavedIds } from '@/lib/savedJobs';
 import AlertModal from '@/components/alerts/AlertModal';
 import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 function JobsPageContent() {
   const router = useRouter();
@@ -102,6 +103,10 @@ function JobsPageContent() {
 
   useEffect(() => {
     hydrateSavedIds();
+  }, []);
+
+  useEffect(() => {
+    if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('view_jobs');
   }, []);
 
   const totalPages = Math.ceil(total / (filters.limit || 20));

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -22,6 +24,7 @@ export default function LoginPage() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || 'Login failed');
+      if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('login_success');
       router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');

--- a/src/app/messages/[id]/page.tsx
+++ b/src/app/messages/[id]/page.tsx
@@ -5,6 +5,8 @@ import { MessageList } from '@/components/messages/MessageList';
 import { Composer } from '@/components/messages/Composer';
 import { usePolling } from '@/hooks/usePolling';
 import { Thread } from '@/types/messages';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 export default function ThreadPage() {
   const params = useParams<{ id: string }>();
@@ -36,6 +38,8 @@ export default function ThreadPage() {
       body: JSON.stringify({ body }),
     }).catch(() => {});
     await load();
+    if (env.NEXT_PUBLIC_ENABLE_ANALYTICS)
+      track('message_send', { conversationId: id });
   }
 
   return (

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -23,6 +25,7 @@ export default function RegisterPage() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || 'Registration failed');
+      if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('signup_success');
       router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');

--- a/src/components/MiniSparkline.tsx
+++ b/src/components/MiniSparkline.tsx
@@ -1,0 +1,39 @@
+'use client';
+interface Props {
+  data: number[];
+  className?: string;
+}
+export default function MiniSparkline({ data, className = '' }: Props) {
+  const w = 100;
+  const h = 30;
+  if (!data.length) {
+    return <svg viewBox={`0 0 ${w} ${h}`} className={className} />;
+  }
+  const max = Math.max(...data);
+  const points = data
+    .map((d, i) => {
+      const x = (i / (data.length - 1 || 1)) * w;
+      const y = h - (d / (max || 1)) * h;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  const min = Math.min(...data);
+  const minI = data.indexOf(min);
+  const maxI = data.indexOf(max);
+  const minX = (minI / (data.length - 1 || 1)) * w;
+  const minY = h - (min / (max || 1)) * h;
+  const maxX = (maxI / (data.length - 1 || 1)) * w;
+  const maxY = h - (max / (max || 1)) * h;
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} className={className}>
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        points={points}
+      />
+      <circle cx={minX} cy={minY} r="1.5" />
+      <circle cx={maxX} cy={maxY} r="1.5" />
+    </svg>
+  );
+}

--- a/src/components/alerts/AlertModal.tsx
+++ b/src/components/alerts/AlertModal.tsx
@@ -6,6 +6,8 @@ import Button from '@/components/ui/Button';
 import { api } from '@/lib/apiClient';
 import { API, JobFilters } from '@/config/api';
 import { toast } from '@/lib/toast';
+import { env } from '@/config/env';
+import { track } from '@/lib/track';
 
 export interface AlertData {
   id?: string | number;
@@ -76,10 +78,12 @@ export default function AlertModal({ open, onClose, initial, onSaved }: Props) {
             : undefined,
       };
       const payload = { name, filters: clean, frequency, email };
-      const res = initial?.id
-        ? await api.patch(API.alertsUpdate(initial.id), payload)
-        : await api.post(API.alertsCreate, payload);
+      const creating = !initial?.id;
+      const res = creating
+        ? await api.post(API.alertsCreate, payload)
+        : await api.patch(API.alertsUpdate(initial!.id!), payload);
       toast('Alert saved');
+      if (creating && env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('alert_create');
       onSaved?.(res.data);
       onClose();
     } catch {

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -51,6 +51,11 @@ export const API = {
 
   // Audit
   adminAuditList: '/admin/audit/list.php', // GET { items:[{at,actor,action,target,meta}] }
+
+  // Metrics
+  metricsTrack: '/metrics/track.php', // POST { event, props, userId?, sessionId?, ua, ip, ref }
+  metricsSummary: '/metrics/summary.php', // GET { range=7|30|90 }
+  metricsTimeseries: '/metrics/timeseries.php', // GET { metric, range }
 };
 
 export type JobFilters = {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -26,6 +26,9 @@ export const env = {
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean),
+  NEXT_PUBLIC_ENABLE_ANALYTICS:
+    String(process.env.NEXT_PUBLIC_ENABLE_ANALYTICS ?? 'true').toLowerCase() === 'true',
+  METRICS_SECRET: process.env.METRICS_SECRET || '',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/lib/sessionId.ts
+++ b/src/lib/sessionId.ts
@@ -1,0 +1,11 @@
+export function getSessionId() {
+  if (typeof document === 'undefined') return '';
+  const KEY = 'quickgig_sid';
+  let sid = localStorage.getItem(KEY);
+  if (!sid) {
+    sid =
+      (crypto?.randomUUID?.() || String(Date.now()) + Math.random().toString(16).slice(2));
+    localStorage.setItem(KEY, sid);
+  }
+  return sid;
+}

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,0 +1,29 @@
+'use client';
+import { env } from '@/config/env';
+import { getSessionId } from './sessionId';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function track(event: string, props: Record<string, any> = {}) {
+  if (!env.NEXT_PUBLIC_ENABLE_ANALYTICS) return;
+  try {
+    const body = JSON.stringify({
+      event,
+      props,
+      sessionId: getSessionId(),
+      ref: typeof document !== 'undefined' ? document.referrer || '' : '',
+    });
+    const url = '/api/metrics/track';
+    if (typeof navigator !== 'undefined' && 'sendBeacon' in navigator) {
+      const blob = new Blob([body], { type: 'application/json' });
+      navigator.sendBeacon(url, blob);
+    } else {
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      }).catch(() => {});
+    }
+  } catch {
+    // swallow
+  }
+}


### PR DESCRIPTION
## Summary
- add env and API config for optional analytics backend
- implement client tracker with session IDs and non-blocking send
- proxy `/api/metrics/track` to backend and render `/admin/metrics` dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3ba55a0c832792a8becd804de9e3