### PR TITLE
feat(employer): post a job MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,12 @@ NEXT_PUBLIC_BANNER_HTML=
 # Optional: webhook to receive apply submissions (if unset, API returns 202 locally)
 # APPLY_WEBHOOK_URL=https://hooks.zapier.com/...
 
+# Optional: webhook to receive employer job postings (if unset, API returns 202 locally)
+# POST_JOB_WEBHOOK_URL=https://hooks.zapier.com/...
+
+# Optional: enable smoke to soft-hit post job page (GET) and NO-OP post
+# SMOKE_POST_JOB=0
+
 # Session/auth
 
 JWT_COOKIE_NAME=auth_token

--- a/pages/api/post-job.ts
+++ b/pages/api/post-job.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { normalizeJobPost } from '../../src/lib/postJob';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'Method not allowed' });
+  try {
+    const payload = normalizeJobPost(req.body);
+    const url = process.env.POST_JOB_WEBHOOK_URL;
+    if (!url) {
+      // Accept locally without forwarding (useful in dev/preview)
+      return res.status(202).json({ ok:true, forwarded:false, payloadSummary:{ title: payload.title, tags: payload.tags?.slice(0,6) }});
+    }
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type':'application/json' },
+      body: JSON.stringify({ source:'quickgig.ph', kind:'job_post', at: new Date().toISOString(), payload }),
+    });
+    const ok = r.ok;
+    const status = r.status;
+    const text = await r.text().catch(()=> '');
+    return res.status(ok ? 200 : 502).json({ ok, forwarded:true, status, body: text.slice(0,2000) });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return res.status(400).json({ ok:false, error: message });
+  }
+}

--- a/pages/employer/post.tsx
+++ b/pages/employer/post.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import path from 'path';
+import fs from 'fs';
+import ProductShell from '../../src/components/layout/ProductShell';
+import { HeadSEO } from '../../src/components/HeadSEO';
+
+export async function getServerSideProps() {
+  try {
+    const pub = path.join(process.cwd(), 'public', 'legacy');
+    const frag = fs.readFileSync(path.join(pub, 'index.fragment.html'), 'utf8');
+    const legacyHtml = `<link rel="preload" as="font" href="/legacy/fonts/LegacySans.woff2" type="font/woff2" crossOrigin><link rel="stylesheet" href="/legacy/styles.css" />` + frag;
+    return { props: { legacyHtml } };
+  } catch {
+    return { props: { legacyHtml: '' } };
+  }
+}
+
+export default function PostJobPage({ legacyHtml }: { legacyHtml:string }) {
+  const [submitting, setSubmitting] = React.useState(false);
+  const [result, setResult] = React.useState<string | null>(null);
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitting(true); setResult(null);
+    const fd = new FormData(e.currentTarget);
+    const body = Object.fromEntries(fd.entries());
+    try {
+      const r = await fetch('/api/post-job', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(body) });
+      const j = await r.json().catch(()=> ({}));
+      setResult(r.ok ? 'Submitted ✅' : `Failed: ${j?.error || r.status}`);
+      if (r.ok) e.currentTarget.reset();
+    } catch {
+      setResult('Network error');
+    } finally { setSubmitting(false); }
+  };
+  return (
+    <ProductShell>
+      <HeadSEO title="Post a job • QuickGig" />
+      <h1>Post a job</h1>
+      <p style={{opacity:.8, marginTop:-8}}>Share your opportunity with QuickGig talent.</p>
+      <form onSubmit={onSubmit} style={{display:'grid', gap:12, maxWidth:720}}>
+        <label>Title<input name="title" required placeholder="e.g., Part-time Barista" /></label>
+        <label>Description<textarea name="description" required rows={6} placeholder="What’s the role, responsibilities, requirements?" /></label>
+        <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:12}}>
+          <label>Location<input name="location" placeholder="City / Remote" /></label>
+          <label>Category<input name="category" placeholder="e.g., Food Service" /></label>
+        </div>
+        <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:12}}>
+          <label>Pay min<input name="payMin" type="number" min="0" step="1" placeholder="e.g., 300" /></label>
+          <label>Pay max<input name="payMax" type="number" min="0" step="1" placeholder="e.g., 500" /></label>
+        </div>
+        <label>Tags (comma-separated)<input name="tags" placeholder="weekend, urgent, night-shift" /></label>
+        <label>Contact email (optional)<input name="email" type="email" placeholder="you@company.com" /></label>
+        <button disabled={submitting} type="submit">{submitting ? 'Submitting…' : 'Submit job'}</button>
+        {result && <div role="status" style={{marginTop:4}}>{result}</div>}
+      </form>
+      {/* If someone forces legacy=1 and HTML exists, still fallback gracefully */}
+      {legacyHtml ? <noscript dangerouslySetInnerHTML={{ __html: legacyHtml }} /> : null}
+      <style jsx>{`
+        input, textarea { width:100%; padding:10px 12px; border:1px solid #e5e7eb; border-radius:10px; font:inherit; }
+        label { display:grid; gap:6px; font-weight:500; }
+        button { padding:10px 14px; border-radius:10px; border:0; cursor:pointer; }
+        button:not(:disabled) { background:#2563eb; color:white; }
+        button:disabled { background:#a5b4fc; color:white; cursor:wait; }
+      `}</style>
+    </ProductShell>
+  );
+}

