### PR TITLE
Guard sockets behind session; treat 401 as logged-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ API_URL=https://api.quickgig.ph
 
 # Feature flags
 NEXT_PUBLIC_ENABLE_APPLY=false
+NEXT_PUBLIC_ENABLE_SOCKETS=true
 
 # Saved jobs via API (optional)
 NEXT_PUBLIC_ENABLE_SAVED_API=false

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ To verify the live API locally, run:
 BASE=https://api.quickgig.ph node tools/check_live_api.mjs
 ```
 
+## Sockets
+
+Socket.io connections are disabled on Vercel preview domains by default. They
+automatically enable on production domains when `NEXT_PUBLIC_ENABLE_SOCKETS=true`.
+
 ## Auth
 
 Environment variables:

--- a/src/components/SessionNav.tsx
+++ b/src/components/SessionNav.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { IS_LEGACY_ROUTE } from '@/env/runtime';
+import { fetchSession } from '@/lib/session';
 
 interface User {
   email: string;
@@ -14,12 +16,10 @@ export default function SessionNav() {
   const router = useRouter();
 
   useEffect(() => {
-    fetch('/api/session/me', { credentials: 'same-origin' })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data?.ok && data.user) setUser(data.user as User);
-      })
-      .catch(() => {});
+    if (IS_LEGACY_ROUTE()) return;
+    fetchSession().then((res) => {
+      if (res.ok && res.user) setUser(res.user as User);
+    });
   }, []);
 
   const logout = async () => {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { IS_LEGACY_ROUTE } from '@/env/runtime';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
 import { api } from '@/lib/apiClient';
 import { login as loginApi, register as registerApi, me as meApi } from '@/lib/auth/client';
@@ -45,6 +46,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   useEffect(() => {
+    if (IS_LEGACY_ROUTE()) {
+      setLoading(false);
+      return;
+    }
     fetchMe().finally(() => setLoading(false));
   }, []);
 

--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
-import { useAuth } from './AuthContext';
-import { API_BASE } from '@/lib/api';
+import type { Socket } from 'socket.io-client';
+import { getSocket } from '@/lib/socket';
 
 interface SocketContextType {
   socket: Socket | null;
@@ -30,43 +29,25 @@ interface SocketProviderProps {
 export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
-  const { user, isAuthenticated } = useAuth();
 
   useEffect(() => {
-    if (isAuthenticated && user) {
-      const newSocket = io(API_BASE, { withCredentials: true, transports: ['websocket', 'polling'] });
-
-      newSocket.on('connect', () => {
-        console.log('Connected to server');
-        setIsConnected(true);
-      });
-
-      newSocket.on('disconnect', () => {
-        console.log('Disconnected from server');
-        setIsConnected(false);
-      });
-
-      newSocket.on('connect_error', (error) => {
-        console.error('Connection error:', error);
-        setIsConnected(false);
-      });
-
-      setSocket(newSocket);
-
-      return () => {
-        newSocket.close();
-        setSocket(null);
-        setIsConnected(false);
-      };
-    } else {
-      // Clean up socket if user is not authenticated
-      if (socket) {
-        socket.close();
-        setSocket(null);
-        setIsConnected(false);
-      }
-    }
-  }, [isAuthenticated, user, socket]);
+    let active = true;
+    let localSocket: Socket | null = null;
+    getSocket().then((s) => {
+      if (!active || !s) return;
+      localSocket = s;
+      setSocket(s);
+      setIsConnected(s.connected);
+      s.on('connect', () => setIsConnected(true));
+      s.on('disconnect', () => setIsConnected(false));
+    });
+    return () => {
+      active = false;
+      localSocket?.close();
+      setSocket(null);
+      setIsConnected(false);
+    };
+  }, []);
 
   const joinChat = (chatRoomId: string) => {
     if (socket && isConnected) {

--- a/src/env/runtime.ts
+++ b/src/env/runtime.ts
@@ -1,0 +1,9 @@
+export const IS_BROWSER = typeof window !== 'undefined';
+export const HOST = IS_BROWSER ? window.location.hostname : process.env.NEXT_PUBLIC_VERCEL_URL || '';
+export const IS_VERCEL_PREVIEW = /\.vercel\.app$/.test(HOST);
+export const ENABLE_SOCKETS = (process.env.NEXT_PUBLIC_ENABLE_SOCKETS ?? 'true') === 'true' && !IS_VERCEL_PREVIEW;
+export const IS_LEGACY_ROUTE = () => {
+  if (!IS_BROWSER) return false;
+  const p = window.location.pathname;
+  return p === '/' || p === '/login';
+};

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,11 @@
+export type SessionState = { ok: boolean; user?: unknown; status: number };
+export async function fetchSession(): Promise<SessionState> {
+  try {
+    const res = await fetch('/api/session/me', { credentials: 'include', cache: 'no-store' });
+    if (res.status === 401) return { ok: false, status: 401 };
+    if (!res.ok) return { ok: false, status: res.status };
+    return { ok: true, user: await res.json(), status: 200 };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,0 +1,30 @@
+import { io, Socket } from 'socket.io-client';
+import { ENABLE_SOCKETS, IS_LEGACY_ROUTE } from '@/env/runtime';
+import { fetchSession } from '@/lib/session';
+
+let socket: Socket | null = null;
+
+export async function getSocket(): Promise<Socket | null> {
+  if (!ENABLE_SOCKETS) return null;
+  if (IS_LEGACY_ROUTE()) return null; // marketing pages never open sockets
+  if (socket) return socket;
+
+  const session = await fetchSession();
+  if (!session.ok) return null; // only connect when logged in
+
+  // Same-origin endpoint expected (proxy on server if needed)
+  socket = io('/', {
+    path: '/socket.io',
+    withCredentials: true,
+    transports: ['websocket'],
+    autoConnect: true,
+  });
+
+  socket.on('connect_error', () => {
+    // Don’t spam console; fail closed
+    try { socket?.close(); } catch {}
+    socket = null;
+  });
+
+  return socket;
+}

--- a/tools/check_no_socket_on_legacy.mjs
+++ b/tools/check_no_socket_on_legacy.mjs
@@ -1,0 +1,7 @@
+import fs from 'node:fs';
+const pages = ['src/app/page.tsx','src/app/login/page.tsx'].filter(p => fs.existsSync(p));
+const bad = pages.filter(p => fs.readFileSync(p,'utf8').includes('io('));
+if (bad.length) {
+  console.error('Socket client imported on marketing pages:', bad.join(', '));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add runtime helpers to detect browser, preview domains, and legacy routes
- ensure session fetch handles 401 without error and badge reflects status
- lazily connect socket.io only after authenticated session
- skip session fetch and socket connection on marketing routes
- document and gate sockets with `NEXT_PUBLIC_ENABLE_SOCKETS`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `node tools/check_no_socket_on_legacy.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a06d7fd8448327adac9dda7b404039