### PR TITLE
ops/seo/perf: preload font, robots+sitemap, cache headers; smoke:prod; tighten verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "legacy:check": "node tools/legacy_verify.mjs --pretty",
     "legacy:import": "node tools/import_from_dir.mjs",
     "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js",
-    "legacy:verify:strict": "node scripts/legacy-verify-strict.mjs"
+    "legacy:verify:strict": "node scripts/legacy-verify-strict.mjs",
+    "smoke:prod": "node scripts/smoke-prod.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/public/legacy/index.fragment.html
+++ b/public/legacy/index.fragment.html
@@ -1,3 +1,7 @@
+<link rel="preload" href="/legacy/fonts/LegacySans.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="icon" href="/favicon.png">
+<meta property="og:image" content="/legacy/img/logo-main.png">
+<meta name="twitter:card" content="summary">
 <section class="legacy-index">
   <h1>Find Gigs Fast</h1>
   <img src="/legacy/img/logo-main.png" alt="QuickGig logo">

--- a/public/legacy/login.fragment.html
+++ b/public/legacy/login.fragment.html
@@ -1,3 +1,7 @@
+<link rel="preload" href="/legacy/fonts/LegacySans.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="icon" href="/favicon.png">
+<meta property="og:image" content="/legacy/img/logo-main.png">
+<meta name="twitter:card" content="summary">
 <main class="legacy-login">
   <div class="login-card">
     <h1>Log In</h1>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://quickgig.ph/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://quickgig.ph/</loc></url>
+  <url><loc>https://quickgig.ph/login</loc></url>
+</urlset>

--- a/scripts/legacy-verify-strict.mjs
+++ b/scripts/legacy-verify-strict.mjs
@@ -1,61 +1,23 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs'; import path from 'path';
+const root=process.cwd();
+const req=['public/legacy/index.fragment.html','public/legacy/login.fragment.html','public/legacy/styles.css'];
+const bad=[/lorem ipsum/i,/\bplaceholder\b/i,/\blipsum\b/i,/\bTODO\b/i];
+const no=[/<script\b/i,/\bon[a-z]+\s*=/i,/javascript\s*:/i];
+const headNeeds=[/rel=["']icon["']/i,/og:image/i,/twitter:card/i,/rel=["']preload["'][^>]+LegacySans\.woff2/i];
 
-const root = process.cwd();
-const must = [
-  'public/legacy/index.fragment.html',
-  'public/legacy/login.fragment.html',
-  'public/legacy/styles.css',
-];
-
-const badText = [
-  /lorem ipsum/i,
-  /\bplaceholder\b/i,
-  /\blipsum\b/i,
-  /\bTODO\b/i,
-];
-
-const disallow = [
-  /<script\b/i,
-  /\bon[a-z]+\s*=/i,
-  /javascript\s*:/i,
-];
-
-function read(file) {
-  try { return fs.readFileSync(path.join(root, file), 'utf8'); }
-  catch { return null; }
+let errs=[];
+for(const f of req){ if(!fs.existsSync(path.join(root,f))) errs.push(`Missing: ${f}`); }
+for(const f of req.filter(f=>f.endsWith('.html'))){
+  const t=fs.readFileSync(path.join(root,f),'utf8');
+  for(const rx of headNeeds) if(!rx.test(t)) errs.push(`Missing meta/preload in ${f}: ${rx}`);
+  for(const rx of bad) if(rx.test(t)) errs.push(`Placeholder in ${f}: ${rx}`);
+  for(const rx of no) if(rx.test(t)) errs.push(`Disallowed pattern in ${f}: ${rx}`);
+  const refs=[...new Set((t.match(/["'](\/legacy[^"' >]+)["']/gi)||[]).map(s=>s.slice(1,-1)))];
+  for(const r of refs){ const disk=path.join(root,'public',r); if(!fs.existsSync(disk)) errs.push(`Missing asset referenced: ${r}`); }
 }
+const css=fs.readFileSync(path.join(root,'public/legacy/styles.css'),'utf8');
+for(const rx of bad) if(rx.test(css)) errs.push(`Placeholder in styles.css: ${rx}`);
+for(const rx of no) if(rx.test(css)) errs.push(`Disallowed in styles.css: ${rx}`);
 
-let errs = [];
-
-// required files
-for (const f of must) {
-  if (!fs.existsSync(path.join(root, f))) errs.push(`Missing required file: ${f}`);
-}
-
-// scan html/css for placeholders and disallowed patterns
-const scanFiles = (dir) => {
-  if (!fs.existsSync(path.join(root, dir))) return;
-  const walk = (p) => {
-    for (const name of fs.readdirSync(p)) {
-      const full = path.join(p, name);
-      const rel = path.relative(root, full);
-      const st = fs.statSync(full);
-      if (st.isDirectory()) walk(full);
-      else if (/\.(html|css)$/i.test(name)) {
-        const txt = fs.readFileSync(full, 'utf8');
-        for (const rx of badText) if (rx.test(txt)) errs.push(`Placeholder text found in ${rel} (${rx})`);
-        for (const rx of disallow) if (rx.test(txt)) errs.push(`Disallowed pattern in ${rel} (${rx})`);
-      }
-    }
-  };
-  walk(path.join(root, dir));
-};
-scanFiles('public/legacy');
-
-if (errs.length) {
-  console.error('legacy:verify:strict failed:\n- ' + errs.join('\n- '));
-  process.exit(1);
-} else {
-  console.log('legacy:verify:strict OK');
-}
+if(errs.length){ console.error('legacy:verify:strict failed:\n- '+errs.join('\n- ')); process.exit(1); }
+console.log('legacy:verify:strict OK');

--- a/scripts/smoke-prod.mjs
+++ b/scripts/smoke-prod.mjs
@@ -1,0 +1,20 @@
+import { execSync as sh } from 'node:child_process';
+const BASE = process.env.SMOKE_BASE || 'https://quickgig.ph';
+function code(u){ return sh(`curl -sS -o /dev/null -w "%{http_code}" "${u}"`).toString().trim(); }
+for (const p of ['/', '/login']) {
+  const u = `${BASE}${p}?legacy=1`;
+  const c = code(u);
+  console.log(u,'->',c);
+  if (+c>=400) process.exit(1);
+  const html = sh(`curl -sS "${u}"`).toString();
+  const assets=[...new Set((html.match(/["'](\/legacy[^"' >]+)["']/gi)||[]).map(s=>s.slice(1,-1)))];
+  for (const a of assets) {
+    const cu = `${BASE}${a}`;
+    const cc = code(cu);
+    console.log(' ',a,'->',cc);
+    if (+cc>=400) { console.error('MISS',a); process.exit(1); }
+  }
+}
+const head = sh(`curl -sSI "${BASE}/legacy/fonts/LegacySans.woff2"`).toString();
+console.log(head.split('\n').filter(l=>/HTTP\\/|content-type|content-length/i.test(l)).join('\n'));
+console.log('Smoke OK ✅');

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "headers": [
+    {
+      "source": "/legacy/img/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/legacy/fonts/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- preload LegacySans.woff2 in legacy fragments
- add robots.txt & sitemap.xml
- set long-cache headers for /legacy assets via vercel.json
- add prod smoke test script and tighten strict verify

## Testing
- `npm run legacy:verify:strict`
- `npm run lint --silent` *(fails: warnings)*
- `npm run build`
- `npm run smoke:prod` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a167c1650c8327966f36cfe16aa3b5