### PR TITLE
fix(routes): add /, /login, /__health; route-manifest print; font installer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.woff2 binary
-*.woff2 binary

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
     "test": "tsc src/lib/flags.ts src/lib/legacy/renderLegacy.ts src/lib/legacy/__tests__/sanitize.test.ts --module commonjs --target ES2019 --esModuleInterop --outDir dist-test && node --test dist-test/legacy/__tests__/sanitize.test.js",
     "legacy:verify:strict": "node scripts/legacy-verify-strict.mjs",
     "smoke:prod": "node scripts/smoke-prod.mjs",
-    "legacy:font:install": "node scripts/legacy-font-install.mjs",
+    "legacy:font:install": "node tools/install_legacy_font.mjs",
     "font:status": "node scripts/font-status.mjs",
-    "postbuild": "node tools/print_routes.mjs"
+    "postbuild": "node tools/print_routes.mjs",
+    "smoke:urls": "node -e \"const u=process.env.BASE||\"http://localhost:3000\"; const f=async (p)=>{const r=await fetch(u+p,{method:\"HEAD\"}); console.log(p, r.status, r.headers.get(\"content-type\")||\"-\");}; (async()=>{for(const p of [\"/__health\",\"/\",\"/?legacy=1\",\"/login\",\"/legacy/styles.css\",\"/legacy/fonts/LegacySans.woff2\"]) await f(p)})()\""
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/pages/__health.ts
+++ b/pages/__health.ts
@@ -1,0 +1,6 @@
+import type { GetServerSideProps } from 'next';
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader('Content-Type', 'text/plain'); res.write('ok'); res.end();
+  return { props: {} };
+};
+export default function Health(){ return null; }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -11,7 +11,7 @@ type Props = { legacyHtml?: string };
 export const getStaticProps: GetStaticProps<Props> = async () => {
   try {
     const pub = path.join(process.cwd(), 'public', 'legacy');
-    const frag = fs.readFileSync(path.join(pub, 'index.fragment.html'), 'utf8');
+    const frag = fs.readFileSync(path.join(pub, 'login.fragment.html'), 'utf8');
     const legacyHtml =
 `<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/legacy/styles.css">
@@ -22,7 +22,7 @@ ${frag}`;
   }
 };
 
-export default function Home({ legacyHtml }: Props){
+export default function Login({ legacyHtml }: Props){
   const [useLegacy, setUseLegacy] = React.useState(() => legacyFlagFromEnv());
   React.useEffect(() => {
     try {
@@ -32,14 +32,14 @@ export default function Home({ legacyHtml }: Props){
   }, []);
   return (
     <>
-      <Head><title>QuickGig</title></Head>
+      <Head><title>Log In · QuickGig</title></Head>
       {useLegacy && legacyHtml ? (
         <main dangerouslySetInnerHTML={{ __html: legacyHtml }} />
       ) : (
         <main style={{ padding: 24, fontFamily: 'ui-sans-serif,system-ui' }}>
-          <h1>QuickGig</h1>
-          <p>Root page is live. Turn on the legacy shell via <code>NEXT_PUBLIC_LEGACY_UI=true</code> or visit
-            <a href="/?legacy=1">/?legacy=1</a>.
+          <h1>Log In</h1>
+          <p>Turn on legacy via <code>NEXT_PUBLIC_LEGACY_UI=true</code> or
+            <a href="/login?legacy=1">/login?legacy=1</a>.
           </p>
         </main>
       )}

--- a/src/lib/legacyFlag.ts
+++ b/src/lib/legacyFlag.ts
@@ -1,6 +1,6 @@
-export function legacyFlagFromQuery(params: URLSearchParams | null | undefined): boolean {
-  try { return !!params && params.get('legacy') === '1'; } catch { return false; }
-}
 export function legacyFlagFromEnv(): boolean {
   return String(process.env.NEXT_PUBLIC_LEGACY_UI || '').toLowerCase() === 'true';
+}
+export function legacyFlagFromQuery(params: URLSearchParams | null | undefined): boolean {
+  try { return !!params && (params.get('legacy') === '1'); } catch { return false; }
 }

--- a/tools/install_legacy_font.mjs
+++ b/tools/install_legacy_font.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs'; import path from 'path';
+const src = process.env.LEGACY_FONT_SRC;
+if(!src) { console.error('LEGACY_FONT_SRC is required'); process.exit(2); }
+const dstDir = path.join(process.cwd(),'public','legacy','fonts');
+const dst = path.join(dstDir,'LegacySans.woff2');
+fs.mkdirSync(dstDir,{recursive:true});
+fs.copyFileSync(src,dst);
+const stat=fs.statSync(dst);
+if(stat.size < 1024){ console.error(`Font looks too small (${stat.size} bytes). Did you pass the real .woff2?`); process.exit(3); }
+console.log(`Installed LegacySans.woff2 (${stat.size} bytes) → ${dst}`);

--- a/tools/print_routes.mjs
+++ b/tools/print_routes.mjs
@@ -1,9 +1,7 @@
 import fs from 'fs';
 try {
-  const routes = fs.readFileSync('.next/routes-manifest.json','utf8');
-  console.log('--- NEXT ROUTES MANIFEST ---');
-  console.log(routes);
-  console.log('----------------------------');
-} catch (e) {
-  console.warn('No routes-manifest found yet (build not run).');
+  const s = fs.readFileSync('.next/routes-manifest.json','utf8');
+  console.log('\n--- NEXT ROUTES MANIFEST ---\n' + s + '\n----------------------------\n');
+} catch {
+  console.log('No routes-manifest.json (build may have failed).');
 }


### PR DESCRIPTION
Stops 404 at root by adding real pages. Adds /__health. Prints Next routes manifest postbuild. Adds a local npm script to install the real LegacySans.woff2 font (LEGACY_FONT_SRC).

------
https://chatgpt.com/codex/tasks/task_e_68a1a97bdc788327b03ba990ccfaed21