### PR TITLE
feat(legacy): enable strict legacy shell by default, hide API badge, add runtime sanity checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ ADMIN_EMAILS=you@quickgig.ph,moderator@quickgig.ph
 NEXT_PUBLIC_ENABLE_ANALYTICS=true
 METRICS_SECRET=change-me
 
-# Legacy marketing UI flags
+# Legacy marketing UI flags (enabled by default)
 NEXT_PUBLIC_LEGACY_UI=true
 NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ NEXT_PUBLIC_ENABLE_APPLY=false
 NEXT_PUBLIC_ENV=local
 ```
 
-3. To preview the legacy marketing shell locally, set:
-```env
-NEXT_PUBLIC_LEGACY_UI=true
-NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
-NEXT_PUBLIC_SHOW_API_BADGE=false
-NEXT_PUBLIC_BANNER_HTML=
-```
+3. Legacy marketing UI is **ON by default**. Ensure these files exist:
+
+   - `public/legacy/styles.css`
+   - `public/legacy/index.fragment.html`
+   - `public/legacy/login.fragment.html`
+
+   To override, adjust the flags in `.env.local`:
+
+   ```env
+   NEXT_PUBLIC_LEGACY_UI=true
+   NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
+   NEXT_PUBLIC_SHOW_API_BADGE=false
+   NEXT_PUBLIC_BANNER_HTML=
+   ```
 
 To verify the live API locally, run:
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,6 @@ import ClientBootstrap from './ClientBootstrap';
 import ClientAuthGuard from './ClientAuthGuard';
 import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
-import { env } from '@/config/env';
 import legacyTheme from '@/theme/legacy';
 import clsx from 'clsx';
 import type { CSSProperties } from 'react';
@@ -87,7 +86,7 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const legacy = env.NEXT_PUBLIC_LEGACY_UI;
+  const legacy = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
   const legacyVars: CSSProperties | undefined = legacy
     ? ({
         '--legacy-color-bg': legacyTheme.colors.bg,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,7 +2,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import React from 'react';
-import { loadFragment, injectLegacyStyles } from '@/lib/legacyFragments';
+import { loadFragment, injectLegacyStyles, verifyLegacyAssets } from '@/lib/legacyFragments';
 import LegacyLogin from './LegacyLogin';
 import './legacy-login.css';
 
@@ -16,6 +16,17 @@ export default function LoginPage({ searchParams }: Props) {
   const nextUrl = typeof searchParams?.next === 'string' ? searchParams.next : undefined;
 
   if (legacy) {
+    const missing = verifyLegacyAssets();
+    if (missing.length) {
+      // eslint-disable-next-line no-console
+      console.error('[legacy] missing assets:', missing.join(', '));
+      return (
+        <div className="p-4 text-red-600">
+          Missing legacy assets: {missing.join(', ')}
+        </div>
+      );
+    }
+
     const header = strict ? loadFragment('header') : '';
     const footer = strict ? loadFragment('footer') : '';
     const main = loadFragment('login');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,24 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import React from 'react';
-import { loadFragment, injectLegacyStyles } from '@/lib/legacyFragments';
+import { loadFragment, injectLegacyStyles, verifyLegacyAssets } from '@/lib/legacyFragments';
 
 export default function Page() {
   const legacy = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
   const strict = process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL === 'true';
+
+  if (legacy) {
+    const missing = verifyLegacyAssets();
+    if (missing.length) {
+      // eslint-disable-next-line no-console
+      console.error('[legacy] missing assets:', missing.join(', '));
+      return (
+        <div className="p-4 text-red-600">
+          Missing legacy assets: {missing.join(', ')}
+        </div>
+      );
+    }
+  }
 
   if (legacy && strict) {
     const header = loadFragment('header');

--- a/src/lib/legacyFragments.ts
+++ b/src/lib/legacyFragments.ts
@@ -1,9 +1,15 @@
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 import { load } from 'cheerio';
 
 const LEGACY_DIR = path.join(process.cwd(), 'public', 'legacy');
 const legacyLogin = ['login', 'php'].join('.');
+
+const REQUIRED_ASSETS = [
+  'styles.css',
+  'index.fragment.html',
+  'login.fragment.html',
+];
 
 function sanitize(html: string): string {
   const $ = load(html);
@@ -41,4 +47,8 @@ export function loadFragment(name: 'index' | 'login' | 'header' | 'footer'): str
 export function injectLegacyStyles(html: string): string {
   if (html.includes('/legacy/styles.css')) return html;
   return `<link rel="stylesheet" href="/legacy/styles.css">\n${html}`;
+}
+
+export function verifyLegacyAssets(): string[] {
+  return REQUIRED_ASSETS.filter((file) => !existsSync(path.join(LEGACY_DIR, file)));
 }


### PR DESCRIPTION
## Summary
- enable legacy marketing shell by default and allow strict shell mode
- hide API badge unless explicitly enabled
- check for missing legacy asset files and render a helpful warning

## Testing
- `npm run legacy:verify`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07724c81483278f19503efa511879