### PR TITLE
Intercept auth requests and post login via proxy

### DIFF
--- a/src/app/ClientBootstrap.tsx
+++ b/src/app/ClientBootstrap.tsx
@@ -1,20 +1,20 @@
 'use client';
 import { useEffect } from 'react';
 
+const reAuth = /^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.php/i;
+
 export default function ClientBootstrap() {
   useEffect(() => {
-    // 1) Intercept fetch
+    // Intercept fetch
     const origFetch = window.fetch;
     window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === 'string'
-        ? input
-        : input instanceof URL
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
           ? input.href
           : (input as Request).url;
-
-      const m = typeof url === 'string' &&
-        url.match(/^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.php/i);
-
+      const m = typeof url === 'string' && url.match(reAuth);
       if (m) {
         const name = m[3];
         const target = `/api/session/${name}`;
@@ -24,17 +24,16 @@ export default function ClientBootstrap() {
       return origFetch(input as RequestInfo, init);
     };
 
-    // 2) Intercept XMLHttpRequest (axios, legacy code)
+    // Intercept XHR (axios/legacy)
     const origOpen = XMLHttpRequest.prototype.open;
-    XMLHttpRequest.prototype.open = function(
+    XMLHttpRequest.prototype.open = function (
       method: string,
       url: string,
       async?: boolean,
       username?: string | null,
       password?: string | null
     ) {
-      const m = typeof url === 'string' &&
-        url.match(/^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.php/i);
+      const m = typeof url === 'string' && url.match(reAuth);
       if (m) {
         const name = m[3];
         const target = `/api/session/${name}`;
@@ -44,12 +43,47 @@ export default function ClientBootstrap() {
       return origOpen.call(this, method, url, async ?? true, username ?? null, password ?? null);
     };
 
+    // Intercept raw <form action="https://quickgig.ph/login.php" method="post">
+    function onFormSubmit(e: Event) {
+      const f = e.target as HTMLFormElement;
+      if (!(f instanceof HTMLFormElement)) return;
+      const action = f.action || '';
+      const m = action.match(reAuth);
+      if (!m) return;
+
+      const name = m[3];
+      const target = `/api/session/${name}`;
+      console.warn('[auth-guard][form] rerouting', action, '→', target);
+      e.preventDefault();
+
+      // Serialize and send via same-origin fetch
+      const fd = new FormData(f);
+      const body: Record<string, string> = {};
+      fd.forEach((v, k) => (body[k] = String(v)));
+
+      fetch(target, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        credentials: 'same-origin',
+      })
+        .then((r) => r.json().catch(() => ({})))
+        .then((json) => {
+          if (json?.ok) window.location.replace('/dashboard');
+          else alert(json?.message || 'Authentication failed');
+        })
+        .catch(() => alert('Auth service unreachable'));
+    }
+    document.addEventListener('submit', onFormSubmit, true);
+
     console.log('[auth-guard] installed');
     return () => {
       window.fetch = origFetch;
       XMLHttpRequest.prototype.open = origOpen;
+      document.removeEventListener('submit', onFormSubmit, true);
     };
   }, []);
 
   return null;
 }
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -18,6 +18,7 @@ export default function LoginPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
+        credentials: 'same-origin',
       });
       const data = await res.json().catch(() => ({}));
       if (data?.ok) { router.replace('/dashboard'); return; }


### PR DESCRIPTION
## Summary
- intercept fetch, XHR, and form posts for auth endpoints and reroute them to `/api/session/*`
- submit login form through the same-origin `/api/session/login` proxy with credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5f5146448327a49fe03ad052806d