### PR TITLE
feat(product+theme): modern shells for / and /login (legacy-safe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "legacy:font:install": "node tools/install_legacy_font.mjs",
     "font:status": "node scripts/font-status.mjs",
     "postbuild": "node tools/print_routes.mjs",
-    "smoke:urls": "node -e \"const u=process.env.BASE||\"http://localhost:3000\"; const f=async (p)=>{const r=await fetch(u+p,{method:\"HEAD\"}); console.log(p, r.status, r.headers.get(\"content-type\")||\"-\");}; (async()=>{for(const p of [\"/__health\",\"/\",\"/?legacy=1\",\"/login\",\"/legacy/styles.css\",\"/legacy/fonts/LegacySans.woff2\"]) await f(p)})()\""
+    "smoke:urls": "node -e \"const u=process.env.BASE||\"http://localhost:3000\"; const f=async (p)=>{const r=await fetch(u+p,{method:\"HEAD\"}); console.log(p, r.status, r.headers.get(\"content-type\")||\"-\");}; (async()=>{for(const p of [\"/__health\",\"/\",\"/?legacy=1\",\"/login\",\"/legacy/styles.css\",\"/legacy/fonts/LegacySans.woff2\"]) await f(p)})()\"",
+    "smoke:product": "node tools/smoke_product.mjs"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,48 +1,43 @@
-/* eslint-disable @next/next/no-html-link-for-pages */
 import * as React from 'react';
 import Head from 'next/head';
 import fs from 'fs';
 import path from 'path';
-import type { GetStaticProps } from 'next';
+import ProductShell from '../src/product/layout/ProductShell';
+import { Card } from '../src/product/ui/Card';
+import { Button } from '../src/product/ui/Button';
+import { tokens as T } from '../src/theme/tokens';
 import { legacyFlagFromEnv, legacyFlagFromQuery } from '../src/lib/legacyFlag';
 
 type Props = { legacyHtml?: string };
-
-export const getStaticProps: GetStaticProps<Props> = async () => {
+export async function getStaticProps() {
   try {
-    const pub = path.join(process.cwd(), 'public', 'legacy');
-    const frag = fs.readFileSync(path.join(pub, 'index.fragment.html'), 'utf8');
-    const legacyHtml =
-`<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/legacy/styles.css">
-${frag}`;
+    const pub = path.join(process.cwd(),'public','legacy');
+    const frag = fs.readFileSync(path.join(pub,'index.fragment.html'),'utf8');
+    const legacyHtml = `<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossOrigin />\n<link rel="stylesheet" href="/legacy/styles.css" />` + frag;
     return { props: { legacyHtml }, revalidate: 300 };
-  } catch {
-    return { props: {}, revalidate: 60 };
-  }
-};
-
+  } catch { return { props: {}, revalidate: 600 }; }
+}
 export default function Home({ legacyHtml }: Props){
-  const [useLegacy, setUseLegacy] = React.useState(() => legacyFlagFromEnv());
-  React.useEffect(() => {
-    try {
-      const params = new URL(window.location.href).searchParams;
-      setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(params));
-    } catch {}
-  }, []);
+  const [useLegacy,setUseLegacy]=React.useState<boolean>(false);
+  React.useEffect(()=>{ try{ setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(new URL(window.location.href).searchParams)); }catch{} },[]);
+  if(useLegacy && legacyHtml){
+    return (<div dangerouslySetInnerHTML={{__html: legacyHtml}}/>);
+  }
   return (
     <>
-      <Head><title>QuickGig</title></Head>
-      {useLegacy && legacyHtml ? (
-        <main dangerouslySetInnerHTML={{ __html: legacyHtml }} />
-      ) : (
-        <main style={{ padding: 24, fontFamily: 'ui-sans-serif,system-ui' }}>
-          <h1>QuickGig</h1>
-          <p>Root page is live. Turn on the legacy shell via <code>NEXT_PUBLIC_LEGACY_UI=true</code> or visit
-            <a href="/?legacy=1">/?legacy=1</a>.
-          </p>
-        </main>
-      )}
+      <Head><title>QuickGig • Find Gigs Fast</title></Head>
+      <ProductShell>
+        <div style={{display:'grid', gap:16}}>
+          <Card>
+            <h1 style={{fontFamily:T.font.ui, fontSize:28, margin:'0 0 8px'}}>Find gigs fast in the Philippines</h1>
+            <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>Search flexible work and apply in minutes.</p>
+            <div style={{display:'flex', gap:12}}>
+              <a href="/find-work"><Button>Browse jobs</Button></a>
+              <a href="/register"><Button variant="subtle">Create account</Button></a>
+            </div>
+          </Card>
+        </div>
+      </ProductShell>
     </>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,48 +1,42 @@
-/* eslint-disable @next/next/no-html-link-for-pages */
 import * as React from 'react';
 import Head from 'next/head';
 import fs from 'fs';
 import path from 'path';
-import type { GetStaticProps } from 'next';
+import ProductShell from '../src/product/layout/ProductShell';
+import { Card } from '../src/product/ui/Card';
+import { Input } from '../src/product/ui/Input';
+import { Button } from '../src/product/ui/Button';
 import { legacyFlagFromEnv, legacyFlagFromQuery } from '../src/lib/legacyFlag';
 
 type Props = { legacyHtml?: string };
-
-export const getStaticProps: GetStaticProps<Props> = async () => {
+export async function getStaticProps() {
   try {
-    const pub = path.join(process.cwd(), 'public', 'legacy');
-    const frag = fs.readFileSync(path.join(pub, 'login.fragment.html'), 'utf8');
-    const legacyHtml =
-`<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/legacy/styles.css">
-${frag}`;
+    const pub = path.join(process.cwd(),'public','legacy');
+    const frag = fs.readFileSync(path.join(pub,'login.fragment.html'),'utf8');
+    const legacyHtml = `<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossOrigin />\n<link rel="stylesheet" href="/legacy/styles.css" />` + frag;
     return { props: { legacyHtml }, revalidate: 300 };
-  } catch {
-    return { props: {}, revalidate: 60 };
-  }
-};
-
+  } catch { return { props: {}, revalidate: 600 }; }
+}
 export default function Login({ legacyHtml }: Props){
-  const [useLegacy, setUseLegacy] = React.useState(() => legacyFlagFromEnv());
-  React.useEffect(() => {
-    try {
-      const params = new URL(window.location.href).searchParams;
-      setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(params));
-    } catch {}
-  }, []);
+  const [useLegacy,setUseLegacy]=React.useState<boolean>(false);
+  React.useEffect(()=>{ try{ setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(new URL(window.location.href).searchParams)); }catch{} },[]);
+  if(useLegacy && legacyHtml){ return (<div dangerouslySetInnerHTML={{__html: legacyHtml}}/>); }
   return (
     <>
-      <Head><title>Log In · QuickGig</title></Head>
-      {useLegacy && legacyHtml ? (
-        <main dangerouslySetInnerHTML={{ __html: legacyHtml }} />
-      ) : (
-        <main style={{ padding: 24, fontFamily: 'ui-sans-serif,system-ui' }}>
-          <h1>Log In</h1>
-          <p>Turn on legacy via <code>NEXT_PUBLIC_LEGACY_UI=true</code> or
-            <a href="/login?legacy=1">/login?legacy=1</a>.
-          </p>
-        </main>
-      )}
+      <Head><title>Log in • QuickGig</title></Head>
+      <ProductShell>
+        <Card style={{maxWidth:520, margin:'0 auto'}}>
+          <h2 style={{marginTop:0}}>Log in</h2>
+          <form method="post" action="/api/auth">
+            <div style={{display:'grid', gap:12}}>
+              <label>Email<Input name="email" type="email" required/></label>
+              <label>Password<Input name="password" type="password" required/></label>
+              <Button type="submit">Log in</Button>
+            </div>
+          </form>
+          <p style={{marginTop:12}}><a href="/register">Need an account?</a></p>
+        </Card>
+      </ProductShell>
     </>
   );
 }

