### PR TITLE
Mount auth guard and proxy login form

### DIFF
--- a/src/app/ClientBootstrap.tsx
+++ b/src/app/ClientBootstrap.tsx
@@ -5,72 +5,49 @@ const reAuth = /^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.
 
 export default function ClientBootstrap() {
   useEffect(() => {
-    // Intercept fetch
+    // fetch
     const origFetch = window.fetch;
     window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-          ? input.href
-          : (input as Request).url;
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
       const m = typeof url === 'string' && url.match(reAuth);
-      if (m) {
-        const name = m[3];
-        const target = `/api/session/${name}`;
-        console.warn('[auth-guard][fetch] rerouting', url, '→', target);
-        input = target;
-      }
+      if (m) input = `/api/session/${m[3]}`;
       return origFetch(input as RequestInfo, init);
     };
 
-    // Intercept XHR (axios/legacy)
+    // XHR (axios/legacy)
     const origOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (
       method: string,
       url: string,
       async?: boolean,
       username?: string | null,
-      password?: string | null
+      password?: string | null,
     ) {
       const m = typeof url === 'string' && url.match(reAuth);
-      if (m) {
-        const name = m[3];
-        const target = `/api/session/${name}`;
-        console.warn('[auth-guard][xhr] rerouting', url, '→', target);
-        return origOpen.call(this, method, target, async ?? true, username ?? null, password ?? null);
-      }
-      return origOpen.call(this, method, url, async ?? true, username ?? null, password ?? null);
+      return origOpen.call(this, method, m ? `/api/session/${m[3]}` : url, async ?? true, username ?? null, password ?? null);
     };
 
-    // Intercept raw <form> posts to auth endpoints
+    // Raw <form action="https://quickgig.ph/login.php" method="post">
     function onFormSubmit(e: Event) {
       const f = e.target as HTMLFormElement;
       if (!(f instanceof HTMLFormElement)) return;
-      const action = f.action || '';
-      const m = action.match(reAuth);
+      const m = (f.action || '').match(reAuth);
       if (!m) return;
 
-      const name = m[3];
-      const target = `/api/session/${name}`;
-      console.warn('[auth-guard][form] rerouting', action, '→', target);
       e.preventDefault();
-
-      // Serialize and send via same-origin fetch
-      const fd = new FormData(f);
       const body: Record<string, string> = {};
-      fd.forEach((v, k) => (body[k] = String(v)));
+      new FormData(f).forEach((v, k) => (body[k] = String(v)));
 
-      fetch(target, {
+      fetch(`/api/session/${m[3]}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
         credentials: 'same-origin',
       })
         .then((r) => r.json().catch(() => ({})))
-        .then((json) => {
-          if (json?.ok) window.location.replace('/dashboard');
-          else alert(json?.message || 'Authentication failed');
+        .then((j) => {
+          if (j?.ok) window.location.replace('/dashboard');
+          else alert(j?.message || 'Authentication failed');
         })
         .catch(() => alert('Auth service unreachable'));
     }
@@ -86,4 +63,3 @@ export default function ClientBootstrap() {
 
   return null;
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { SocketProvider } from "../context/SocketContext";
 import Navigation from "../components/Navigation";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { ToastProvider } from "../components/ToastProvider";
-import ClientBootstrap from '@/app/ClientBootstrap';
+import ClientBootstrap from './ClientBootstrap';
 import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,82 +3,46 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function LoginPage() {
-  const r = useRouter();
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [err, setErr] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setErr('');
-    setLoading(true);
+    e.preventDefault(); setErr(''); setBusy(true);
     try {
       const res = await fetch('/api/session/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
+        credentials: 'same-origin',
       });
-      const json = await res.json().catch(() => ({}));
-      if (json?.ok) {
-        r.replace('/dashboard');
-        return;
-      }
-      setErr(json?.message || 'Invalid email or password');
-    } catch {
-      setErr('Auth service unreachable');
-    } finally {
-      setLoading(false);
-    }
+      const data = await res.json().catch(() => ({}));
+      if (data?.ok) { router.replace('/dashboard'); return; }
+      setErr(data?.message || 'Invalid email or password');
+    } catch { setErr('Auth service unreachable'); }
+    finally { setBusy(false); }
   }
 
   return (
-    <div className="qg-container py-12">
-      <div className="max-w-md mx-auto bg-white/70 rounded-2xl p-6 shadow">
-        <h1 className="text-2xl font-bold mb-2">Login</h1>
-        <p className="text-sm text-gray-600 mb-4">Sign in to your QuickGig account.</p>
-        <form onSubmit={onSubmit} className="space-y-3">
-          {err && (
-            <div role="alert" className="alert-error">
-              {err}
-            </div>
-          )}
-          <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
-            <input
-              className="w-full border rounded-lg p-2"
-              type="email"
-              name="email"
-              autoComplete="username"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Password</label>
-            <input
-              className="w-full border rounded-lg p-2"
-              type="password"
-              name="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={loading}
-            className="btn btn-primary w-full"
-          >
-            {loading ? 'Signing in…' : 'Login'}
-          </button>
-        </form>
-        <p className="text-sm mt-3">
-          No account? <a className="text-sky-600 font-semibold" href="/register">Sign up</a>
-        </p>
-      </div>
-    </div>
+    <form id="login-form" onSubmit={onSubmit} noValidate>
+      {err && <div role="alert" className="alert-error">{err}</div>}
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit" disabled={busy} className="btn btn-primary w-full">
+        {busy ? 'Signing in…' : 'Login'}
+      </button>
+    </form>
   );
 }


### PR DESCRIPTION
## Summary
- intercept auth requests on the client to reroute to `/api/session/*`
- mount the client auth guard in the root layout
- implement a simple login form posting to `/api/session/login`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f6c611b10832782c2a0a3bbe6ff01