### PR TITLE
Make `/login` render the App Router page; remove shadows/redirects; submit same-origin to `/api/session/login`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,5 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  async redirects() {
-    return [
-      {
-        source: '/:path*',
-        destination: 'https://app.quickgig.ph/:path*',
-        permanent: true, // use 308 on Vercel
-      },
-    ];
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,52 +1,26 @@
 'use client';
-
 import * as React from 'react';
-
 export default function LoginPage() {
-  const [email, setEmail] = React.useState('');
-  const [password, setPassword] = React.useState('');
-  const [err, setErr] = React.useState('');
-  const [loading, setLoading] = React.useState(false);
-
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setErr('');
-    setLoading(true);
-    try {
-      const res = await fetch('/api/session/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify({ email, password }),
-      });
-      type LoginRes = { ok?: boolean; message?: string };
-      const data: LoginRes = await res.json().catch(() => ({} as LoginRes));
-      if (!res.ok || !data?.ok) { setErr(data?.message || 'Invalid email or password'); return; }
-      location.replace('/dashboard');
-    } catch { setErr('Network error. Please try again.'); }
-    finally { setLoading(false); }
+  const [email,setEmail]=React.useState(''); const [password,setPassword]=React.useState('');
+  const [err,setErr]=React.useState(''); const [loading,setLoading]=React.useState(false);
+  React.useEffect(()=>{ console.log('[login] App Router page rendered'); },[]);
+  async function onSubmit(e:React.FormEvent<HTMLFormElement>){e.preventDefault();setErr('');setLoading(true);
+    try{const r=await fetch('/api/session/login',{method:'POST',headers:{'Content-Type':'application/json'},
+      credentials:'same-origin',body:JSON.stringify({email,password})}); const d=await r.json().catch(()=>({}));
+      if(r.ok&&d?.ok){location.replace('/dashboard');} else {setErr(d?.message||'Invalid email or password');}}
+    catch{setErr('Auth service unreachable');} finally{setLoading(false);}
   }
-
-  return (
-    <main className="mx-auto max-w-md p-6">
-      <h1 className="text-2xl font-semibold mb-4">Login</h1>
-      {err && <div className="mb-3 text-red-600">{err}</div>}
-      <form onSubmit={onSubmit} noValidate>
-        <label className="block mb-2">
-          <span className="block text-sm">Email</span>
-          <input className="w-full border rounded p-2" type="email" name="email"
-            value={email} onChange={e=>setEmail(e.target.value)} autoComplete="email" required />
-        </label>
-        <label className="block mb-4">
-          <span className="block text-sm">Password</span>
-          <input className="w-full border rounded p-2" type="password" name="password"
-            value={password} onChange={e=>setPassword(e.target.value)} autoComplete="current-password" required />
-        </label>
-        <button type="submit" disabled={loading}
-          className="w-full rounded bg-yellow-400 py-2 font-medium disabled:opacity-60">
-          {loading ? 'Signing in…' : 'Login'}
-        </button>
-      </form>
-    </main>
-  );
+  return(<main className="mx-auto max-w-md p-6">
+    <h1 className="text-2xl font-semibold mb-4">Login</h1>{err&&<div className="mb-3 text-red-600">{err}</div>}
+    <form onSubmit={onSubmit} noValidate>
+      <label className="block mb-2"><span className="block text-sm">Email</span>
+        <input className="w-full border rounded p-2" type="email" name="email" value={email}
+               onChange={e=>setEmail(e.target.value)} autoComplete="email" required/></label>
+      <label className="block mb-4"><span className="block text-sm">Password</span>
+        <input className="w-full border rounded p-2" type="password" name="password" value={password}
+               onChange={e=>setPassword(e.target.value)} autoComplete="current-password" required/></label>
+      <button type="submit" disabled={loading} className="w-full rounded bg-yellow-400 py-2 font-medium disabled:opacity-60">
+        {loading?'Signing in…':'Login'}</button>
+    </form></main>);
 }
+


### PR DESCRIPTION
## Summary
- Use App Router page for `/login` with client-side fetch to `/api/session/login` and console render message
- Remove legacy domain redirect from Next.js config

## Self-checks
```bash
$ git ls-files 'pages/login*'
# no output
$ find public -maxdepth 3 -type f -iname 'login*' -print 2>/dev/null
# no output
$ printf '%s\n' "grep -RIn --exclude-dir=node_modules --exclude-dir=.next -E 'login\\.php' app src pages public || true" | bash
grep: app: No such file or directory
grep: pages: No such file or directory
$ node -e "try{const n=require('./next.config.js');Promise.resolve(n.redirects?.()||[]).then(r=>console.log(r))}catch{console.log('no next.config.js/redirects')}"
[]
$ node -e "try{const n=require('./next.config.js');Promise.resolve(n.rewrites?.()||[]).then(r=>console.log(r))}catch{console.log('no next.config.js/rewrites')}"
[]
```

## Testing
```bash
$ npm test
npm ERR! Missing script: "test"
```


------
https://chatgpt.com/codex/tasks/task_e_689fbce00ff48327a8cba3594c3c9135