### PR TITLE
fix(diag): rename page to /legacy-diag (no leading underscore)

### DIFF
--- a/src/pages/legacy-diag.tsx
+++ b/src/pages/legacy-diag.tsx
@@ -67,7 +67,7 @@ export default function LegacyDiagPage() {
         <button onClick={() => setLS(null)}>Clear Override</button>
       </div>
       <p>
-        Quick links: <Link href="/?legacy=1">/?legacy=1</Link> · <Link href="/login?legacy=1">/login?legacy=1</Link> · <Link href="/_legacy-diag?diag=1">/_legacy-diag?diag=1</Link>
+        Quick links: <Link href="/?legacy=1">/?legacy=1</Link> · <Link href="/login?legacy=1">/login?legacy=1</Link> · <Link href="/legacy-diag?diag=1">/legacy-diag?diag=1</Link>
       </p>
       {err && <pre style={{color:'crimson'}}>{err}</pre>}
       {!data ? <p>Loading…</p> : (


### PR DESCRIPTION
## Summary
- rename legacy diagnostics page from `/_legacy-diag` to `/legacy-diag`
- update internal quick link to new `/legacy-diag?diag=1` path
- retain query-string gating logic

## Testing
- `npm run legacy:verify:strict`
- `npm run lint --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a16eb8c5748327b8239243c31cb405