### PR TITLE
fix(import): make legacy importer robust to spaces, add tilde/quote handling + dry-run, tighten verify, and update docs/scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint && npm run typecheck
+      - name: Import (dry run – no local files in CI)
+        run: LEGACY_IMPORT_DRY_RUN=true npm run legacy:import -- --from "$HOME/QuickGig Project/frontend/public/legacy"
       - run: npm run legacy:verify

--- a/docs/LEGACY_IMPORT.md
+++ b/docs/LEGACY_IMPORT.md
@@ -1,5 +1,20 @@
 # Legacy asset import
 
+## Quick start
+
+```sh
+# Option A (env var)
+export LEGACY_SRC="$HOME/Documents/QuickGig Project/frontend/public/legacy"
+npm run legacy:import
+npm run legacy:verify
+
+# Option B (flag)
+npm run legacy:import -- --from "$HOME/Documents/QuickGig Project/frontend/public/legacy"
+npm run legacy:verify
+```
+
+Note: wrap the path in quotes if it contains spaces.
+
 ## Prerequisites
 
 Set the following environment variables while validating the legacy UI:
@@ -21,13 +36,6 @@ NEXT_PUBLIC_BANNER_HTML='<div class="mx-auto max-w-6xl px-4 py-2 text-center tex
 
 The banner value must be on a single line or escaped properly if multi-line. Redeploy after changing environment variables.
 
-## Import
-
-```sh
-npm run legacy:import -- --from "$HOME/QuickGig Project/frontend/public/legacy"
-npm run legacy:verify
-```
-
 ## Commit & PR
 
 ```sh
@@ -39,7 +47,8 @@ git push -u origin chore/import-real-legacy
 
 ## Troubleshooting
 
-- Ensure `styles.css`, `index.fragment.html`, and `login.fragment.html` exist in the source directory.
+- **Missing source directory** – ensure the path is correct or set `LEGACY_SRC`; wrap paths with spaces in quotes.
+- **Missing styles.css** – ensure `styles.css`, `index.fragment.html`, and `login.fragment.html` exist in the source directory.
 - Asset paths are rewritten to `/legacy/img/...` and `/legacy/fonts/...` automatically.
 - Missing `img` or `fonts` folders produce warnings but do not stop the import.
 - `logo-icon.png` is copied to `public/favicon.png` if present; absence is not an error.

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "scan:links": "node tools/check_links.mjs",
     "bootstrap": "node tools/dev/bootstrap.mjs",
     "legacy:sync": "node tools/legacy/sync.js",
-    "legacy:verify": "node tools/legacy/verify.mjs --verify",
+    "legacy:verify": "node tools/legacy_verify.mjs",
     "legacy:tree": "node -e \"import('fs').then(fs=>{const {readdirSync, statSync}=fs.default;function tree(d,p=''){for(const f of readdirSync(d)){const fp=d+'/'+f;const s=statSync(fp);console.log(p+(s.isDirectory()?'📁 ':'📄 ')+f); if(s.isDirectory()) tree(fp,p+'  ');} } try{tree('public/legacy');}catch(e){console.log('public/legacy not found');}})\"",
-    "legacy:check": "node tools/legacy/verify.mjs --check",
-    "legacy:import": "node tools/legacy/import_from_dir.mjs",
+    "legacy:check": "node tools/legacy_verify.mjs --pretty",
+    "legacy:import": "node tools/import_from_dir.mjs",
     "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js"
   },
   "dependencies": {

--- a/tools/lib/paths.mjs
+++ b/tools/lib/paths.mjs
@@ -1,0 +1,24 @@
+import os from 'os';
+import path from 'path';
+
+export function stripQuotes(s = '') {
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+export function expandTilde(p = '') {
+  const home = os.homedir();
+  if (p.startsWith('~')) {
+    return path.join(home, p.slice(1));
+  }
+  if (p.startsWith('$HOME')) {
+    return path.join(home, p.slice(5));
+  }
+  return p;
+}
+
+export function resolveInputPath(input = '') {
+  return path.resolve(expandTilde(stripQuotes(input)));
+}


### PR DESCRIPTION
## Summary
- add path utilities for quote stripping, tilde expansion, and resolution
- enhance legacy import script with env/arg parsing, dry-run, and sanitization
- simplify legacy verify to only fail when required files are missing and add pretty output
- document import flow with paths containing spaces and update CI

## Testing
- `node tools/import_from_dir.mjs --help`
- `LEGACY_IMPORT_DRY_RUN=true npm run legacy:import -- --from "$HOME/QuickGig Project/frontend/public/legacy"`
- `npm run legacy:check`
- `npm run legacy:verify`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13eab42d48327874e8fcebbfdc7f0