### PR TITLE
feat(polish): nav+footer, SEO, 404/500, stronger smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,10 @@ METRICS_SECRET=change-me
 NEXT_PUBLIC_LEGACY_UI=true
 NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
 NEXT_PUBLIC_SHOW_API_BADGE=false
-# Optional banner
+# Optional banner HTML (sanitized) for top notice
 NEXT_PUBLIC_BANNER_HTML=
+# Optional: set a job id for smoke to also hit /jobs/{id} and /jobs/{id}/apply
+# SMOKE_JOB_ID=123
 
 # Optional: webhook to receive apply submissions (if unset, API returns 202 locally)
 # APPLY_WEBHOOK_URL=https://hooks.zapier.com/...

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import ProductShell from '../src/components/layout/ProductShell';
+import { HeadSEO } from '../src/components/HeadSEO';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <ProductShell>
+      <HeadSEO title="Page not found • QuickGig" noIndex />
+      <h1>Page not found</h1>
+      <p>We couldn’t find that page. Try <Link href="/">the homepage</Link> or <Link href="/find-work">find work</Link>.</p>
+    </ProductShell>
+  );
+}

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import ProductShell from '../src/components/layout/ProductShell';
+import { HeadSEO } from '../src/components/HeadSEO';
+import Link from 'next/link';
+
+export default function AppError() {
+  return (
+    <ProductShell>
+      <HeadSEO title="Something went wrong • QuickGig" noIndex />
+      <h1>Something went wrong</h1>
+      <p>Please retry, or go back to <Link href="/">the homepage</Link>.</p>
+    </ProductShell>
+  );
+}

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import ProductShell from '../src/product/layout/ProductShell';
+import ProductShell from '../src/components/layout/ProductShell';
 import { HeadSEO } from '../src/components/HeadSEO';
 import { tokens as T } from '../src/theme/tokens';
 import { searchJobs, type JobSummary } from '../src/lib/api';
@@ -61,10 +61,9 @@ export default function FindWorkPage(props: Props) {
   const prevPage = () => router.push({ pathname: '/find-work', query: { q, location, page: Math.max(1, page - 1) } });
 
   return (
-    <>
+    <ProductShell>
       <HeadSEO title="Find Work • QuickGig" canonical="/find-work" />
-      <ProductShell>
-        <section style={{ display:'grid', gap:16 }}>
+      <section style={{ display:'grid', gap:16 }}>
           <form onSubmit={submit} style={{
             display:'grid', gap:12, gridTemplateColumns:'1fr 1fr auto',
             alignItems:'end', background:'#fff', border:`1px solid ${T.colors.border}`,
@@ -113,8 +112,7 @@ export default function FindWorkPage(props: Props) {
               No jobs found. Try different keywords or locations.
             </div>
           )}
-        </section>
-      </ProductShell>
-    </>
+      </section>
+    </ProductShell>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { HeadSEO } from '../src/components/HeadSEO';
 import fs from 'fs';
 import path from 'path';
-import ProductShell from '../src/product/layout/ProductShell';
+import ProductShell from '../src/components/layout/ProductShell';
 import { Card } from '../src/product/ui/Card';
 import { Button } from '../src/product/ui/Button';
 import { tokens as T } from '../src/theme/tokens';
@@ -30,10 +30,9 @@ export default function Home({ legacyHtml, jobs }: Props){
     return (<div dangerouslySetInnerHTML={{__html: legacyHtml}}/>);
   }
   return (
-    <>
+    <ProductShell>
       <HeadSEO title="QuickGig • Find Gigs Fast" canonical="/" />
-      <ProductShell>
-        <div style={{display:'grid', gap:16}}>
+      <div style={{display:'grid', gap:16}}>
           <Card>
             <h1 style={{fontFamily:T.font.ui, fontSize:28, margin:'0 0 8px'}}>Find gigs fast in the Philippines</h1>
             <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>Search flexible work and apply in minutes.</p>
@@ -50,8 +49,7 @@ export default function Home({ legacyHtml, jobs }: Props){
               <JobGrid jobs={jobs}/>
             </section>
           ) : null}
-        </div>
-      </ProductShell>
-    </>
+      </div>
+    </ProductShell>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { tokens as T } from '../theme/tokens';
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer style={{
+      marginTop: 32,
+      padding: '24px 0',
+      borderTop: `1px solid ${T.colors.border}`,
+      color: T.colors.subtle
+    }}>
+      <div style={{display:'flex', gap:12, flexWrap:'wrap', alignItems:'center', justifyContent:'space-between'}}>
+        <div>© {new Date().getFullYear()} QuickGig.ph</div>
+        <nav style={{display:'flex', gap:12}}>
+          <Link href="/find-work">Find work</Link>
+          <Link href="/login">Sign in</Link>
+          <Link href="/__health">Health</Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/HeadSEO.tsx
+++ b/src/components/HeadSEO.tsx
@@ -5,11 +5,13 @@ export function HeadSEO({
   description = 'Browse flexible gigs in the Philippines and apply in minutes.',
   image = '/legacy/img/og.jpg',
   canonical = '',
+  noIndex = false,
 }: {
   title: string;
   description?: string;
   image?: string;
   canonical?: string;
+  noIndex?: boolean;
 }) {
   return (
     <Head>
@@ -20,6 +22,7 @@ export function HeadSEO({
       <meta property="og:type" content="website" />
       <meta property="og:image" content={image} />
       {canonical ? <link rel="canonical" href={canonical} /> : null}
+      {noIndex ? <meta name="robots" content="noindex" /> : null}
       <meta name="twitter:card" content="summary_large_image" />
     </Head>
   );

--- a/src/components/layout/ProductShell.tsx
+++ b/src/components/layout/ProductShell.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { tokens as T } from '../../theme/tokens';
 import NavBar from '../product/NavBar';
+import Footer from '../Footer';
 
 export default function ProductShell({children}:{children:React.ReactNode}) {
   return (
@@ -12,7 +13,7 @@ export default function ProductShell({children}:{children:React.ReactNode}) {
         <NavBar />
       </header>
       <main style={{display:'grid', gap:16}}>{children}</main>
-      <footer style={{marginTop:'auto', color:T.colors.subtle, fontSize:13}}>© {new Date().getFullYear()} QuickGig</footer>
+      <Footer />
     </div>
   );
 }

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -16,4 +16,12 @@ const fetchJson = async (url) => {
     catch (e) { console.log('WARN', String(e)); }
     await sleep(250);
   }
+  // Soft-check a guaranteed-404 path; do not fail build
+  try {
+    const url404 = BASE.replace(/\/+$/,'') + '/definitely-not-here-404';
+    const r404 = await fetch(url404);
+    console.log('404-check', r404.status);
+  } catch (e) {
+    console.log('404-check error', String(e));
+  }
 })();


### PR DESCRIPTION
## Summary
- add global footer component and render in ProductShell
- ensure HeadSEO used across pages and allow noindex
- add custom 404 and 500 pages
- extend smoke test with soft 404 check

## Testing
- `npm run lint --silent`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cbc4b6fc83279627f42886a98838