--- a/src/product/layout/ProductShell.tsx
+++ b/src/product/layout/ProductShell.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { NavBar } from '../ui/NavBar';
+import { Footer } from '../ui/Footer';
+import { Banner } from '../ui/Banner';
+
+export default function ProductShell({children}:{children:React.ReactNode}){
+  const bannerHtml = (process.env.NEXT_PUBLIC_BANNER_HTML ?? '').trim() || undefined;
+  return (
+    <>
+      <Banner html={bannerHtml}/>
+      <NavBar/>
+      <main style={{maxWidth:1024, margin:'0 auto', padding:'24px 16px'}}>{children}</main>
+      <Footer/>
+    </>
+  );
+}

--- a/src/product/ui/Banner.tsx
+++ b/src/product/ui/Banner.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { tokens as T } from '../../theme/tokens';
+
+export function Banner({html}:{html?:string}){
+  if(!html) return null;
+  return (
+    <div style={{background:T.colors.brand, color:'#fff', fontFamily:T.font.ui}}>
+      <div style={{maxWidth:1024, margin:'0 auto', padding:'8px 12px'}}>
+        <span dangerouslySetInnerHTML={{__html: html}} />
+      </div>
+    </div>
+  );
+}

--- a/src/product/ui/Button.tsx
+++ b/src/product/ui/Button.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { tokens as T } from '../../theme/tokens';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'solid' | 'subtle' | 'danger';
+  size?: 'sm'|'md';
+};
+export function Button({ variant='solid', size='md', style, ...rest }: Props) {
+  const pad = size === 'sm' ? '8px 12px' : '10px 16px';
+  let bg: string = T.colors.brand, fg: string = T.colors.brandTextOn, brd: string = 'transparent';
+  if (variant==='subtle'){ bg='transparent'; fg=T.colors.text; brd=T.colors.border; }
+  if (variant==='danger'){ bg=T.colors.danger; fg='#fff'; }
+  return (
+    <button
+      style={{
+        fontFamily: T.font.ui, padding: pad, borderRadius: T.radius.md,
+        background: bg, color: fg, border: `1px solid ${brd}`,
+        boxShadow: T.shadow.sm, cursor:'pointer', ...style
+      }}
+      {...rest}
+    />
+  );
+}
+export default Button;

