### PR TITLE
feat: improve login form submission

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,29 +8,29 @@ export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [err, setErr] = useState('');
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  async function onSubmit(e: React.FormEvent) {
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setError(null);
-    if (!email || !password) { setError('Email and password are required'); return; }
+    setErr('');
     setLoading(true);
     try {
+      console.log('[login] submit', { email });
       const res = await fetch('/api/session/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
       });
-      const data = await res.json().catch(() => ({ ok: false, message: 'Invalid response from server' }));
-      if (!data.ok) {
-        setError(data.message || 'Login failed');
-      } else {
+      const data = await res.json().catch(() => ({}));
+      if (data?.ok) {
         if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('login_success');
-        router.push('/dashboard');
+        router.replace('/dashboard');
+        return;
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Login failed');
+      setErr(data?.message || 'Invalid email or password');
+    } catch {
+      setErr('Auth service unreachable');
     } finally {
       setLoading(false);
     }
@@ -41,17 +41,41 @@ export default function LoginPage() {
       <div className="max-w-md mx-auto bg-white/70 rounded-2xl p-6 shadow">
         <h1 className="text-2xl font-bold mb-2">Login</h1>
         <p className="text-sm text-gray-600 mb-4">Sign in to your QuickGig account.</p>
-        {error && <div className="bg-red-100 text-red-700 border border-red-200 rounded-lg p-3 mb-3">{error}</div>}
         <form onSubmit={onSubmit} className="space-y-3">
+          {err ? (
+            <div role="alert" className="bg-red-100 text-red-700 border border-red-200 rounded-lg p-3">
+              {err}
+            </div>
+          ) : null}
           <div>
             <label className="block text-sm font-medium mb-1">Email</label>
-            <input className="w-full border rounded-lg p-2" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
+            <input
+              className="w-full border rounded-lg p-2"
+              type="email"
+              name="email"
+              autoComplete="username"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Password</label>
-            <input className="w-full border rounded-lg p-2" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
+            <input
+              className="w-full border rounded-lg p-2"
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
           </div>
-          <button className="w-full bg-yellow-400 font-semibold rounded-lg py-2" type="submit" disabled={loading}>
+          <button
+            className="w-full bg-yellow-400 font-semibold rounded-lg py-2"
+            type="submit"
+            disabled={loading}
+          >
             {loading ? 'Signing in…' : 'Login'}
           </button>
         </form>


### PR DESCRIPTION
## Summary
- handle login form submission via onSubmit and POST to /api/session/login
- show server error messages and redirect to dashboard on success

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f4ae2e7148327a0fa030d8b922080