### PR TITLE
feat(legacy): add missing helper, self-test API, diagnostics page, and strict verifier; fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "legacy:tree": "node -e \"import('fs').then(fs=>{const {readdirSync, statSync}=fs.default;function tree(d,p=''){for(const f of readdirSync(d)){const fp=d+'/'+f;const s=statSync(fp);console.log(p+(s.isDirectory()?'📁 ':'📄 ')+f); if(s.isDirectory()) tree(fp,p+'  ');} } try{tree('public/legacy');}catch(e){console.log('public/legacy not found');}})\"",
     "legacy:check": "node tools/legacy_verify.mjs --pretty",
     "legacy:import": "node tools/import_from_dir.mjs",
-    "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js"
+    "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js",
+    "legacy:verify:strict": "node scripts/legacy-verify-strict.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/legacy-verify-strict.mjs
+++ b/scripts/legacy-verify-strict.mjs
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = process.cwd();
+const must = [
+  'public/legacy/index.fragment.html',
+  'public/legacy/login.fragment.html',
+  'public/legacy/styles.css',
+];
+
+const badText = [
+  /lorem ipsum/i,
+  /\bplaceholder\b/i,
+  /\blipsum\b/i,
+  /\bTODO\b/i,
+];
+
+const disallow = [
+  /<script\b/i,
+  /\bon[a-z]+\s*=/i,
+  /javascript\s*:/i,
+];
+
+function read(file) {
+  try { return fs.readFileSync(path.join(root, file), 'utf8'); }
+  catch { return null; }
+}
+
+let errs = [];
+
+// required files
+for (const f of must) {
+  if (!fs.existsSync(path.join(root, f))) errs.push(`Missing required file: ${f}`);
+}
+
+// scan html/css for placeholders and disallowed patterns
+const scanFiles = (dir) => {
+  if (!fs.existsSync(path.join(root, dir))) return;
+  const walk = (p) => {
+    for (const name of fs.readdirSync(p)) {
+      const full = path.join(p, name);
+      const rel = path.relative(root, full);
+      const st = fs.statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (/\.(html|css)$/i.test(name)) {
+        const txt = fs.readFileSync(full, 'utf8');
+        for (const rx of badText) if (rx.test(txt)) errs.push(`Placeholder text found in ${rel} (${rx})`);
+        for (const rx of disallow) if (rx.test(txt)) errs.push(`Disallowed pattern in ${rel} (${rx})`);
+      }
+    }
+  };
+  walk(path.join(root, dir));
+};
+scanFiles('public/legacy');
+
+if (errs.length) {
+  console.error('legacy:verify:strict failed:\n- ' + errs.join('\n- '));
+  process.exit(1);
+} else {
+  console.log('legacy:verify:strict OK');
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -27,18 +27,19 @@ function JobsPageContent() {
 
   // read filters from URL
   useEffect(() => {
+    const params = search ?? new URLSearchParams();
     const f: JobFilters = {
-      q: search.get('q') || undefined,
-      location: search.get('location') || undefined,
-      category: search.get('category') || undefined,
-      type: search.get('type') || undefined,
-      remote: search.get('remote') === '1',
-      minSalary: search.get('minSalary') ? Number(search.get('minSalary')) : undefined,
-      maxSalary: search.get('maxSalary') ? Number(search.get('maxSalary')) : undefined,
-      sort: (search.get('sort') as JobFilters['sort']) || undefined,
-      page: search.get('page') ? Number(search.get('page')) : 1,
-      limit: search.get('limit') ? Number(search.get('limit')) : 20,
-      savedOnly: search.get('saved') === '1',
+      q: params.get('q') || undefined,
+      location: params.get('location') || undefined,
+      category: params.get('category') || undefined,
+      type: params.get('type') || undefined,
+      remote: params.get('remote') === '1',
+      minSalary: params.get('minSalary') ? Number(params.get('minSalary')) : undefined,
+      maxSalary: params.get('maxSalary') ? Number(params.get('maxSalary')) : undefined,
+      sort: (params.get('sort') as JobFilters['sort']) || undefined,
+      page: params.get('page') ? Number(params.get('page')) : 1,
+      limit: params.get('limit') ? Number(params.get('limit')) : 20,
+      savedOnly: params.get('saved') === '1',
     };
     setFilters(f);
   }, [search]);

--- a/src/app/messages/[id]/page.tsx
+++ b/src/app/messages/[id]/page.tsx
@@ -10,7 +10,7 @@ import { track } from '@/lib/track';
 
 export default function ThreadPage() {
   const params = useParams<{ id: string }>();
-  const id = params.id;
+  const id = params?.id ?? '';
   const [thread, setThread] = useState<Thread>({ messages: [] });
 
   async function load() {

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1,0 +1,37 @@
+export type LegacySource = 'env' | 'url' | 'localStorage' | 'none';
+
+function coerceBool(v: unknown): boolean {
+  return String(v).toLowerCase() === 'true';
+}
+
+export function readLegacyFlagClient(): { enabled: boolean; source: LegacySource } {
+  let enabled = coerceBool(process.env.NEXT_PUBLIC_LEGACY_UI);
+  let source: LegacySource = enabled ? 'env' : 'none';
+
+  if (typeof window !== 'undefined') {
+    const url = new URL(window.location.href);
+    const q = url.searchParams.get('legacy');
+
+    if (q === '1' || q === '0') {
+      localStorage.setItem('legacy_ui', q);
+      url.searchParams.delete('legacy');
+      window.history.replaceState({}, '', url);
+      source = 'url';
+      enabled = q === '1';
+    }
+
+    const ls = localStorage.getItem('legacy_ui');
+    if (ls === '1') { enabled = true; source = source === 'env' ? 'env' : 'localStorage'; }
+    if (ls === '0' && source !== 'env') { enabled = false; source = 'localStorage'; }
+  }
+
+  return { enabled, source };
+}
+
+export function legacyEnabled(): boolean {
+  return readLegacyFlagClient().enabled;
+}
+
+export function getOverrideSource(): LegacySource {
+  return readLegacyFlagClient().source;
+}

--- a/src/pages/_legacy-diag.tsx
+++ b/src/pages/_legacy-diag.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { legacyEnabled, getOverrideSource } from '../lib/legacy';
+
+type SelfTest = {
+  env: Record<string,string | undefined>;
+  files: Record<string, { exists:boolean; size?:number; sha256?:string; first200?:string }>;
+  alerts: string[];
+};
+
+export default function LegacyDiagPage() {
+  const [data, setData] = React.useState<SelfTest | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    fetch('/api/legacy-selftest').then(r => r.json()).then(setData).catch(e => setErr(String(e)));
+  }, []);
+
+  const on = legacyEnabled();
+  const src = getOverrideSource();
+
+  const setLS = (v: '1'|'0'|null) => {
+    if (v === null) localStorage.removeItem('legacy_ui');
+    else localStorage.setItem('legacy_ui', v);
+    location.reload();
+  };
+
+  return (
+    <main style={{fontFamily:'ui-sans-serif, system-ui', padding:'24px', maxWidth:900, margin:'0 auto'}}>
+      <h1 style={{fontSize:28, fontWeight:700}}>Legacy Diagnostics</h1>
+      <p>Legacy enabled: <strong>{on ? 'true' : 'false'}</strong> (source: <code>{src}</code>)</p>
+      <div style={{display:'flex', gap:8, margin:'12px 0'}}>
+        <button onClick={() => setLS('1')}>Force Legacy ON</button>
+        <button onClick={() => setLS('0')}>Force Legacy OFF</button>
+        <button onClick={() => setLS(null)}>Clear Override</button>
+      </div>
+      <p>
+        Quick links: <a href="/?legacy=1">/?legacy=1</a> · <a href="/login?legacy=1">/login?legacy=1</a>
+      </p>
+      {err && <pre style={{color:'crimson'}}>{err}</pre>}
+      {!data ? <p>Loading…</p> : (
+        <>
+          <h2>Environment</h2>
+          <pre>{JSON.stringify(data.env, null, 2)}</pre>
+          <h2>Files</h2>
+          <pre>{JSON.stringify(data.files, null, 2)}</pre>
+          {data.alerts.length > 0 ? (
+            <div style={{background:'#fff3cd', padding:12, border:'1px solid #ffeeba', borderRadius:8}}>
+              <strong>Alerts:</strong>
+              <ul>{data.alerts.map((a,i)=><li key={i}>{a}</li>)}</ul>
+            </div>
+          ) : <p>Alerts: none ✅</p>}
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/pages/api/legacy-selftest.ts
+++ b/src/pages/api/legacy-selftest.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+type FileInfo = { exists: boolean; size?: number; sha256?: string; first200?: string };
+type Resp = {
+  env: {
+    NEXT_PUBLIC_LEGACY_UI?: string;
+    NEXT_PUBLIC_LEGACY_STRICT_SHELL?: string;
+    NEXT_PUBLIC_SHOW_API_BADGE?: string;
+  };
+  files: Record<string, FileInfo>;
+  alerts: string[];
+};
+
+const root = process.cwd();
+const files = [
+  'public/legacy/index.fragment.html',
+  'public/legacy/login.fragment.html',
+  'public/legacy/styles.css',
+];
+
+function info(rel: string): FileInfo {
+  const full = path.join(root, rel);
+  if (!fs.existsSync(full)) return { exists: false };
+  const buf = fs.readFileSync(full);
+  const size = buf.length;
+  const sha256 = crypto.createHash('sha256').update(buf).digest('hex');
+  let first200 = '';
+  try { first200 = buf.toString('utf8').replace(/\s+/g,' ').slice(0, 200); } catch {}
+  return { exists: true, size, sha256, first200 };
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
+  const resp: Resp = {
+    env: {
+      NEXT_PUBLIC_LEGACY_UI: process.env.NEXT_PUBLIC_LEGACY_UI,
+      NEXT_PUBLIC_LEGACY_STRICT_SHELL: process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL,
+      NEXT_PUBLIC_SHOW_API_BADGE: process.env.NEXT_PUBLIC_SHOW_API_BADGE,
+    },
+    files: {},
+    alerts: [],
+  };
+
+  for (const f of files) resp.files[f] = info(f);
+
+  // font presence (metadata only)
+  const font = 'public/legacy/fonts/LegacySans.woff2';
+  resp.files[font] = info(font);
+
+  // placeholder alerts
+  for (const f of files) {
+    const fi = resp.files[f];
+    if (fi.first200 && /lorem ipsum|placeholder|lipsum|TODO/i.test(fi.first200)) {
+      resp.alerts.push(`Placeholder-looking content detected in ${f}`);
+    }
+  }
+
+  res.status(200).json(resp);
+}


### PR DESCRIPTION
## Summary
- add strict legacy verifier script and wire into package.json
- implement client helper and diagnostics page for legacy flag
- expose self-test API for checking legacy assets and env vars
- fix type issues in jobs and messages pages so build passes

## Testing
- `npm run legacy:verify:strict`
- `npm run lint --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a15f1dbd3c8327bfb0d9c8c2e025cf