### PR TITLE
refactor: proxy client auth through session routes

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { login } from '@/lib/auth/client';
 
 export default function LoginPage() {
-  const r = useRouter();
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [err, setErr] = useState('');
@@ -14,17 +15,9 @@ export default function LoginPage() {
     setErr('');
     setLoading(true);
     try {
-      const res = await fetch('/api/session/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (json?.ok) {
-        r.replace('/dashboard');
-        return;
-      }
-      setErr(json?.message || 'Invalid email or password');
+      const data = await login(email, password);
+      if (data?.ok) router.replace('/dashboard');
+      else setErr(data?.message || 'Invalid email or password');
     } catch {
       setErr('Auth service unreachable');
     } finally {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { env } from '@/config/env';
 import { track } from '@/lib/track';
+import { register } from '@/lib/auth/client';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -18,13 +19,8 @@ export default function RegisterPage() {
     if (!name || !email || !password) { setError('All fields are required'); return; }
     setLoading(true);
     try {
-      const res = await fetch('/api/session/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email, password }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message || 'Registration failed');
+      const data = await register({ name, email, password });
+      if (!data?.ok) throw new Error(data?.message || 'Registration failed');
       if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('signup_success');
       router.push('/dashboard');
     } catch (err) {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
 import { api } from '@/lib/apiClient';
+import { login as loginApi, register as registerApi, me as meApi } from '@/lib/auth/client';
 
 interface AuthContextType {
   user: User | null;
@@ -34,10 +35,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const fetchMe = async () => {
     try {
-      const res = await fetch('/api/session/me', { cache: 'no-store' });
-      if (!res.ok) throw new Error('Not authenticated');
-      const data = (await res.json()) as User;
-      setUser(data);
+      const data = await meApi();
+      const userData = (data.user || data) as User;
+      if (userData && Object.keys(userData).length) setUser(userData);
+      else setUser(null);
     } catch {
       setUser(null);
     }
@@ -48,20 +49,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const login = async (data: LoginData) => {
-    await fetch('/api/session/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+    await loginApi(data.email, data.password);
     await fetchMe();
   };
 
   const signup = async (data: SignupData) => {
-    await fetch('/api/session/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+    await registerApi({ email: data.email, password: data.password, name: data.name });
     await fetchMe();
   };
 

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,0 +1,24 @@
+'use client';
+
+async function post(path: string, body: Record<string, unknown>) {
+  const res = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'same-origin',
+  });
+  return res.json().catch(() => ({}));
+}
+
+export async function login(email: string, password: string) {
+  return post('/api/session/login', { email, password });
+}
+
+export async function register(payload: { email: string; password: string; name?: string }) {
+  return post('/api/session/register', payload);
+}
+
+export async function me() {
+  const res = await fetch('/api/session/me', { credentials: 'same-origin' });
+  return res.json().catch(() => ({}));
+}


### PR DESCRIPTION
## Summary
- add client auth sdk for login/register/me via `/api/session/*`
- update login and registration pages to use auth sdk
- refactor auth context to reuse auth sdk helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f50b7c7a08327924ecae4a0263607