### PR TITLE
Add health endpoints, version info, and API badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,7 @@ METRICS_SECRET=change-me
 
 # Legacy marketing UI flags
 NEXT_PUBLIC_LEGACY_UI=true
+
+# Observability
 NEXT_PUBLIC_SHOW_API_BADGE=false
 NEXT_PUBLIC_BANNER_HTML=

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ Backend endpoints (see `src/config/api.ts`):
 
 The frontend never blocks or fails the UI if the metrics backend is absent; `/api/metrics/track` always returns `{ ok: true }`.
 
+## Observability
+
+- Toggle the API badge with `NEXT_PUBLIC_SHOW_API_BADGE=true`.
+- `GET /api/health` → `{ ok: true, services: { app: 'up'|'degraded' }, time }`.
+- `GET /api/version` → `{ ok: true, commit, branch, buildTime, node, next, app }`.
+- Logs are emitted to Vercel Runtime Logs with `[health]` and `[version]` prefixes.
+
 ## Authentication
 
 Session routes in `src/app/api/session` proxy to the backend and set an HTTP-only cookie used for auth. `middleware.ts` protects sensitive pages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  env: {
+    BUILD_TIME: new Date().toISOString(),
+  },
+};
 
 module.exports = nextConfig;
 

--- a/src/app/(marketing)/MarketingHome.tsx
+++ b/src/app/(marketing)/MarketingHome.tsx
@@ -1,21 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { env } from '@/config/env';
-
-type ApiStatus = 'loading' | 'ok' | 'error';
 
 export default function MarketingHome() {
-  const [status, setStatus] = useState<ApiStatus>('loading');
-
-  useEffect(() => {
-    if (env.NEXT_PUBLIC_SHOW_API_BADGE) {
-      fetch('/api/health-check')
-        .then((res) => setStatus(res.ok ? 'ok' : 'error'))
-        .catch(() => setStatus('error'));
-    }
-  }, []);
 
   return (
     <div>
@@ -32,13 +19,6 @@ export default function MarketingHome() {
           </Link>
         </div>
       </section>
-      {env.NEXT_PUBLIC_SHOW_API_BADGE && (
-        <div className="api-badge">
-          {status === 'loading'
-            ? 'Checking API…'
-            : `API: ${status === 'ok' ? 'OK' : 'ERROR'}`}
-        </div>
-      )}
       <section className="features">
         <div className="feature">
           <span className="icon">📝</span>Post gig in minutes

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,17 @@
+import { log } from '@/lib/log';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const envOk = Boolean(process.env.JWT_COOKIE_NAME);
+  const time = new Date().toISOString();
+  const state = envOk ? 'ok' : 'degraded';
+  log(`[health] ${state}`, { envOk, time });
+  return Response.json({
+    ok: true,
+    services: {
+      app: envOk ? 'up' : 'degraded',
+    },
+    time,
+  });
+}

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,24 @@
+import { log } from '@/lib/log';
+import nextPkg from 'next/package.json';
+import appPkg from '../../../../package.json';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const commit = process.env.VERCEL_GIT_COMMIT_SHA || null;
+  const branch = process.env.VERCEL_GIT_COMMIT_REF || null;
+  const buildTime = process.env.BUILD_TIME || null;
+  const node = process.version;
+  const next = nextPkg.version;
+  const app = appPkg.version;
+  log('[version]', { commit, branch, buildTime });
+  return Response.json({
+    ok: true,
+    commit,
+    branch,
+    buildTime,
+    node,
+    next,
+    app,
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,6 @@ import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
 import { env } from '@/config/env';
 import legacyTheme from '@/theme/legacy';
-import { showApiBadge } from '@/lib/config';
 import clsx from 'clsx';
 import type { CSSProperties } from 'react';
 import fs from 'fs';
@@ -190,12 +189,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </ToastProvider>
           </SocketProvider>
         </AuthProvider>
-        {!showApiBadge && (
-          <style
-            // Hide any existing API badge class if present
-            dangerouslySetInnerHTML={{ __html: `.api-badge{display:none!important}` }}
-          />
-        )}
       </body>
     </html>
   );

--- a/src/components/ApiBadge.tsx
+++ b/src/components/ApiBadge.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+
+const showBadge = process.env.NEXT_PUBLIC_SHOW_API_BADGE === 'true';
+
+export default function ApiBadge() {
+  type Status = 'ok' | 'degraded' | 'error';
+  const [status, setStatus] = useState<Status>('degraded');
+
+  async function check() {
+    try {
+      const res = await fetch('/api/health', { credentials: 'same-origin' });
+      const data = await res.json();
+      if (data.ok && data.services?.app === 'up') {
+        setStatus('ok');
+      } else if (data.ok) {
+        setStatus('degraded');
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  useEffect(() => {
+    if (!showBadge) return;
+    check();
+    const id = setInterval(check, 20000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!showBadge) return null;
+
+  const color =
+    status === 'ok'
+      ? 'bg-green-500 text-white'
+      : status === 'degraded'
+      ? 'bg-yellow-400 text-black'
+      : 'bg-red-500 text-white';
+
+  const label =
+    status === 'ok'
+      ? 'API: OK'
+      : status === 'degraded'
+      ? 'API: DEGRADED'
+      : 'API: ERROR';
+
+  return (
+    <span
+      className={clsx(
+        'api-badge inline-block w-24 rounded px-2 py-1 text-center text-xs font-medium',
+        color,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import SessionNav from './SessionNav';
+import ApiBadge from './ApiBadge';
 
 export default function SiteHeader() {
   return (
@@ -9,6 +10,7 @@ export default function SiteHeader() {
           QuickGig.ph
         </Link>
         <nav aria-label="User session" className="flex items-center space-x-4">
+          <ApiBadge />
           <SessionNav />
         </nav>
       </div>

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,9 @@
+export const log = (msg: string, meta?: unknown) => {
+  try { console.info(`[app] ${msg}`, meta ?? {}); } catch {}
+};
+export const warn = (msg: string, meta?: unknown) => {
+  try { console.warn(`[app] ${msg}`, meta ?? {}); } catch {}
+};
+export const error = (msg: string, meta?: unknown) => {
+  try { console.error(`[app] ${msg}`, meta ?? {}); } catch {}
+};


### PR DESCRIPTION
## Summary
- add `/api/health` and `/api/version` for runtime diagnostics
- show optional `<ApiBadge/>` in header controlled by `NEXT_PUBLIC_SHOW_API_BADGE`
- log build time and route calls for Vercel Runtime Logs

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a04dd6db488327bae909a561a12fe5