### PR TITLE
Force Next.js login route; bypass any static/legacy shadows

### DIFF
--- a/src/app/next-login/page.tsx
+++ b/src/app/next-login/page.tsx
@@ -1,0 +1,3 @@
+// Alias that renders the actual Next login page
+export { default } from '../login/page';
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const url = req.nextUrl;
+
+  // Only guard GET /login (form posts go to /api/session/login)
+  if (req.method === 'GET' && url.pathname === '/login') {
+    const to = url.clone();
+    to.pathname = '/next-login';
+    return NextResponse.rewrite(to);
+  }
+  return NextResponse.next();
+}
+export const config = { matcher: ['/login'] };
+


### PR DESCRIPTION
## Summary
- Rewrite GET /login to /next-login via middleware
- Alias `/next-login` to the existing login page

## Testing
- `git ls-files 'public/**/login*'`
- `bash -lc "grep -RIn --exclude-dir=node_modules -E 'login\.php|quickgig\.ph/login\.php' src app public || true"`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fc439ae5083278040a057cc229caf