### PR TITLE
Implement auth session routes with engine proxy

### DIFF
--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -1,19 +1,22 @@
 import { NextResponse } from 'next/server';
 import { env } from '@/config/env';
-import { proxyFetch } from '@/server/proxy';
+import { parseSafe } from '@/server/proxy';
 
 export async function POST(req: Request) {
+  console.info('POST /api/session/login');
   const body = await req.json().catch(() => ({}));
   try {
-    const { res, data } = await proxyFetch('/auth/login', {
+    const res = await fetch(`${env.API_URL}/auth/login.php`, {
       method: 'POST',
-      body,
-      formFallback: true,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      credentials: 'include',
     });
-
-    const d = (typeof data === 'object' && data
-      ? (data as Record<string, unknown>)
-      : {}) as Record<string, unknown>;
+    const data = await parseSafe(res);
+    const d =
+      typeof data === 'object' && data
+        ? (data as Record<string, unknown>)
+        : ({} as Record<string, unknown>);
     const token =
       typeof d['token'] === 'string'
         ? (d['token'] as string)
@@ -22,12 +25,11 @@ export async function POST(req: Request) {
           : typeof d['jwt'] === 'string'
             ? (d['jwt'] as string)
             : typeof d['data'] === 'object' && d['data'] !== null &&
-              typeof (d['data'] as Record<string, unknown>)['token'] === 'string'
+                typeof (d['data'] as Record<string, unknown>)['token'] === 'string'
               ? ((d['data'] as Record<string, unknown>)['token'] as string)
               : '';
-
     if (res.ok && token) {
-      const resp = NextResponse.json({ ok: true });
+      const resp = NextResponse.json({ ok: true }, { status: res.status });
       resp.cookies.set(env.JWT_COOKIE_NAME, token, {
         httpOnly: true,
         sameSite: 'lax',
@@ -35,21 +37,22 @@ export async function POST(req: Request) {
         path: '/',
         maxAge: 60 * 60 * 24 * 30,
       });
+      console.info('POST /api/session/login', res.status);
       return resp;
     }
-
     const message =
       typeof d['message'] === 'string'
         ? (d['message'] as string)
         : typeof d['error'] === 'string'
           ? (d['error'] as string)
           : 'Invalid email or password';
-
-    return NextResponse.json({ ok: false, message }, { status: 200 });
-  } catch {
+    console.info('POST /api/session/login', res.status, message);
+    return NextResponse.json({ ok: false, message }, { status: res.status });
+  } catch (err) {
+    console.info('POST /api/session/login error', err);
     return NextResponse.json(
       { ok: false, message: 'Auth service unreachable' },
-      { status: 200 }
+      { status: 500 },
     );
   }
 }
@@ -57,3 +60,4 @@ export async function POST(req: Request) {
 export async function OPTIONS() {
   return new Response(null, { status: 200 });
 }
+


### PR DESCRIPTION
## Summary
- proxy /api/session/login, register, and me to PHP engine using fetch with credentials
- log session requests and forward status codes and cookies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fcbd7f7d483279e4b2cfe87286eeb