### PR TITLE
Legacy UI parity — mirror app.quickgig.ph marketing shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,8 @@ ADMIN_EMAILS=you@quickgig.ph,moderator@quickgig.ph
 # Metrics (optional)
 NEXT_PUBLIC_ENABLE_ANALYTICS=true
 METRICS_SECRET=change-me
+
+# Legacy UI
+NEXT_PUBLIC_LEGACY_UI=true
+NEXT_PUBLIC_SHOW_API_BADGE=false
+NEXT_PUBLIC_BANNER_HTML=

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ NEXT_PUBLIC_ENABLE_APPLY=false
 NEXT_PUBLIC_ENV=local
 ```
 
+3. To preview the legacy marketing shell locally, set:
+```env
+NEXT_PUBLIC_LEGACY_UI=true
+NEXT_PUBLIC_SHOW_API_BADGE=false
+NEXT_PUBLIC_BANNER_HTML=
+```
+
 To verify the live API locally, run:
 
 ```bash

--- a/src/app/(marketing)/MarketingHome.tsx
+++ b/src/app/(marketing)/MarketingHome.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { env } from '@/config/env';
+
+type ApiStatus = 'loading' | 'ok' | 'error';
+
+export default function MarketingHome() {
+  const [status, setStatus] = useState<ApiStatus>('loading');
+
+  useEffect(() => {
+    if (env.NEXT_PUBLIC_SHOW_API_BADGE) {
+      fetch('/api/health-check')
+        .then((res) => setStatus(res.ok ? 'ok' : 'error'))
+        .catch(() => setStatus('error'));
+    }
+  }, []);
+
+  return (
+    <div>
+      <section className="hero">
+        <div className="wordmark">QuickGig</div>
+        <p className="headline">Kahit saan sa Pinas, may gig para sa’yo!</p>
+        <p className="subheadline">Gigs and talent, matched fast.</p>
+        <div className="cta-group">
+          <Link href="/register" className="btn primary">
+            Simulan Na!
+          </Link>
+          <Link href="/find-work" className="btn secondary">
+            Browse Jobs
+          </Link>
+        </div>
+      </section>
+      {env.NEXT_PUBLIC_SHOW_API_BADGE && (
+        <div className="api-badge">
+          {status === 'loading'
+            ? 'Checking API…'
+            : `API: ${status === 'ok' ? 'OK' : 'ERROR'}`}
+        </div>
+      )}
+      <section className="features">
+        <div className="feature">
+          <span className="icon">📝</span>Post gig in minutes
+        </div>
+        <div className="feature">
+          <span className="icon">⚡</span>Apply with one tap
+        </div>
+        <div className="feature">
+          <span className="icon">🔒</span>Secure messaging
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,11 @@ import ClientBootstrap from './ClientBootstrap';
 import ClientAuthGuard from './ClientAuthGuard';
 import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
+import { env } from '@/config/env';
+import legacyTheme from '@/theme/legacy';
+import clsx from 'clsx';
+import type { CSSProperties } from 'react';
+import '../styles/legacy.css';
 
 export const metadata: Metadata = {
   title: "QuickGig.ph - Find Gigs Fast in the Philippines",
@@ -50,7 +55,7 @@ export const metadata: Metadata = {
     images: ['/logo-main.png'],
     creator: '@QuickGigPH',
   },
-  icons: [{ rel: 'icon', url: '/favicon.svg' }],
+  icons: [{ rel: 'icon', url: '/favicon.png' }],
   manifest: '/manifest.json',
   robots: {
     index: true,
@@ -68,72 +73,104 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const legacy = env.NEXT_PUBLIC_LEGACY_UI;
+  const legacyVars: CSSProperties | undefined = legacy
+    ? ({
+        '--legacy-color-bg': legacyTheme.colors.bg,
+        '--legacy-color-text': legacyTheme.colors.text,
+        '--legacy-color-header-bg': legacyTheme.colors.headerBg,
+        '--legacy-color-footer-bg': legacyTheme.colors.footerBg,
+        '--legacy-color-cta': legacyTheme.colors.cta,
+        '--legacy-color-cta-hover': legacyTheme.colors.ctaHover,
+        '--legacy-color-border': legacyTheme.colors.border,
+        '--legacy-radius-md': legacyTheme.radii.md,
+        '--legacy-radius-lg': legacyTheme.radii.lg,
+        '--legacy-radius-full': legacyTheme.radii.full,
+        '--legacy-shadow-sm': legacyTheme.shadows.sm,
+        '--legacy-space-1': legacyTheme.spacing[1],
+        '--legacy-space-2': legacyTheme.spacing[2],
+        '--legacy-space-3': legacyTheme.spacing[3],
+        '--legacy-space-4': legacyTheme.spacing[4],
+        '--legacy-space-6': legacyTheme.spacing[6],
+        '--legacy-space-8': legacyTheme.spacing[8],
+        '--legacy-space-16': legacyTheme.spacing[16],
+      } as CSSProperties)
+    : undefined;
+
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en" className={clsx('scroll-smooth', legacy && 'legacy')} style={legacyVars}>
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        {legacy && (
+          <>
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+            <link
+              href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+              rel="stylesheet"
+            />
+          </>
+        )}
       </head>
-      <body className="font-body antialiased bg-bg text-fg">
+      <body className={legacy ? 'legacy-body' : 'font-body antialiased bg-bg text-fg'}>
         <ClientAuthGuard />
         <ClientBootstrap />
         <AuthProvider>
           <SocketProvider>
             <ToastProvider>
               <ErrorBoundary>
-                <Navigation />
-                <main className="min-h-screen">
-                  {children}
-                </main>
-                <footer className="qg-footer">
-              <div className="qg-container">
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-                  <div className="col-span-1 md:col-span-2">
-                    {/* eslint-disable-next-line @next/next/no-img-element -- logo placeholder */}
-                    <img src="/logo-horizontal.png" alt="QuickGig.ph" className="h-8 mb-4" />
-                    <p className="text-fg opacity-70 mb-4">
-                      Ang pinakamabilis na paraan para makahanap ng trabaho at talent sa Pilipinas.
-                    </p>
-                    <p className="text-sm text-fg opacity-60">
-                      © 2024 QuickGig.ph. All rights reserved.
-                    </p>
-                  </div>
-                  <div>
-                    <h3 className="font-heading font-semibold text-fg mb-4">Para sa Freelancers</h3>
-                    <ul className="space-y-2 text-fg opacity-70">
-                      <li>
-                        <Link href="/find-work" className="hover:text-qg-accent transition-colors">Find Work</Link>
-                      </li>
-                      <li>
-                        <Link href="/profile" className="hover:text-qg-accent transition-colors">Profile</Link>
-                      </li>
-                      <li>
-                        <Link href="/my-jobs" className="hover:text-qg-accent transition-colors">My Jobs</Link>
-                      </li>
-                    </ul>
-                  </div>
-                  <div>
-                    <h3 className="font-heading font-semibold text-fg mb-4">Para sa Employers</h3>
-                    <ul className="space-y-2 text-fg opacity-70">
-                      <li>
-                        <Link href="/post-job" className="hover:text-qg-accent transition-colors">Post Job</Link>
-                      </li>
-                      <li>
-                        <Link href="/buy-tickets" className="hover:text-qg-accent transition-colors">Buy Tickets</Link>
-                      </li>
-                      <li>
-                        <Link href="/messages" className="hover:text-qg-accent transition-colors">Messages</Link>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-                </footer>
+                {legacy ? (
+                  <>{children}</>
+                ) : (
+                  <>
+                    <Navigation />
+                    <main className="min-h-screen">{children}</main>
+                    <footer className="qg-footer">
+                      <div className="qg-container">
+                        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+                          <div className="col-span-1 md:col-span-2">
+                            {/* eslint-disable-next-line @next/next/no-img-element -- logo placeholder */}
+                            <img src="/logo-horizontal.png" alt="QuickGig.ph" className="h-8 mb-4" />
+                            <p className="text-fg opacity-70 mb-4">
+                              Ang pinakamabilis na paraan para makahanap ng trabaho at talent sa Pilipinas.
+                            </p>
+                            <p className="text-sm text-fg opacity-60">
+                              © 2024 QuickGig.ph. All rights reserved.
+                            </p>
+                          </div>
+                          <div>
+                            <h3 className="font-heading font-semibold text-fg mb-4">Para sa Freelancers</h3>
+                            <ul className="space-y-2 text-fg opacity-70">
+                              <li>
+                                <Link href="/find-work" className="hover:text-qg-accent transition-colors">Find Work</Link>
+                              </li>
+                              <li>
+                                <Link href="/profile" className="hover:text-qg-accent transition-colors">Profile</Link>
+                              </li>
+                              <li>
+                                <Link href="/my-jobs" className="hover:text-qg-accent transition-colors">My Jobs</Link>
+                              </li>
+                            </ul>
+                          </div>
+                          <div>
+                            <h3 className="font-heading font-semibold text-fg mb-4">Para sa Employers</h3>
+                            <ul className="space-y-2 text-fg opacity-70">
+                              <li>
+                                <Link href="/post-job" className="hover:text-qg-accent transition-colors">Post Job</Link>
+                              </li>
+                              <li>
+                                <Link href="/buy-tickets" className="hover:text-qg-accent transition-colors">Buy Tickets</Link>
+                              </li>
+                              <li>
+                                <Link href="/messages" className="hover:text-qg-accent transition-colors">Messages</Link>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </footer>
+                  </>
+                )}
               </ErrorBoundary>
             </ToastProvider>
           </SocketProvider>

--- a/src/app/login/legacy-login.css
+++ b/src/app/login/legacy-login.css
@@ -9,9 +9,9 @@
   width: 100%;
   max-width: 24rem;
   background: rgba(255, 255, 255, 0.7);
-  border-radius: 1rem;
+  border-radius: var(--legacy-radius-lg);
   padding: 1.5rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--legacy-shadow-sm);
 }
 
 .legacy-login h1 {
@@ -41,27 +41,34 @@
 
 .legacy-login input {
   margin-top: 0.25rem;
-  padding: 0.5rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.5rem;
+  padding: var(--legacy-space-2);
+  border: 1px solid var(--legacy-color-border);
+  border-radius: var(--legacy-radius-md);
+}
+.legacy-login input:focus {
+  outline: 2px solid var(--legacy-color-cta);
+  outline-offset: 2px;
 }
 
 .legacy-login .error-banner {
   background: #fee2e2;
   color: #b91c1c;
   border: 1px solid #fecaca;
-  border-radius: 0.5rem;
+  border-radius: var(--legacy-radius-md);
   padding: 0.5rem;
 }
 
 .legacy-login button {
   width: 100%;
-  background: #facc15;
-  padding: 0.5rem;
-  border-radius: 0.5rem;
+  background: var(--legacy-color-cta);
+  padding: var(--legacy-space-2);
+  border-radius: var(--legacy-radius-full);
   font-weight: 600;
+  color: #000;
 }
-
+.legacy-login button:hover {
+  background: var(--legacy-color-cta-hover);
+}
 .legacy-login button:disabled {
   opacity: 0.6;
 }
@@ -75,4 +82,3 @@
   color: #0284c7;
   font-weight: 600;
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,21 @@
 import type { Metadata } from 'next';
 import HomePageClient from './HomePageClient';
+import LegacyShell from '@/components/LegacyShell';
+import MarketingHome from './(marketing)/MarketingHome';
+import { env } from '@/config/env';
 
 export const metadata: Metadata = {
   title: 'QuickGig',
   description: 'Gigs and talent, matched fast.',
 };
 
-export default async function Page() {
+export default function Page() {
+  if (env.NEXT_PUBLIC_LEGACY_UI) {
+    return (
+      <LegacyShell>
+        <MarketingHome />
+      </LegacyShell>
+    );
+  }
   return <HomePageClient />;
 }
-

--- a/src/components/BannerAd.tsx
+++ b/src/components/BannerAd.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+import { env } from '@/config/env';
+
+function sanitize(html: string) {
+  return html
+    .replace(/<script.*?>.*?<\/script>/gi, '')
+    .replace(/on[a-z]+="[^"]*"/gi, '');
+}
+
+export default function BannerAd() {
+  const [dismissed, setDismissed] = useState(false);
+  if (!env.NEXT_PUBLIC_BANNER_HTML || dismissed) return null;
+  const safe = sanitize(env.NEXT_PUBLIC_BANNER_HTML);
+  return (
+    <div className="banner-ad">
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: safe }} />
+      <button aria-label="Dismiss banner" onClick={() => setDismissed(true)}>
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/components/LegacyFooter.tsx
+++ b/src/components/LegacyFooter.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function LegacyFooter() {
+  return (
+    <footer className="legacy-footer">
+      <p>© {new Date().getFullYear()} QuickGig.ph</p>
+      <div className="mt-2 flex justify-center gap-4 text-sm">
+        <Link href="/find-work">Find Work</Link>
+        <Link href="/post-job">Post Job</Link>
+        <Link href="/login">Login</Link>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/LegacyHeader.tsx
+++ b/src/components/LegacyHeader.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+
+export default function LegacyHeader() {
+  const { isAuthenticated, logout } = useAuth();
+  return (
+    <header className="legacy-header">
+      <div className="logo">
+        <Link href="/" className="font-bold text-xl">QuickGig<span>.ph</span></Link>
+      </div>
+      <nav>
+        <Link href="/">Home</Link>
+        <Link href="/find-work">Find Work</Link>
+        <Link href="/post-job">Post Job</Link>
+      </nav>
+      <div className="auth">
+        {isAuthenticated ? (
+          <>
+            <Link href="/dashboard">Dashboard</Link>
+            <Link href="/messages">Messages</Link>
+            <Link href="/profile">Profile</Link>
+            <button onClick={() => logout()}>Logout</button>
+          </>
+        ) : (
+          <>
+            <Link href="/login">Login</Link>
+            <Link href="/register">Sign Up</Link>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/LegacyShell.tsx
+++ b/src/components/LegacyShell.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import LegacyHeader from './LegacyHeader';
+import LegacyFooter from './LegacyFooter';
+import BannerAd from './BannerAd';
+
+export default function LegacyShell({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    console.info('legacy-ui: enabled');
+  }, []);
+  return (
+    <div>
+      <LegacyHeader />
+      <BannerAd />
+      <main className="legacy-main">{children}</main>
+      <LegacyFooter />
+    </div>
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,11 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_SAVED_API ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_SHOW_LOGOUT_ALL:
     String(process.env.NEXT_PUBLIC_SHOW_LOGOUT_ALL ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_LEGACY_UI:
+    String(process.env.NEXT_PUBLIC_LEGACY_UI ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_SHOW_API_BADGE:
+    String(process.env.NEXT_PUBLIC_SHOW_API_BADGE ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_BANNER_HTML: process.env.NEXT_PUBLIC_BANNER_HTML || '',
   RESEND_API_KEY: process.env.RESEND_API_KEY || '',
   NOTIFY_FROM: process.env.NOTIFY_FROM || 'QuickGig <noreply@quickgig.ph>',
   NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',

--- a/src/styles/legacy.css
+++ b/src/styles/legacy.css
@@ -1,0 +1,159 @@
+/* Legacy UI variables and utilities */
+
+html.legacy {
+  --legacy-color-bg: #f8fafc;
+  --legacy-color-text: #0f172a;
+  --legacy-color-header-bg: #0b3d39;
+  --legacy-color-footer-bg: #0b3d39;
+  --legacy-color-cta: #F6C20F;
+  --legacy-color-cta-hover: #FFCC00;
+  --legacy-color-border: #d1d5db;
+  --legacy-shadow-sm: 0 1px 2px rgba(0,0,0,0.1);
+  --legacy-space-1: 0.25rem;
+  --legacy-space-2: 0.5rem;
+  --legacy-space-3: 0.75rem;
+  --legacy-space-4: 1rem;
+  --legacy-space-6: 1.5rem;
+  --legacy-space-8: 2rem;
+  --legacy-space-16: 4rem;
+  --legacy-radius-md: 0.5rem;
+  --legacy-radius-lg: 1rem;
+  --legacy-radius-full: 9999px;
+}
+
+body.legacy-body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: var(--legacy-color-bg);
+  color: var(--legacy-color-text);
+}
+
+.legacy-header {
+  background: var(--legacy-color-header-bg);
+  color: #fff;
+  padding: var(--legacy-space-2) var(--legacy-space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  box-shadow: var(--legacy-shadow-sm);
+}
+.legacy-header nav a {
+  margin-right: var(--legacy-space-4);
+  color: #fff;
+}
+.legacy-header nav a:last-child {
+  margin-right: 0;
+}
+.legacy-header a:hover {
+  text-decoration: underline;
+}
+.legacy-header .auth a {
+  margin-left: var(--legacy-space-4);
+  color: #fff;
+}
+.legacy-header .auth button { margin-left: var(--legacy-space-4); background: none; border: none; color: #fff; cursor: pointer; }
+.legacy-header .auth button:hover { text-decoration: underline; }
+
+.banner-ad {
+  background: var(--legacy-color-cta);
+  color: #000;
+  padding: var(--legacy-space-2) var(--legacy-space-4);
+  position: relative;
+  text-align: center;
+}
+.banner-ad button {
+  position: absolute;
+  right: var(--legacy-space-2);
+  top: var(--legacy-space-2);
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.legacy-main {
+  min-height: 60vh;
+}
+
+.legacy-footer {
+  background: var(--legacy-color-footer-bg);
+  color: #fff;
+  text-align: center;
+  padding: var(--legacy-space-6) var(--legacy-space-4);
+  margin-top: var(--legacy-space-8);
+}
+
+.hero {
+  background: linear-gradient(135deg, #0ea37f, #1b5e55);
+  color: #fff;
+  padding: var(--legacy-space-16) var(--legacy-space-4);
+  text-align: center;
+}
+.hero .wordmark {
+  font-size: 3rem;
+  font-weight: 700;
+}
+.hero .headline {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-top: var(--legacy-space-4);
+}
+.hero .subheadline {
+  margin-top: var(--legacy-space-2);
+  font-size: 1.125rem;
+  opacity: 0.9;
+}
+.hero .cta-group {
+  margin-top: var(--legacy-space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--legacy-space-4);
+  align-items: center;
+}
+@media (min-width: 640px) {
+  .hero .cta-group {
+    flex-direction: row;
+  }
+}
+.btn {
+  padding: var(--legacy-space-3) var(--legacy-space-6);
+  border-radius: var(--legacy-radius-full);
+  font-weight: 600;
+}
+.btn.primary {
+  background: var(--legacy-color-cta);
+  color: #000;
+}
+.btn.primary:hover {
+  background: var(--legacy-color-cta-hover);
+}
+.btn.secondary {
+  border: 2px solid var(--legacy-color-cta);
+  color: var(--legacy-color-cta);
+}
+.btn.secondary:hover {
+  background: var(--legacy-color-cta);
+  color: #000;
+}
+
+.features {
+  display: grid;
+  gap: var(--legacy-space-8);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  padding: var(--legacy-space-16) var(--legacy-space-4);
+  text-align: center;
+}
+.feature .icon {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: var(--legacy-space-2);
+}
+
+.api-badge {
+  padding: var(--legacy-space-2) 0;
+  text-align: center;
+}
+

--- a/src/theme/legacy.ts
+++ b/src/theme/legacy.ts
@@ -1,0 +1,36 @@
+export const legacyTheme = {
+  colors: {
+    bg: '#f8fafc',
+    text: '#0f172a',
+    headerBg: '#0b3d39',
+    footerBg: '#0b3d39',
+    brand: '#0ea37f',
+    cta: '#F6C20F',
+    ctaHover: '#FFCC00',
+    border: '#d1d5db',
+  },
+  fonts: {
+    body: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
+    heading: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
+  },
+  radii: {
+    md: '0.5rem',
+    lg: '1rem',
+    full: '9999px',
+  },
+  shadows: {
+    sm: '0 1px 2px rgba(0,0,0,0.05)',
+    md: '0 4px 6px rgba(0,0,0,0.1)',
+  },
+  spacing: {
+    1: '0.25rem',
+    2: '0.5rem',
+    3: '0.75rem',
+    4: '1rem',
+    6: '1.5rem',
+    8: '2rem',
+    16: '4rem',
+  },
+};
+
+export default legacyTheme;


### PR DESCRIPTION
## Summary
- add legacy theme tokens and global styles
- implement header/footer shell with optional banner ad
- render marketing hero when `NEXT_PUBLIC_LEGACY_UI=true`
- restyle login form and document legacy UI env flags

## Testing
- `grep -RIn --line-number --exclude-dir=node_modules 'NEXT_PUBLIC_LEGACY_UI' .`
- `grep -RIn --exclude-dir=node_modules --exclude-dir=.next -E 'login\.php|quickgig\.ph/login\.php' . || echo "OK: no legacy login.php refs"`
- `grep -RIn --exclude-dir=node_modules 'MarketingHome' src/app`
- `grep -RIn --exclude-dir=node_modules -E '/api/session/login' src/app/login`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fe732cbf48327b1be3e5da2943d84