### PR TITLE
fix(login): submit to /api/session/login (same-origin); remove engine actions, duplicates, and static shadows

### DIFF
--- a/src/app/ClientBootstrap.tsx
+++ b/src/app/ClientBootstrap.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect } from 'react';
 
-const reAuth = /^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.php/i;
+const reAuth = /^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)(\.php)?/i;
 
 export default function ClientBootstrap() {
   useEffect(() => {
@@ -27,7 +27,7 @@ export default function ClientBootstrap() {
       return origOpen.call(this, method, m ? `/api/session/${m[3]}` : url, async ?? true, username ?? null, password ?? null);
     };
 
-    // Raw <form action="https://quickgig.ph/login.php" method="post">
+    // Raw <form action="https://quickgig.ph/login" method="post">
     function onFormSubmit(e: Event) {
       const f = e.target as HTMLFormElement;
       if (!(f instanceof HTMLFormElement)) return;

--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -7,7 +7,7 @@ async function toJsonSafe(r: Response) {
 
 export async function POST(req: Request) {
   const { email, password } = await req.json().catch(() => ({}));
-  const url = `${env.API_URL}/auth/login.php`;
+  const url = `${env.API_URL}/auth/login`;
   try {
     // Try JSON
     let r = await fetch(url, {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,48 +1,52 @@
 'use client';
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+
+import * as React from 'react';
 
 export default function LoginPage() {
-  const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [err, setErr] = useState('');
-  const [busy, setBusy] = useState(false);
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [err, setErr] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault(); setErr(''); setBusy(true);
+    e.preventDefault();
+    setErr('');
+    setLoading(true);
     try {
       const res = await fetch('/api/session/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
         credentials: 'same-origin',
+        body: JSON.stringify({ email, password }),
       });
-      const data = await res.json().catch(() => ({}));
-      if (data?.ok) { router.replace('/dashboard'); return; }
-      setErr(data?.message || 'Invalid email or password');
-    } catch { setErr('Auth service unreachable'); }
-    finally { setBusy(false); }
+      type LoginRes = { ok?: boolean; message?: string };
+      const data: LoginRes = await res.json().catch(() => ({} as LoginRes));
+      if (!res.ok || !data?.ok) { setErr(data?.message || 'Invalid email or password'); return; }
+      location.replace('/dashboard');
+    } catch { setErr('Network error. Please try again.'); }
+    finally { setLoading(false); }
   }
 
   return (
-    <form id="login-form" onSubmit={onSubmit} noValidate>
-      {err && <div role="alert" className="alert-error">{err}</div>}
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-      />
-      <input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-      />
-      <button type="submit" disabled={busy} className="btn btn-primary w-full">
-        {busy ? 'Signing in…' : 'Login'}
-      </button>
-    </form>
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl font-semibold mb-4">Login</h1>
+      {err && <div className="mb-3 text-red-600">{err}</div>}
+      <form onSubmit={onSubmit} noValidate>
+        <label className="block mb-2">
+          <span className="block text-sm">Email</span>
+          <input className="w-full border rounded p-2" type="email" name="email"
+            value={email} onChange={e=>setEmail(e.target.value)} autoComplete="email" required />
+        </label>
+        <label className="block mb-4">
+          <span className="block text-sm">Password</span>
+          <input className="w-full border rounded p-2" type="password" name="password"
+            value={password} onChange={e=>setPassword(e.target.value)} autoComplete="current-password" required />
+        </label>
+        <button type="submit" disabled={loading}
+          className="w-full rounded bg-yellow-400 py-2 font-medium disabled:opacity-60">
+          {loading ? 'Signing in…' : 'Login'}
+        </button>
+      </form>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- modernize login page to POST to our own `/api/session/login` and handle errors client-side
- tighten bootstrap auth redirects and drop legacy `login.php` form reference
- point session login API to `/auth/login` instead of legacy `login.php`

## Testing
- `git ls-files 'pages/login*'`
- `find public -maxdepth 3 -type f -iname 'login*' -print`
- `grep -RIn --exclude-dir=node_modules --exclude-dir=.next -E 'login\.php' app src pages public || true`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fb6b3b06c8327bfa8c2383b14a242