### PR TITLE
feat(apply flow): add /jobs/[id]/apply, /api/apply proxy, CTA wiring (legacy-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ NEXT_PUBLIC_SHOW_API_BADGE=false
 # Optional banner
 NEXT_PUBLIC_BANNER_HTML=
 
+# Optional: webhook to receive apply submissions (if unset, API returns 202 locally)
+# APPLY_WEBHOOK_URL=https://hooks.zapier.com/...
+
 # Session/auth
 
 JWT_COOKIE_NAME=auth_token

--- a/pages/api/apply.ts
+++ b/pages/api/apply.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type ApplyPayload = {
+  jobId: string;
+  name: string;
+  email: string;
+  message?: string;
+  // in the future: resumeUrl?: string;
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'Method Not Allowed' });
+  try {
+    const payload = req.body as ApplyPayload;
+    if (!payload?.jobId || !payload?.name || !payload?.email)
+      return res.status(400).json({ ok:false, error:'Missing fields' });
+
+    const url = process.env.APPLY_WEBHOOK_URL;
+    if (url) {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: {'content-type':'application/json'},
+        body: JSON.stringify({ source:'quickgig-frontend', ...payload }),
+      });
+      // tolerate non-2xx: still report accepted to not block UX
+      return res.status(202).json({ ok:true, forwarded: r.ok });
+    }
+    // No webhook configured — accept locally
+    return res.status(202).json({ ok:true, forwarded:false });
+  } catch (e: unknown) {
+    return res.status(500).json({ ok:false, error: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/pages/jobs/[id]/apply.tsx
+++ b/pages/jobs/[id]/apply.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import type { GetServerSideProps } from 'next';
+import Link from 'next/link';
+import path from 'path';
+import fs from 'fs';
+import ProductShell from '../../../src/components/layout/ProductShell';
+import { HeadSEO } from '../../../src/components/HeadSEO';
+import { getJobDetails, type JobDetail } from '../../../src/lib/api';
+import { legacyFlagFromEnv, legacyFlagFromQuery } from '../../../src/lib/legacyFlag';
+import { tokens as T } from '../../../src/theme/tokens';
+
+type Props = { job: JobDetail|null; legacyHtml?: string };
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ params }) => {
+  const id = String(params?.id ?? '');
+  const job = await getJobDetails(id);
+  let legacyHtml: string|undefined;
+  try {
+    const pub = path.join(process.cwd(),'public','legacy');
+    const frag = fs.readFileSync(path.join(pub,'login.fragment.html'),'utf8'); // reuse login shell as fallback
+    legacyHtml = `<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossOrigin />
+<link rel="stylesheet" href="/legacy/styles.css" />` + frag;
+  } catch {}
+  return { props: { job, legacyHtml } };
+};
+
+export default function ApplyPage({ job, legacyHtml }: Props) {
+  const [useLegacy, setUseLegacy] = React.useState(false);
+  React.useEffect(() => {
+    try { setUseLegacy(legacyFlagFromEnv() || legacyFlagFromQuery(new URL(window.location.href).searchParams)); } catch {}
+  }, []);
+  if (useLegacy && legacyHtml) return <div dangerouslySetInnerHTML={{__html: legacyHtml}} />;
+
+  return (
+    <ProductShell>
+      <HeadSEO title={job ? `Apply • ${job.title} • QuickGig` : 'Apply • QuickGig'} />
+      <section style={{display:'grid', gap:16}}>
+        {job ? (
+          <header style={{display:'grid', gap:4}}>
+            <h1 style={{margin:0}}>{job.title}</h1>
+            <div style={{color:T.colors.subtle}}>
+              {job.company ? `${job.company} • ` : ''}{job.location || 'Anywhere'}{job.payRange ? ` • ${job.payRange}`:''}
+            </div>
+          </header>
+        ) : (
+          <h1>Apply</h1>
+        )}
+
+        <ApplyForm jobId={String(job?.id ?? '')} />
+      </section>
+    </ProductShell>
+  );
+}
+
+function field(label:string, el:React.ReactNode) {
+  return (
+    <label style={{display:'grid', gap:6}}>
+      <span style={{fontWeight:600}}>{label}</span>
+      {el}
+    </label>
+  );
+}
+
+function ApplyForm({ jobId }: { jobId: string }) {
+  const [name,setName] = React.useState('');
+  const [email,setEmail] = React.useState('');
+  const [message,setMessage] = React.useState('');
+  const [status,setStatus] = React.useState<'idle'|'sending'|'ok'|'err'>('idle');
+  const disabled = !jobId || !name || !email || status==='sending';
+
+  async function onSubmit(e:React.FormEvent) {
+    e.preventDefault();
+    setStatus('sending');
+    try {
+      const r = await fetch('/api/apply', {
+        method:'POST',
+        headers:{'content-type':'application/json'},
+        body: JSON.stringify({ jobId, name, email, message }),
+      });
+      const j = await r.json().catch(()=>({}));
+      if (r.ok) setStatus('ok'); else setStatus('err');
+      if (!r.ok) console.error('apply failed', j);
+    } catch {
+      setStatus('err');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}
+      style={{background:'#fff', border:`1px solid ${T.colors.border}`, borderRadius:12, padding:16, display:'grid', gap:12, maxWidth:560}}>
+      {field('Full name',
+        <input value={name} onChange={e=>setName(e.target.value)} placeholder="Juan Dela Cruz"
+               style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
+      )}
+      {field('Email',
+        <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="you@example.com"
+               style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
+      )}
+      {field('Message (optional)',
+        <textarea value={message} onChange={e=>setMessage(e.target.value)} rows={5}
+                  placeholder="Short note to the employer"
+                  style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`, resize:'vertical'}} />
+      )}
+
+      <div style={{display:'flex', gap:8}}>
+        <button type="submit" disabled={disabled}
+          style={{padding:'10px 14px', borderRadius:8, background: disabled? '#9aa5b1': T.colors.brand, color:'#fff',
+                  border:'none', fontWeight:700, cursor: disabled? 'not-allowed':'pointer'}}>
+          {status==='sending' ? 'Sending…' : 'Submit application'}
+        </button>
+        <Link href="/login" style={{padding:'10px 14px', borderRadius:8, border:`1px solid ${T.colors.border}`, textDecoration:'none'}}>Sign in</Link>
+      </div>
+
+      {status==='ok' && <p role="status" style={{color:'green', margin:0}}>Thanks! Your application was received.</p>}
+      {status==='err' && <p role="status" style={{color:'crimson', margin:0}}>Something went wrong. Please try again.</p>}
+    </form>
+  );
+}

--- a/src/product/JobCard.tsx
+++ b/src/product/JobCard.tsx
@@ -1,22 +1,58 @@
 import * as React from 'react';
+import Link from 'next/link';
 import { tokens as T } from '../theme/tokens';
 import type { JobSummary } from '../lib/api';
 
 export function JobCard({ job }: { job: JobSummary }) {
-  const href = job.url ?? (job.id ? `/jobs/${job.id}` : '#');
   return (
-    <a href={href} style={{
-      display:'block', textDecoration:'none', color:T.colors.text,
-      background:'#fff', border:`1px solid ${T.colors.border}`,
-      borderRadius: T.radius.lg, padding:16, boxShadow: T.shadow.sm
-    }}>
-      <div style={{fontWeight:600, marginBottom:6}}>{job.title}</div>
-      {job.company && <div style={{color:T.colors.subtle, fontSize:14}}>{job.company}</div>}
-      <div style={{display:'flex', gap:12, marginTop:8, color:T.colors.subtle, fontSize:13}}>
+    <div
+      style={{
+        display: 'grid',
+        gap: 8,
+        background: '#fff',
+        border: `1px solid ${T.colors.border}`,
+        borderRadius: T.radius.lg,
+        padding: 16,
+        boxShadow: T.shadow.sm,
+      }}
+    >
+      <Link
+        href={`/jobs/${job.id}`}
+        style={{ fontWeight: 600, textDecoration: 'none', color: T.colors.text }}
+      >
+        {job.title}
+      </Link>
+      {job.company && (
+        <div style={{ color: T.colors.subtle, fontSize: 14 }}>{job.company}</div>
+      )}
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          marginTop: 8,
+          color: T.colors.subtle,
+          fontSize: 13,
+        }}
+      >
         {job.location && <span>📍 {job.location}</span>}
         {job.payRange && <span>💰 {job.payRange}</span>}
       </div>
-    </a>
+      <div style={{ marginTop: 8 }}>
+        <Link
+          href={`/jobs/${job.id}/apply`}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            background: T.colors.brand,
+            color: '#fff',
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Apply
+        </Link>
+      </div>
+    </div>
   );
 }
 

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -2,7 +2,9 @@
 import { setTimeout as sleep } from 'timers/promises';
 const BASE = process.env.SMOKE_URL || process.env.BASE || '';
 if (!BASE) { console.log('No SMOKE_URL set; skipping smoke'); process.exit(0); }
-const PATHS = ['/', '/find-work', '/login', ...(process.env.SMOKE_JOB_ID ? [`/jobs/${process.env.SMOKE_JOB_ID}`] : [])];
+const PATHS = ['/', '/find-work', '/login',
+  ...(process.env.SMOKE_JOB_ID ? [`/jobs/${process.env.SMOKE_JOB_ID}`, `/jobs/${process.env.SMOKE_JOB_ID}/apply`] : [])
+];
 const fetchJson = async (url) => {
   const r = await fetch(url, { headers:{ 'accept':'text/html' }});
   if (!r.ok) throw new Error(`${r.status} ${url}`);


### PR DESCRIPTION
## Summary
- add API route to forward apply submissions to webhook when available
- create SSR apply page with legacy fallback and modern form
- link job cards to details and add apply button
- extend smoke test to cover apply page and document webhook env var

## Testing
- `npm run lint --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1c84a7fd48327ba549e3de773b153