### PR TITLE
fix(routes): add index route

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import fs from 'fs';
+import path from 'path';
+import type { GetStaticProps } from 'next';
+import { legacyFlagFromEnv, legacyFlagFromQuery } from '../src/lib/legacyFlag';
+
+type Props = { legacyHtml?: string };
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  try {
+    const pub = path.join(process.cwd(), 'public', 'legacy');
+    const frag = fs.readFileSync(path.join(pub, 'index.fragment.html'), 'utf8');
+    const legacyHtml =
+`<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/legacy/styles.css">
+${frag}`;
+    return { props: { legacyHtml }, revalidate: 300 };
+  } catch {
+    return { props: {}, revalidate: 60 };
+  }
+};
+
+export default function Home({ legacyHtml }: Props){
+  const [useLegacy, setUseLegacy] = React.useState(() => legacyFlagFromEnv());
+  React.useEffect(() => {
+    try { setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(new URL(window.location.href).searchParams)); } catch {}
+  }, []);
+  return (
+    <>
+      <Head><title>QuickGig</title></Head>
+      {useLegacy && legacyHtml
+        ? <main dangerouslySetInnerHTML={{ __html: legacyHtml }} />
+        : <main style={{ padding: 24, fontFamily: 'ui-sans-serif,system-ui' }}>
+            <h1>QuickGig</h1>
+            <p>
+              Root page is live. Turn on the legacy shell via <code>NEXT_PUBLIC_LEGACY_UI=true</code> or visit <Link href="/?legacy=1">/?legacy=1</Link>.
+            </p>
+          </main>}
+    </>
+  );
+}

--- a/src/lib/legacyFlag.ts
+++ b/src/lib/legacyFlag.ts
@@ -1,0 +1,6 @@
+export function legacyFlagFromQuery(params: URLSearchParams | null | undefined): boolean {
+  try { return !!params && params.get('legacy') === '1'; } catch { return false; }
+}
+export function legacyFlagFromEnv(): boolean {
+  return String(process.env.NEXT_PUBLIC_LEGACY_UI || '').toLowerCase() === 'true';
+}


### PR DESCRIPTION
## Summary
- add pages/index.tsx to stop 404 at root and optionally render legacy shell
- add legacy flag helpers

## Testing
- `npm run lint --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1a6a87698832797f311e17c0ebf13