### PR TITLE
feat(legacy): add self-test API & diagnostics page, force-legacy override, and strict no-lorem verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "legacy:tree": "node -e \"import('fs').then(fs=>{const {readdirSync, statSync}=fs.default;function tree(d,p=''){for(const f of readdirSync(d)){const fp=d+'/'+f;const s=statSync(fp);console.log(p+(s.isDirectory()?'📁 ':'📄 ')+f); if(s.isDirectory()) tree(fp,p+'  ');} } try{tree('public/legacy');}catch(e){console.log('public/legacy not found');}})\"",
     "legacy:check": "node tools/legacy_verify.mjs --pretty",
     "legacy:import": "node tools/import_from_dir.mjs",
-    "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js"
+    "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js",
+    "legacy:verify:strict": "node scripts/legacy-verify-strict.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/legacy-verify-strict.mjs
+++ b/scripts/legacy-verify-strict.mjs
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+const requiredFiles = [
+  'public/legacy/index.fragment.html',
+  'public/legacy/login.fragment.html',
+  'public/legacy/styles.css',
+];
+
+const disallowed = /(lorem ipsum|placeholder|lipsum|TODO)/i;
+const disallowedTag = /<script\b/i;
+const disallowedHandler = /on\w+=/i;
+
+let errors = [];
+
+for (const file of requiredFiles) {
+  if (!fs.existsSync(file)) {
+    errors.push(`missing required file: ${file}`);
+  }
+}
+
+const htmlFiles = requiredFiles.filter(f => f.endsWith('.html'));
+const cssFiles = requiredFiles.filter(f => f.endsWith('.css'));
+
+for (const file of [...htmlFiles, ...cssFiles]) {
+  if (!fs.existsSync(file)) continue;
+  const content = fs.readFileSync(file, 'utf8');
+  if (disallowed.test(content)) {
+    errors.push(`disallowed placeholder in ${file}`);
+  }
+  if (file.endsWith('.html')) {
+    if (disallowedTag.test(content)) {
+      errors.push(`script tag found in ${file}`);
+    }
+    if (disallowedHandler.test(content)) {
+      errors.push(`inline event handler found in ${file}`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error('Legacy strict verify failed:\n' + errors.map(e => ` - ${e}`).join('\n'));
+  process.exit(1);
+} else {
+  console.log('Legacy strict verify passed');
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import type { CSSProperties } from 'react';
 import fs from 'fs';
 import path from 'path';
 import '../styles/legacy.css';
+import { legacyEnabled, getOverrideSource } from '@/lib/legacy';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -86,7 +87,10 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const legacy = process.env.NEXT_PUBLIC_LEGACY_UI === 'true';
+  const legacy = legacyEnabled();
+  if (legacy) {
+    console.info('LEGACY_UI:on', { source: getOverrideSource() });
+  }
   const legacyVars: CSSProperties | undefined = legacy
     ? ({
         '--legacy-color-bg': legacyTheme.colors.bg,

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1,0 +1,68 @@
+export type LegacySource = 'env' | 'url' | 'localStorage' | 'none';
+
+let overrideSource: LegacySource = 'none';
+
+export function legacyEnabled(url?: string): boolean {
+  if (process.env.NEXT_PUBLIC_LEGACY_UI === 'true') {
+    overrideSource = 'env';
+    return true;
+  }
+
+  let search = '';
+  if (typeof window !== 'undefined') {
+    search = window.location.search;
+  } else if (url) {
+    try {
+      const u = new URL(url, 'http://localhost');
+      search = u.search;
+    } catch {
+      search = '';
+    }
+  }
+
+  const params = new URLSearchParams(search);
+  const legacyParam = params.get('legacy');
+  if (legacyParam === '1' || legacyParam === '0') {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('legacy_ui', legacyParam);
+      overrideSource = 'url';
+      params.delete('legacy');
+      const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}${window.location.hash}`;
+      window.location.replace(newUrl);
+    } else {
+      overrideSource = 'url';
+    }
+    return legacyParam === '1';
+  }
+
+  const lsVal = typeof window !== 'undefined' ? localStorage.getItem('legacy_ui') : null;
+  if (lsVal === '1') {
+    overrideSource = 'localStorage';
+    return true;
+  }
+  if (lsVal === '0') {
+    overrideSource = 'localStorage';
+    return false;
+  }
+
+  overrideSource = 'none';
+  return false;
+}
+
+export function getOverrideSource(): LegacySource {
+  return overrideSource;
+}
+
+export function setLegacyOverride(val: '1' | '0') {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('legacy_ui', val);
+    window.location.reload();
+  }
+}
+
+export function clearLegacyOverride() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem('legacy_ui');
+    window.location.reload();
+  }
+}

--- a/src/pages/_legacy-diag.tsx
+++ b/src/pages/_legacy-diag.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { legacyEnabled, getOverrideSource, setLegacyOverride, clearLegacyOverride } from '@/lib/legacy';
+
+interface SelfTest {
+  env: Record<string, string | null>;
+  overrideSource: string;
+  index: { exists: boolean };
+  login: { exists: boolean };
+  styles: { exists: boolean };
+  font: { exists: boolean };
+  alerts: string[];
+  [key: string]: unknown;
+}
+
+export default function LegacyDiag() {
+  const [data, setData] = useState<SelfTest | null>(null);
+
+  useEffect(() => {
+    legacyEnabled();
+    fetch('/api/legacy-selftest').then(r => r.json()).then(setData);
+  }, []);
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: 20 }}>
+      <h1>Legacy Diagnostics</h1>
+      <section>
+        <p>NEXT_PUBLIC_LEGACY_UI: {process.env.NEXT_PUBLIC_LEGACY_UI}</p>
+        <p>NEXT_PUBLIC_LEGACY_STRICT_SHELL: {process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL}</p>
+        <p>NEXT_PUBLIC_SHOW_API_BADGE: {process.env.NEXT_PUBLIC_SHOW_API_BADGE}</p>
+        <p>override source: {getOverrideSource()}</p>
+      </section>
+      <section style={{ marginTop: 20 }}>
+        <button onClick={() => setLegacyOverride('1')}>Force Legacy ON</button>{' '}
+        <button onClick={() => setLegacyOverride('0')}>Force Legacy OFF</button>{' '}
+        <button onClick={clearLegacyOverride}>Clear Override</button>
+      </section>
+      <section style={{ marginTop: 20 }}>
+        <a href="/?legacy=1">/?legacy=1</a> | <a href="/login?legacy=1">/login?legacy=1</a>
+      </section>
+      <section style={{ marginTop: 20 }}>
+        {data ? (
+          <>
+            <ul>
+              {['index', 'login', 'styles', 'font'].map((k) => (
+                <li key={k}>
+                  {k}: {data[k]?.exists ? '✅' : '❌'}
+                </li>
+              ))}
+            </ul>
+            {data.alerts.length > 0 && (
+              <div>
+                Alerts:
+                <ul>
+                  {data.alerts.map((a) => (
+                    <li key={a}>❌ {a}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <pre>{JSON.stringify(data, null, 2)}</pre>
+          </>
+        ) : (
+          <p>Loading...</p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export async function getServerSideProps() {
+  if (process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_ENABLE_LEGACY_DIAG !== 'true') {
+    return { notFound: true };
+  }
+  return { props: {} };
+}

--- a/src/pages/api/legacy-selftest.ts
+++ b/src/pages/api/legacy-selftest.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { legacyEnabled, getOverrideSource } from '@/lib/legacy';
+
+type FileInfo = {
+  exists: boolean;
+  size: number;
+  sha256: string | null;
+  first200: string | null;
+};
+
+function sanitize(str: string): string {
+  return str.replace(/[\u0000-\u001F\u007F<>]/g, '');
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  legacyEnabled(req.url || '');
+  const alerts: string[] = [];
+  const base = process.cwd();
+  const files = {
+    index: 'public/legacy/index.fragment.html',
+    login: 'public/legacy/login.fragment.html',
+    styles: 'public/legacy/styles.css',
+    font: 'public/legacy/fonts/LegacySans.woff2',
+  } as const;
+
+  const getInfo = (rel: string, text: boolean): FileInfo => {
+    const fp = path.join(base, rel);
+    try {
+      const buf = fs.readFileSync(fp);
+      const hash = crypto.createHash('sha256').update(buf).digest('hex');
+      const info: FileInfo = { exists: true, size: buf.length, sha256: hash, first200: null };
+      if (text) {
+        const str = buf.toString('utf8');
+        info.first200 = sanitize(str.slice(0, 200));
+        if (/(lorem ipsum|placeholder|lipsum|TODO)/i.test(str)) {
+          alerts.push(`${rel} contains placeholder text`);
+        }
+      }
+      return info;
+    } catch {
+      return { exists: false, size: 0, sha256: null, first200: null };
+    }
+  };
+
+  const data = {
+    env: {
+      NEXT_PUBLIC_LEGACY_UI: process.env.NEXT_PUBLIC_LEGACY_UI || null,
+      NEXT_PUBLIC_LEGACY_STRICT_SHELL: process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL || null,
+      NEXT_PUBLIC_SHOW_API_BADGE: process.env.NEXT_PUBLIC_SHOW_API_BADGE || null,
+    },
+    overrideSource: getOverrideSource(),
+    index: getInfo(files.index, true),
+    login: getInfo(files.login, true),
+    styles: getInfo(files.styles, true),
+    font: getInfo(files.font, false),
+    alerts,
+  };
+
+  res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- add strict verification script blocking placeholder text and inline scripts in legacy assets
- expose `/api/legacy-selftest` and `_legacy-diag` diagnostics page with override controls
- wire helper to force legacy shell via env, URL, or localStorage

## Testing
- `npm run legacy:verify:strict`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a15cc0a2c483279fdd5726ea41e8cb