### PR TITLE
fix(diag): HTTP-probe legacy assets; show status/URL

### DIFF
--- a/src/pages/_legacy-diag.tsx
+++ b/src/pages/_legacy-diag.tsx
@@ -25,7 +25,7 @@ function useDiagAllowed() {
 
 type SelfTest = {
   env: Record<string,string | undefined>;
-  files: Record<string, { exists:boolean; size?:number; sha256?:string; first200?:string }>;
+  files: Record<string, { exists:boolean; url?:string; httpStatus?:number; size?:number; sha256?:string; first200?:string }>;
   alerts: string[];
 };
 
@@ -75,7 +75,28 @@ export default function LegacyDiagPage() {
           <h2>Environment</h2>
           <pre>{JSON.stringify(data.env, null, 2)}</pre>
           <h2>Files</h2>
-          <pre>{JSON.stringify(data.files, null, 2)}</pre>
+          <table style={{borderCollapse:'collapse', width:'100%'}}>
+            <thead>
+              <tr>
+                <th style={{textAlign:'left', borderBottom:'1px solid #ddd', padding:'6px'}}>Path</th>
+                <th style={{textAlign:'left', borderBottom:'1px solid #ddd', padding:'6px'}}>Exists</th>
+                <th style={{textAlign:'left', borderBottom:'1px solid #ddd', padding:'6px'}}>HTTP</th>
+                <th style={{textAlign:'left', borderBottom:'1px solid #ddd', padding:'6px'}}>Size</th>
+                <th style={{textAlign:'left', borderBottom:'1px solid #ddd', padding:'6px'}}>SHA256</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(data.files).map(([k,v])=>(
+                <tr key={k}>
+                  <td style={{padding:'6px'}}><code>{k}</code>{v.url ? <> — <a href={v.url} target="_blank" rel="noreferrer">open</a></> : null}</td>
+                  <td style={{padding:'6px'}}>{v.exists ? '✅' : '❌'}</td>
+                  <td style={{padding:'6px'}}>{v.httpStatus ?? '-'}</td>
+                  <td style={{padding:'6px'}}>{typeof v.size==='number' ? v.size : '-'}</td>
+                  <td style={{padding:'6px', wordBreak:'break-all'}}>{v.sha256 ?? '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
           {data.alerts.length > 0 ? (
             <div style={{background:'#fff3cd', padding:12, border:'1px solid #ffeeba', borderRadius:8}}>
               <strong>Alerts:</strong>

--- a/src/pages/api/legacy-selftest.ts
+++ b/src/pages/api/legacy-selftest.ts
@@ -3,7 +3,15 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 
-type FileInfo = { exists: boolean; size?: number; sha256?: string; first200?: string };
+type FileInfo = {
+  exists: boolean;
+  url?: string;
+  httpStatus?: number;
+  size?: number;
+  sha256?: string;
+  first200?: string;
+};
+
 type Resp = {
   env: {
     NEXT_PUBLIC_LEGACY_UI?: string;
@@ -14,48 +22,91 @@ type Resp = {
   alerts: string[];
 };
 
-const root = process.cwd();
-const files = [
-  'public/legacy/index.fragment.html',
-  'public/legacy/login.fragment.html',
-  'public/legacy/styles.css',
+const LEGACY_PATHS = [
+  '/legacy/index.fragment.html',
+  '/legacy/login.fragment.html',
+  '/legacy/styles.css',
+  '/legacy/fonts/LegacySans.woff2',
 ];
 
-function info(rel: string): FileInfo {
-  const full = path.join(root, rel);
+function sha256(buf: Buffer | string) {
+  const b = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+  return crypto.createHash('sha256').update(b).digest('hex');
+}
+
+async function probeHttp(base: string, urlPath: string): Promise<FileInfo> {
+  const url = `${base}${urlPath}`;
+  try {
+    const res = await fetch(url, { method: 'GET' }); // GET so we can read first200 if text
+    const ct = res.headers.get('content-type') || '';
+    const isText = /text\/|application\/(json|xml)/i.test(ct) || /\.html?$|\.css$/i.test(urlPath);
+    let first200 = '';
+    let size: number | undefined;
+
+    if (isText) {
+      const text = await res.text();
+      size = Buffer.byteLength(text);
+      first200 = text.replace(/\s+/g, ' ').slice(0, 200);
+      return { exists: res.status < 400, url, httpStatus: res.status, size, first200, sha256: sha256(text) };
+    } else {
+      const buf = Buffer.from(await res.arrayBuffer());
+      size = buf.length;
+      return { exists: res.status < 400, url, httpStatus: res.status, size, sha256: sha256(buf) };
+    }
+  } catch {
+    return { exists: false, url, httpStatus: 0 };
+  }
+}
+
+function probeFs(projectRoot: string, urlPath: string): FileInfo {
+  const rel = path.join('public', urlPath);
+  const full = path.join(projectRoot, rel);
   if (!fs.existsSync(full)) return { exists: false };
   const buf = fs.readFileSync(full);
   const size = buf.length;
-  const sha256 = crypto.createHash('sha256').update(buf).digest('hex');
   let first200 = '';
-  try { first200 = buf.toString('utf8').replace(/\s+/g,' ').slice(0, 200); } catch {}
-  return { exists: true, size, sha256, first200 };
+  try { first200 = buf.toString('utf8').replace(/\s+/g,' ').slice(0,200); } catch {}
+  return { exists: true, size, sha256: sha256(buf), first200 };
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
-  const resp: Resp = {
-    env: {
-      NEXT_PUBLIC_LEGACY_UI: process.env.NEXT_PUBLIC_LEGACY_UI,
-      NEXT_PUBLIC_LEGACY_STRICT_SHELL: process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL,
-      NEXT_PUBLIC_SHOW_API_BADGE: process.env.NEXT_PUBLIC_SHOW_API_BADGE,
-    },
-    files: {},
-    alerts: [],
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
+  const env = {
+    NEXT_PUBLIC_LEGACY_UI: process.env.NEXT_PUBLIC_LEGACY_UI,
+    NEXT_PUBLIC_LEGACY_STRICT_SHELL: process.env.NEXT_PUBLIC_LEGACY_STRICT_SHELL,
+    NEXT_PUBLIC_SHOW_API_BADGE: process.env.NEXT_PUBLIC_SHOW_API_BADGE,
   };
 
-  for (const f of files) resp.files[f] = info(f);
+  const proto = (req.headers['x-forwarded-proto'] as string) || 'https';
+  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host || 'localhost:3000';
+  const base = `${proto}://${host}`;
 
-  // font presence (metadata only)
-  const font = 'public/legacy/fonts/LegacySans.woff2';
-  resp.files[font] = info(font);
+  const isVercel = !!process.env.VERCEL;
+  const root = process.cwd();
 
-  // placeholder alerts
-  for (const f of files) {
-    const fi = resp.files[f];
-    if (fi.first200 && /lorem ipsum|placeholder|lipsum|TODO/i.test(fi.first200)) {
-      resp.alerts.push(`Placeholder-looking content detected in ${f}`);
+  const files: Record<string, FileInfo> = {};
+
+  for (const p of LEGACY_PATHS) {
+    if (isVercel) {
+      files[`public${p}`] = await probeHttp(base, p);
+    } else {
+      // Local dev: prefer fs, but also include URL for parity
+      const fsInfo = probeFs(root, p);
+      if (!fsInfo.exists) {
+        files[`public${p}`] = await probeHttp(base, p);
+      } else {
+        files[`public${p}`] = { ...fsInfo, url: `${base}${p}`, httpStatus: fsInfo.exists ? 200 : 404 };
+      }
     }
   }
 
-  res.status(200).json(resp);
+  // Alerts if placeholder-looking content is detected in the fragments or CSS first200
+  const alerts: string[] = [];
+  for (const key of Object.keys(files)) {
+    const info = files[key];
+    if (info.first200 && /lorem ipsum|placeholder|lipsum|TODO/i.test(info.first200)) {
+      alerts.push(`Placeholder-looking content detected in ${key}`);
+    }
+  }
+
+  res.status(200).json({ env, files, alerts });
 }


### PR DESCRIPTION
## Summary
- switch legacy self-test to HTTP probes with fs fallback
- surface probe URL and HTTP status in diagnostics page

## Testing
- `npm run build`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a16c1dc4c4832794ae30ab417d6153