--- a/src/product/ui/Card.tsx
+++ b/src/product/ui/Card.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { tokens as T } from '../../theme/tokens';
+export function Card(props: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...props} style={{
+      background:'#fff', border:`1px solid ${T.colors.border}`,
+      borderRadius:T.radius.lg, boxShadow:T.shadow.md, padding:16, ...props.style
+    }}/>
+  );
+}

--- a/src/product/ui/Footer.tsx
+++ b/src/product/ui/Footer.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { tokens as T } from '../../theme/tokens';
+export function Footer(){
+  return (
+    <footer style={{borderTop:`1px solid ${T.colors.border}`, marginTop:32}}>
+      <div style={{maxWidth:1024, margin:'0 auto', padding:'16px', color:T.colors.subtle, fontFamily:T.font.ui}}>
+        © QuickGig PH · <a href="/system/status">Status</a>
+      </div>
+    </footer>
+  );
+}

--- a/src/product/ui/Input.tsx
+++ b/src/product/ui/Input.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { tokens as T } from '../../theme/tokens';
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      style={{
+        width:'100%', padding:'10px 12px', borderRadius: T.radius.md,
+        border:`1px solid ${T.colors.border}`, background:'#fff',
+        fontFamily: T.font.ui, ...props.style,
+      }}
+    />
+  );
+}
+export function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      style={{
+        width:'100%', padding:'10px 12px', borderRadius: T.radius.md,
+        border:`1px solid ${T.colors.border}`, background:'#fff',
+        fontFamily: T.font.ui, ...props.style,
+      }}
+    />
+  );
+}

--- a/src/product/ui/NavBar.tsx
+++ b/src/product/ui/NavBar.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Link from 'next/link';
+import { tokens as T } from '../../theme/tokens';
+export function NavBar(){
+  return (
+    <nav style={{position:'sticky', top:0, zIndex:20, background:'#fff', borderBottom:`1px solid ${T.colors.border}`}}>
+      <div style={{maxWidth:1024, margin:'0 auto', padding:'10px 16px', display:'flex', alignItems:'center', gap:16}}>
+        <Link href="/" legacyBehavior>
+          <a style={{display:'flex', alignItems:'center', gap:10, textDecoration:'none', color:T.colors.text}}>
+            <img alt="QuickGig" src="/legacy/img/logo-main.png" width="28" height="28" />
+            <strong>QuickGig</strong>
+          </a>
+        </Link>
+        <div style={{marginLeft:'auto', display:'flex', gap:12}}>
+          <Link href="/find-work" legacyBehavior><a style={{textDecoration:'none', color:T.colors.text}}>Find work</a></Link>
+          <Link href="/login" legacyBehavior><a style={{textDecoration:'none', color:T.colors.text}}>Log in</a></Link>
+          <Link href="/register" legacyBehavior>
+            <a style={{color:'#fff', background:T.colors.brand, padding:'8px 12px', borderRadius:12, textDecoration:'none'}}>Sign up</a>
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,16 @@
+export const tokens = {
+  colors: {
+    bg: '#ffffff',
+    text: '#0f172a',
+    subtle: '#475569',
+    brand: '#2563eb',
+    brandTextOn: '#ffffff',
+    border: '#e2e8f0',
+    surface: '#f8fafc',
+    danger: '#ef4444',
+  },
+  space: { xs: 6, sm: 10, md: 16, lg: 24, xl: 32 },
+  radius: { sm: 8, md: 12, lg: 16, pill: 999 },
+  shadow: { sm: '0 1px 2px rgba(0,0,0,.06)', md: '0 6px 24px rgba(15,23,42,.08)' },
+  font: { ui: 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial' },
+} as const;

--- a/src/types/react-style.d.ts
+++ b/src/types/react-style.d.ts
@@ -1,0 +1,6 @@
+import 'react';
+declare module 'react' {
+  interface CSSProperties {
+    [key: `--${string}`]: string | number | undefined;
+  }
+}

--- a/tools/smoke_product.mjs
+++ b/tools/smoke_product.mjs
@@ -1,0 +1,13 @@
+const BASE=process.env.BASE ?? 'http://localhost:3000';
+const paths=['/','/login'];
+const fetch = (...a)=>import('node-fetch').then(({default: f})=>f(...a));
+(async()=>{
+  let bad=0;
+  for(const p of paths){
+    const r = await fetch(BASE+p, {redirect:'manual'});
+    const ok = r.status>=200 && r.status<400;
+    console.log(p, r.status, ok ? 'OK' : 'FAIL');
+    if(!ok) bad++;
+  }
+  if(bad) process.exit(1);
+})();


### PR DESCRIPTION
## Summary
- add base tokens and product UI primitives
- introduce ProductShell and modern / and /login pages with legacy toggle
- add smoke script

## Testing
- `npm run lint --silent`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1baeb1f5883279f0563fb2341a5a5