### PR TITLE
chore(ci): add legacy guard script, wire into CI, and document usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           cache: 'npm'
       - name: Install
         run: npm ci
+      - name: Legacy guard
+        run: npm run check:legacy
       - name: Lint
         run: npm run lint
       - name: Typecheck

--- a/docs/LEGACY_GUARD.md
+++ b/docs/LEGACY_GUARD.md
@@ -1,0 +1,14 @@
+# Legacy Guard
+
+Prevents real-time socket code from reaching static marketing pages (`/` and `/login`).
+
+## Run locally
+
+```bash
+npm run check:legacy
+```
+
+## If the guard fails
+
+Move any `socket.io-client`, `io()`, or `WebSocket` usage out of these pages or guard it behind client-only, non-marketing routes.
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:app:soft": "node tools/check_live_app.mjs || true",
     "check:dns:app": "node tools/check_dns_app.mjs",
     "check:jobs": "node tools/check_jobs_api.mjs || true",
+    "check:legacy": "node tools/check_no_socket_on_legacy.mjs",
     "smoke": "node tools/smoke.mjs",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",

--- a/tools/check_no_socket_on_legacy.mjs
+++ b/tools/check_no_socket_on_legacy.mjs
@@ -1,7 +1,35 @@
 import fs from 'node:fs';
-const pages = ['src/app/page.tsx','src/app/login/page.tsx'].filter(p => fs.existsSync(p));
-const bad = pages.filter(p => fs.readFileSync(p,'utf8').includes('io('));
-if (bad.length) {
-  console.error('Socket client imported on marketing pages:', bad.join(', '));
-  process.exit(1);
+import path from 'node:path';
+
+const candidates = [
+  'src/app/page.tsx',
+  'src/app/login/page.tsx',
+  'app/page.tsx',
+  'app/login/page.tsx',
+  'pages/index.tsx',
+  'pages/index.jsx',
+  'pages/login.tsx',
+  'pages/login.jsx',
+];
+
+const existing = candidates.filter(p => fs.existsSync(path.join(process.cwd(), p)));
+const patterns = [
+  /from\s+['"]socket\.io-client['"]/,
+  /require\(['"]socket\.io-client['"]\)/,
+  /\bio\s*\(/,
+  /\bnew\s+WebSocket\s*\(/,
+];
+
+const bad = [];
+for (const file of existing) {
+  const src = fs.readFileSync(path.join(process.cwd(), file), 'utf8');
+  if (patterns.some(rx => rx.test(src))) bad.push(file);
 }
+
+if (bad.length) {
+  console.error('❌ Legacy guard failed. Realtime/socket code found in marketing pages:\n  - ' + bad.join('\n  - '));
+  process.exit(1);
+} else {
+  console.log('✅ Legacy guard OK (no socket/realtime code in marketing pages).');
+}
+


### PR DESCRIPTION
## Summary
* add socket/WebSocket marketing-page guard and npm script
* run guard in CI before build
* document legacy guard usage

## Testing
- `npm run check:legacy`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a073348bec8327ac9315170a089844