### PR TITLE
fix(diag): alias /_legacy-diag → /legacy-diag; add redirect + rewrite

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,10 @@ const nextConfig = {
   env: {
     BUILD_TIME: new Date().toISOString(),
   },
+  async redirects() {
+    return [
+      { source: '/_legacy-diag', destination: '/legacy-diag', permanent: false },
+    ];
+  },
 };
-
 module.exports = nextConfig;
-

--- a/src/pages/_legacy-diag.tsx
+++ b/src/pages/_legacy-diag.tsx
@@ -1,2 +1,2 @@
-// Alias route: keep old /_legacy-diag working after rename to /legacy-diag
+// Alias: keep old /_legacy-diag working by re-exporting the new page.
 export { default } from './legacy-diag';

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,31 @@
   "headers": [
     {
       "source": "/legacy/img/(.*)",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     },
     {
       "source": "/legacy/fonts/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "Access-Control-Allow-Origin", "value": "*" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
       ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/_legacy-diag",
+      "destination": "/legacy-diag"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- keep old /_legacy-diag route working by re-exporting the new page
- redirect /_legacy-diag to /legacy-diag via Next.js config
- add Vercel rewrite to support /_legacy-diag

## Testing
- `npm run legacy:verify:strict` *(fails: Font too small (likely placeholder): 0 bytes; expected ≥ 10240)*
- `npm run lint --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a18f25f77c8327b74027ce68edd39b