### PR TITLE
feat(legacy): render legacy shell with banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,12 +30,11 @@ ADMIN_EMAILS=you@quickgig.ph,moderator@quickgig.ph
 NEXT_PUBLIC_ENABLE_ANALYTICS=true
 METRICS_SECRET=change-me
 
-# Legacy marketing UI flags (enabled by default)
+# Legacy UI flags
 NEXT_PUBLIC_LEGACY_UI=true
-NEXT_PUBLIC_LEGACY_STRICT_SHELL=false
-
-# Observability
+NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
 NEXT_PUBLIC_SHOW_API_BADGE=false
+# Optional banner
 NEXT_PUBLIC_BANNER_HTML=
 
 # Session/auth

--- a/docs/LEGACY_IMPORT.md
+++ b/docs/LEGACY_IMPORT.md
@@ -9,6 +9,18 @@ export NEXT_PUBLIC_LEGACY_UI=true
 export NEXT_PUBLIC_LEGACY_STRICT_SHELL=true # optional
 ```
 
+## Render the legacy shell
+
+```env
+# Flags
+NEXT_PUBLIC_LEGACY_UI=true
+NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
+NEXT_PUBLIC_SHOW_API_BADGE=false
+NEXT_PUBLIC_BANNER_HTML='<div class="mx-auto max-w-6xl px-4 py-2 text-center text-sm rounded-xl border border-[var(--legacy-cta-outline)] shadow-[var(--legacy-shadow)]" style="background:radial-gradient(100% 120% at 0% 0%, var(--legacy-bg-start), var(--legacy-bg-end));color:var(--legacy-hero-text)"><strong>Heads up:</strong> Beta preview of the new QuickGig.ph experience.</div>'
+```
+
+The banner value must be on a single line or escaped properly if multi-line. Redeploy after changing environment variables.
+
 ## Import
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "legacy:verify": "node tools/legacy/verify.mjs --verify",
     "legacy:tree": "node -e \"import('fs').then(fs=>{const {readdirSync, statSync}=fs.default;function tree(d,p=''){for(const f of readdirSync(d)){const fp=d+'/'+f;const s=statSync(fp);console.log(p+(s.isDirectory()?'📁 ':'📄 ')+f); if(s.isDirectory()) tree(fp,p+'  ');} } try{tree('public/legacy');}catch(e){console.log('public/legacy not found');}})\"",
     "legacy:check": "node tools/legacy/verify.mjs --check",
-    "legacy:import": "node tools/legacy/import_from_dir.mjs"
+    "legacy:import": "node tools/legacy/import_from_dir.mjs",
+    "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/src/app/_health/legacy/route.ts
+++ b/src/app/_health/legacy/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET() {
+  const base = path.join(process.cwd(), 'public', 'legacy');
+  const index = await fileExists(path.join(base, 'index.fragment.html'));
+  const login = await fileExists(path.join(base, 'login.fragment.html'));
+  const css = await fileExists(path.join(base, 'styles.css'));
+  return NextResponse.json({ exists: true, index, login, css });
+}
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,33 +2,13 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import React from 'react';
-import LegacyShell from '@/app/(marketing)/LegacyShell';
-import { verifyLegacyAssets } from '@/lib/legacyFragments';
-import './legacy-login.css';
+import { legacyUI } from '@/lib/flags';
+import { renderLegacyLogin } from '@/lib/legacy/renderLegacy';
 
-interface Props {
-  searchParams?: { next?: string };
-}
-
-export default function LoginPage({ searchParams }: Props) {
-  const legacy = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
-  const strict = process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL === 'true';
-  const nextUrl = typeof searchParams?.next === 'string' ? searchParams.next : undefined;
-
-  if (legacy) {
-    const missing = verifyLegacyAssets();
-    if (!missing.length) {
-      return <LegacyShell fragment="login" nextUrl={nextUrl} />;
-    }
-    if (strict) {
-      // eslint-disable-next-line no-console
-      console.error('[legacy] missing assets:', missing.join(', '));
-      return (
-        <div className="p-4 text-red-600">
-          Missing legacy assets: {missing.join(', ')}
-        </div>
-      );
-    }
+export default async function LoginPage() {
+  if (legacyUI) {
+    const html = await renderLegacyLogin();
+    return <div suppressHydrationWarning dangerouslySetInnerHTML={{ __html: html }} />;
   }
 
   return <div className="p-4">Login</div>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,27 +2,13 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import React from 'react';
-import LegacyShell from '@/app/(marketing)/LegacyShell';
-import { verifyLegacyAssets } from '@/lib/legacyFragments';
+import { legacyUI } from '@/lib/flags';
+import { renderLegacyHome } from '@/lib/legacy/renderLegacy';
 
-export default function Page() {
-  const legacy = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
-  const strict = process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL === 'true';
-
-  if (legacy) {
-    const missing = verifyLegacyAssets();
-    if (!missing.length) {
-      return <LegacyShell fragment="index" />;
-    }
-    if (strict) {
-      // eslint-disable-next-line no-console
-      console.error('[legacy] missing assets:', missing.join(', '));
-      return (
-        <div className="p-4 text-red-600">
-          Missing legacy assets: {missing.join(', ')}
-        </div>
-      );
-    }
+export default async function Page() {
+  if (legacyUI) {
+    const html = await renderLegacyHome();
+    return <div suppressHydrationWarning dangerouslySetInnerHTML={{ __html: html }} />;
   }
 
   // Fallback: existing React home (keep your current implementation below)

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,3 @@
+export const legacyUI = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
+export const strictShell = process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL === 'true';
+export const bannerHTML = process.env.NEXT_PUBLIC_BANNER_HTML || '';

--- a/src/lib/legacy/__tests__/sanitize.test.ts
+++ b/src/lib/legacy/__tests__/sanitize.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sanitizeLegacyHtml, renderLegacyHome } from '../renderLegacy';
+
+test('removes scripts and handlers', () => {
+  const input = `
+    <div onclick="alert('x')">
+      <img src="/img/a.png" />
+      <img src="img/b.png" />
+      <link href="/fonts/a.woff" />
+      <link href="fonts/b.woff" />
+      <script>alert('hi')</script>
+    </div>
+  `;
+  const out = sanitizeLegacyHtml(input);
+  assert(!out.includes('<script'));
+  assert(!out.includes('onclick'));
+  assert(out.includes('src="/legacy/img/a.png"'));
+  assert(out.includes('src="/legacy/img/b.png"'));
+  assert(out.includes('href="/legacy/fonts/a.woff"'));
+  assert(out.includes('href="/legacy/fonts/b.woff"'));
+});
+
+test('banner HTML is sanitized', async () => {
+  process.env.NEXT_PUBLIC_BANNER_HTML = '<div onclick="evil()"><script>alert(1)</script><span>Hi</span></div>';
+  const out = await renderLegacyHome();
+  assert(out.includes('<span>Hi</span>'));
+  assert(!out.includes('onclick'));
+  assert(!out.includes('<script'));
+  delete process.env.NEXT_PUBLIC_BANNER_HTML;
+});
+

--- a/src/lib/legacy/renderLegacy.ts
+++ b/src/lib/legacy/renderLegacy.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { load, type Element } from 'cheerio';
+
+const LEGACY_DIR = path.join(process.cwd(), 'public', 'legacy');
+const CSS_PATH = '/legacy/styles.css';
+
+export function sanitizeLegacyHtml(html: string): string {
+  const $ = load(html, { decodeEntities: false }, false);
+
+  $('script').remove();
+  $('*').each((_, el) => {
+    const attrs = (el as Element).attribs || {};
+    for (const name of Object.keys(attrs)) {
+      if (name.toLowerCase().startsWith('on')) {
+        $(el).removeAttr(name);
+      }
+    }
+  });
+
+  const rewrite = (val: string): string => {
+    if (/^https?:/i.test(val)) return val;
+    if (val.startsWith('/img/')) return '/legacy' + val;
+    if (val.startsWith('img/')) return '/legacy/' + val;
+    if (val.startsWith('/fonts/')) return '/legacy' + val;
+    if (val.startsWith('fonts/')) return '/legacy/' + val;
+    return val;
+  };
+
+  $('[src],[href]').each((_, el) => {
+    for (const attr of ['src', 'href']) {
+      const val = $(el).attr(attr);
+      if (!val) continue;
+      $(el).attr(attr, rewrite(val));
+    }
+  });
+
+  $('[srcset]').each((_, el) => {
+    const val = $(el).attr('srcset');
+    if (!val) return;
+    const parts = val.split(',').map((part) => {
+      const [url, descriptor] = part.trim().split(/\s+/);
+      const rewritten = rewrite(url);
+      return descriptor ? `${rewritten} ${descriptor}` : rewritten;
+    });
+    $(el).attr('srcset', parts.join(', '));
+  });
+
+  return $.root().children().toString();
+}
+
+async function readFragment(name: string): Promise<string> {
+  const file = path.join(LEGACY_DIR, `${name}.fragment.html`);
+  const fragment = await fs.readFile(file, 'utf8');
+  return sanitizeLegacyHtml(fragment);
+}
+
+function injectBanner(html: string): string {
+  const bannerRaw = process.env.NEXT_PUBLIC_BANNER_HTML;
+  if (!bannerRaw) return html;
+  const safe = sanitizeLegacyHtml(bannerRaw);
+  return safe + html;
+}
+
+async function withStyles(html: string): Promise<string> {
+  // Ensure CSS file exists
+  await fs.readFile(path.join(LEGACY_DIR, 'styles.css'), 'utf8');
+  const links = `<link rel="preload" as="style" href="${CSS_PATH}"><link rel="stylesheet" href="${CSS_PATH}">`;
+  return links + html;
+}
+
+export async function renderLegacyHome(): Promise<string> {
+  const content = await readFragment('index');
+  const withBanner = injectBanner(content);
+  return withStyles(withBanner);
+}
+
+export async function renderLegacyLogin(): Promise<string> {
+  let content = await readFragment('login');
+  const $ = load(content, { decodeEntities: false });
+  $('form').attr('action', '/api/session/login');
+  content = $.root().children().toString();
+  const withBanner = injectBanner(content);
+  return withStyles(withBanner);
+}
+


### PR DESCRIPTION
## Summary
- render legacy marketing fragments via `renderLegacy` utility with style preload and optional sanitized banner
- gate legacy shell via env flags and expose _health/legacy route
- document legacy shell flags and add sanitizer tests

## Testing
- `npm test`
- `npm run lint` *(fails: Do not include stylesheets manually, missing deps, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a130e998508327afd0bf2da572bf10