--- a/src/components/product/NavBar.tsx
+++ b/src/components/product/NavBar.tsx
@@ -19,6 +19,7 @@ export default function NavBar() {
       <Link href="/" style={linkStyle(is('/'))}>Home</Link>
       <Link href="/find-work" style={linkStyle(is('/find-work'))}>Find Work</Link>
       <Link href="/saved" style={linkStyle(is('/saved'))}>Saved</Link>
+      <Link href="/employer/post" style={linkStyle(is('/employer/post'))}>Post a job</Link>
       <div style={{flex:1}} />
       <Link href="/login" style={linkStyle(is('/login'))}>Sign in</Link>
     </nav>

--- a/src/lib/postJob.ts
+++ b/src/lib/postJob.ts
@@ -1,0 +1,34 @@
+export type JobPostPayload = {
+  title: string;
+  description: string;
+  location?: string;
+  category?: string;
+  payMin?: number | null;
+  payMax?: number | null;
+  tags?: string[];
+  email?: string; // contact email (optional)
+};
+
+export function normalizeJobPost(input: Record<string, unknown>): JobPostPayload {
+  const toNum = (v: unknown) => {
+    const n = typeof v === 'string' ? Number(v) : v;
+    return typeof n === 'number' && Number.isFinite(n) ? n : null;
+  };
+  const t = (s: unknown) => (typeof s === 'string' ? s.trim() : '');
+  const arr = (a: unknown) => Array.isArray(a) ? a.map(t).filter(Boolean) :
+    typeof a === 'string' ? a.split(',').map(t).filter(Boolean) : [];
+  const title = t(input.title);
+  const description = t(input.description);
+  if (!title || !description) throw new Error('title and description are required');
+  const payload: JobPostPayload = {
+    title,
+    description,
+    location: t(input.location),
+    category: t(input.category),
+    payMin: toNum(input.payMin),
+    payMax: toNum(input.payMax),
+    tags: arr(input.tags),
+    email: t(input.email) || undefined,
+  };
+  return payload;
+}

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -25,6 +25,13 @@ const fetchJson = async (url) => {
     const rS = await fetch(`${BASE}/saved`);
     console.log('saved page', rS.status);
   } catch (e) { console.log('saved page error', String(e)); }
+
+  if (process.env.SMOKE_POST_JOB === '1') {
+    try {
+      const rP = await fetch(`${BASE}/employer/post`);
+      console.log('post-job page', rP.status);
+    } catch (e) { console.log('post-job page error', String(e)); }
+  }
   // Soft-check a guaranteed-404 path; do not fail build
   try {
     const url404 = BASE.replace(/\/+$/,'') + '/definitely-not-here-404';


### PR DESCRIPTION
## Summary
- document POST_JOB_WEBHOOK_URL and optional SMOKE_POST_JOB
- add post-job payload helper
- proxy /api/post-job to POST_JOB_WEBHOOK_URL with local fallback
- ship employer post-job page and nav link
- smoke test optional post-job page

## Testing
- `npm run lint --silent`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d63fff488327a599b1445b33599e