### PR TITLE
chore: add auth login diagnostics

### DIFF
--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -1,32 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
 import { env } from '@/config/env';
 import { API } from '@/config/api';
 
-export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const res = await fetch(`${env.API_URL}${API.login}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  const data = await res.json();
-  if (!res.ok) {
-    return NextResponse.json(data, { status: res.status });
-  }
-  const token = data.token || data.accessToken || data.jwt;
-  if (!token) {
+function jsonSafe<T = any>(r: Response): Promise<T | null> {
+  return r.text().then(t => { try { return JSON.parse(t) } catch { return t ? (t as any) : null } });
+}
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json().catch(() => ({}));
+  const url = `${env.API_URL}${API.login}`;
+  const start = Date.now();
+
+  try {
+    // try JSON first
+    let res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+
+    // if backend doesn’t accept JSON, retry as form-encoded
+    if (res.status === 415 || res.status === 400) {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ email: String(email || ''), password: String(password || '') }),
+      });
+    }
+
+    const data: any = await jsonSafe(res);
+    const dur = Date.now() - start;
+    console.log('[auth.login] →', { url, status: res.status, ok: res.ok, durMs: dur, preview: typeof data === 'string' ? data.slice(0,200) : (data && Object.keys(data).slice(0,6)) });
+
+    const token = data?.token || data?.accessToken || data?.jwt || '';
+    if (res.ok && token) {
+      const resp = NextResponse.json({ ok: true });
+      resp.headers.set('Set-Cookie',
+        `${env.JWT_COOKIE_NAME}=${token}; Path=/; HttpOnly; SameSite=Lax; ${process.env.NODE_ENV==='production'?'Secure; ':''}Max-Age=${60*60*24*30}`
+      );
+      return resp;
+    }
+
     return NextResponse.json(
-      { message: data.message || 'Missing token' },
-      { status: 400 },
+      { ok: false, message: (data && (data.message || data.error)) || 'Invalid email or password' },
+      { status: 200 }
     );
+  } catch (e: any) {
+    console.error('[auth.login] EXCEPTION', { url, msg: e?.message });
+    return NextResponse.json({ ok: false, message: 'Auth service unreachable' }, { status: 200 });
   }
-  const response = NextResponse.json({ ok: true });
-  response.cookies.set(env.JWT_COOKIE_NAME, token, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    maxAge: 60 * 60 * 24 * 30,
-  });
-  return response;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,10 +22,13 @@ export default function LoginPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message || 'Login failed');
-      if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('login_success');
-      router.push('/dashboard');
+      const data = await res.json().catch(() => ({ ok: false, message: 'Invalid response from server' }));
+      if (!data.ok) {
+        setError(data.message || 'Login failed');
+      } else {
+        if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('login_success');
+        router.push('/dashboard');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');
     } finally {


### PR DESCRIPTION
## Summary
- log auth login backend responses and retry form-encoded when needed
- handle login API `{ ok, message }` responses on client

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f43e370a8832786b72037c7f4d96e