### PR TITLE
feat(taglish): Taglish copy + switcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
 NEXT_PUBLIC_SHOW_API_BADGE=false
 # Optional banner HTML (sanitized) for top notice
 NEXT_PUBLIC_BANNER_HTML=
+## Copy variant (english|taglish). Can be overridden by ?lang=, or localStorage('copyVariant')
+NEXT_PUBLIC_COPY_VARIANT=english
 # Optional: set a job id for smoke to also hit /jobs/{id} and /jobs/{id}/apply
 # SMOKE_JOB_ID=123
 

--- a/pages/employer/post.tsx
+++ b/pages/employer/post.tsx
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import ProductShell from '../../src/components/layout/ProductShell';
 import { HeadSEO } from '../../src/components/HeadSEO';
+import { t } from '../../src/lib/t';
 
 export async function getServerSideProps() {
   try {
@@ -34,8 +35,8 @@ export default function PostJobPage({ legacyHtml }: { legacyHtml:string }) {
   };
   return (
     <ProductShell>
-      <HeadSEO title="Post a job • QuickGig" />
-      <h1>Post a job</h1>
+      <HeadSEO title={`${t('employer_post')} • QuickGig`} />
+      <h1>{t('employer_post')}</h1>
       <p style={{opacity:.8, marginTop:-8}}>Share your opportunity with QuickGig talent.</p>
       <form onSubmit={onSubmit} style={{display:'grid', gap:12, maxWidth:720}}>
         <label>Title<input name="title" required placeholder="e.g., Part-time Barista" /></label>

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -6,6 +6,7 @@ import { JobGrid } from '../src/product/JobCard';
 import { searchJobs, type JobSummary } from '../src/lib/api';
 import FilterBar from '../src/product/ui/FilterBar';
 import Pagination from '../src/product/ui/Pagination';
+import { t } from '../src/lib/t';
 
 type Props = {
   legacyHtml?: string;
@@ -19,8 +20,8 @@ export default function FindWork({ legacyHtml, items=[], total, q, loc, cat, sor
   const hasNext = total ? (page*size < total) : (items.length===size);
   return (
     <ProductShell>
-      <HeadSEO title="Find Gigs • QuickGig" />
-      <h1>Find work</h1>
+      <HeadSEO title={`${t('nav_find')} • QuickGig`} />
+      <h1>{t('nav_find')}</h1>
       <FilterBar q={q} loc={loc} cat={cat} sort={sort} />
       {items.length ? (
         <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import { tokens as T } from '../src/theme/tokens';
 import { JobGrid } from '../src/product/JobCard';
 import { featuredJobs, type JobSummary } from '../src/lib/api';
 import { legacyFlagFromEnv, legacyFlagFromQuery } from '../src/lib/legacyFlag';
+import { t } from '../src/lib/t';
 
 type Props = { legacyHtml?: string; jobs: JobSummary[] };
 export async function getStaticProps() {
@@ -31,21 +32,21 @@ export default function Home({ legacyHtml, jobs }: Props){
   }
   return (
     <ProductShell>
-      <HeadSEO title="QuickGig • Find Gigs Fast" canonical="/" />
+      <HeadSEO title={t('site_title')} canonical="/" />
       <div style={{display:'grid', gap:16}}>
           <Card>
-            <h1 style={{fontFamily:T.font.ui, fontSize:28, margin:'0 0 8px'}}>Find gigs fast in the Philippines</h1>
-            <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>Search flexible work and apply in minutes.</p>
+            <h1 style={{fontFamily:T.font.ui, fontSize:28, margin:'0 0 8px'}}>{t('home_hero_title')}</h1>
+            <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>{t('home_hero_tag')}</p>
             <div style={{display:'flex', gap:12}}>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a href="/find-work"><Button>Browse jobs</Button></a>
+              <a href="/find-work"><Button>{t('nav_find')}</Button></a>
               <a href="/register"><Button variant="subtle">Create account</Button></a>
             </div>
           </Card>
           {/* Featured jobs */}
           {jobs?.length ? (
             <section>
-              <h2 style={{margin:'8px 0 12px', fontSize:20}}>Featured jobs</h2>
+              <h2 style={{margin:'8px 0 12px', fontSize:20}}>{t('jobs_featured')}</h2>
               <JobGrid jobs={jobs}/>
             </section>
           ) : null}

--- a/pages/jobs/[id].tsx
+++ b/pages/jobs/[id].tsx
@@ -9,6 +9,7 @@ import { legacyFlagFromEnv, legacyFlagFromQuery } from '../../src/lib/legacyFlag
 import { getJobDetails, type JobDetail } from '../../src/lib/api';
 import { tokens as T } from '../../src/theme/tokens';
 import { useSavedJobs } from '../../src/product/useSavedJobs';
+import { t } from '../../src/lib/t';
 
 type Props = { job: JobDetail | null; legacyHtml?: string };
 
@@ -36,9 +37,9 @@ export default function JobDetailsPage({ job, legacyHtml }: Props) {
   if (!job) {
     return (
       <ProductShell>
-        <HeadSEO title="Job not found • QuickGig" />
+        <HeadSEO title={`${t('not_found')} • QuickGig`} />
         <div style={{background:'#fff', border:`1px solid ${T.colors.border}`, padding:16, borderRadius:8}}>
-          Job not found.
+          {t('not_found')}
         </div>
       </ProductShell>
     );
@@ -67,7 +68,7 @@ export default function JobDetailsPage({ job, legacyHtml }: Props) {
           <div style={{color:T.colors.subtle}}>No description provided.</div>
         )}
         <div style={{display:'flex', gap:8}}>
-          <Link href="/login" style={{padding:'10px 14px', borderRadius:8, background:T.colors.brand, color:'#fff', textDecoration:'none', fontWeight:700}}>Apply now</Link>
+          <Link href="/login" style={{padding:'10px 14px', borderRadius:8, background:T.colors.brand, color:'#fff', textDecoration:'none', fontWeight:700}}>{t('job_apply')}</Link>
           <Link href="/find-work" style={{padding:'10px 14px', borderRadius:8, border:`1px solid ${T.colors.border}`, background:'#fff', textDecoration:'none'}}>Back to search</Link>
         </div>
       </article>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -7,6 +7,7 @@ import { Card } from '../src/product/ui/Card';
 import { Input } from '../src/product/ui/Input';
 import { Button } from '../src/product/ui/Button';
 import { legacyFlagFromEnv, legacyFlagFromQuery } from '../src/lib/legacyFlag';
+import { t } from '../src/lib/t';
 
 type Props = { legacyHtml?: string };
 export async function getStaticProps() {
@@ -23,15 +24,15 @@ export default function Login({ legacyHtml }: Props){
   if(useLegacy && legacyHtml){ return (<div dangerouslySetInnerHTML={{__html: legacyHtml}}/>); }
   return (
     <>
-      <Head><title>Log in • QuickGig</title></Head>
+      <Head><title>{t('login_title')} • QuickGig</title></Head>
       <ProductShell>
         <Card style={{maxWidth:520, margin:'0 auto'}}>
-          <h2 style={{marginTop:0}}>Log in</h2>
+          <h2 style={{marginTop:0}}>{t('login_title')}</h2>
           <form method="post" action="/api/auth">
             <div style={{display:'grid', gap:12}}>
               <label>Email<Input name="email" type="email" required/></label>
               <label>Password<Input name="password" type="password" required/></label>
-              <Button type="submit">Log in</Button>
+              <Button type="submit">{t('login_title')}</Button>
             </div>
           </form>
           <p style={{marginTop:12}}><a href="/register">Need an account?</a></p>

--- a/src/components/LocaleSwitch.tsx
+++ b/src/components/LocaleSwitch.tsx
@@ -1,0 +1,17 @@
+'use client';
+import * as React from 'react';
+import { getVariantRuntime, setVariantRuntime } from '../lib/t';
+export default function LocaleSwitch() {
+  const [v, setV] = React.useState<"english"|"taglish">(getVariantRuntime());
+  function set(lang: "english"|"taglish") {
+    setVariantRuntime(lang);
+    setV(lang);
+    location.reload();
+  }
+  return (
+    <div style={{display:'inline-flex', gap:8, alignItems:'center'}}>
+      <button aria-pressed={v==='english'} onClick={()=>set('english')}>EN</button>
+      <button aria-pressed={v==='taglish'} onClick={()=>set('taglish')}>TL</button>
+    </div>
+  );
+}

--- a/src/components/product/NavBar.tsx
+++ b/src/components/product/NavBar.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { tokens as T } from '../../theme/tokens';
+import { t } from '../../lib/t';
+import dynamic from 'next/dynamic';
+const LocaleSwitch = dynamic(() => import('../LocaleSwitch'), { ssr: false });
 
 const linkStyle = (active: boolean): React.CSSProperties => ({
   padding: '10px 12px',
@@ -17,11 +20,12 @@ export default function NavBar() {
   return (
     <nav style={{display:'flex', gap:8, alignItems:'center', padding:'8px 0'}}>
       <Link href="/" style={linkStyle(is('/'))}>Home</Link>
-      <Link href="/find-work" style={linkStyle(is('/find-work'))}>Find Work</Link>
-      <Link href="/saved" style={linkStyle(is('/saved'))}>Saved</Link>
-      <Link href="/employer/post" style={linkStyle(is('/employer/post'))}>Post a job</Link>
+      <Link href="/find-work" style={linkStyle(is('/find-work'))}>{t('nav_find')}</Link>
+      <Link href="/saved" style={linkStyle(is('/saved'))}>{t('nav_saved')}</Link>
+      <Link href="/employer/post" style={linkStyle(is('/employer/post'))}>{t('nav_post')}</Link>
       <div style={{flex:1}} />
-      <Link href="/login" style={linkStyle(is('/login'))}>Sign in</Link>
+      <Link href="/login" style={linkStyle(is('/login'))}>{t('nav_signin')}</Link>
+      <span style={{marginLeft:12}}><LocaleSwitch /></span>
     </nav>
   );
 }

--- a/src/lib/t.ts
+++ b/src/lib/t.ts
@@ -1,0 +1,81 @@
+/** tiny copy helper with english/taglish variants and simple runtime switching */
+export type Messages = Record<string, string>;
+export type Bundle = { english: Messages; taglish: Messages };
+
+const english: Messages = {
+  site_title: "QuickGig • Find Gigs Fast in the Philippines",
+  nav_find: "Find work",
+  nav_saved: "Saved",
+  nav_post: "Post a job",
+  nav_signin: "Sign in",
+  nav_signout: "Sign out",
+  nav_language: "Language",
+  home_hero_title: "Hanap trabaho made simple",
+  home_hero_tag: "Search gigs near you and apply in minutes.",
+  search_placeholder: "Search jobs (keyword, company…)",
+  search_filters: "Filters",
+  jobs_featured: "Featured jobs",
+  saved_title: "Saved jobs",
+  job_apply: "Apply now",
+  job_applied: "Applied",
+  job_save: "Save",
+  job_saved: "Saved",
+  login_title: "Sign in",
+  apply_title: "Apply to this job",
+  employer_post: "Post a job",
+  not_found: "Page not found",
+};
+
+const taglish: Messages = {
+  site_title: "QuickGig • Hanap Trabaho, Bilis!",
+  nav_find: "Hanap trabaho",
+  nav_saved: "Na-save",
+  nav_post: "Mag-post ng trabaho",
+  nav_signin: "Mag-log in",
+  nav_signout: "Mag-log out",
+  nav_language: "Wika",
+  home_hero_title: "Hanap trabaho, walang abala",
+  home_hero_tag: "Mag-search ng gigs malapit sa’yo at mag-apply agad.",
+  search_placeholder: "Maghanap ng trabaho (keyword, company…)",
+  search_filters: "Mga filter",
+  jobs_featured: "Mga tampok na trabaho",
+  saved_title: "Mga na-save na trabaho",
+  job_apply: "Mag-apply ngayon",
+  job_applied: "Nakapag-apply na",
+  job_save: "I-save",
+  job_saved: "Na-save",
+  login_title: "Mag-log in",
+  apply_title: "Mag-apply sa trabahong ito",
+  employer_post: "Mag-post ng trabaho",
+  not_found: "Hindi makita ang page",
+};
+
+const bundle: Bundle = { english, taglish };
+
+function readVariantFromEnv(): keyof Bundle {
+  const v = (process.env.NEXT_PUBLIC_COPY_VARIANT || "english").toLowerCase();
+  return (v === "taglish" ? "taglish" : "english") as keyof Bundle;
+}
+
+/** Decide variant: ?lang=tl|en > localStorage('copyVariant') > env */
+export function getVariantRuntime(): keyof Bundle {
+  if (typeof window === "undefined") return readVariantFromEnv();
+  const u = new URL(window.location.href);
+  const q = u.searchParams.get("lang");
+  if (q === "tl") return "taglish";
+  if (q === "en") return "english";
+  const saved = window.localStorage.getItem("copyVariant");
+  if (saved === "taglish" || saved === "english") return saved as keyof Bundle;
+  return readVariantFromEnv();
+}
+
+export function setVariantRuntime(v: "english" | "taglish") {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem("copyVariant", v);
+  }
+}
+
+export function t(key: keyof typeof english): string {
+  const v = getVariantRuntime();
+  return (bundle[v][key] ?? bundle.english[key] ?? key) as string;
+}

--- a/src/product/JobCard.tsx
+++ b/src/product/JobCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { tokens as T } from '../theme/tokens';
 import type { JobSummary } from '../lib/api';
 import { useSavedJobs } from './useSavedJobs';
+import { t } from '../lib/t';
 
 export function JobCard({ job }: { job: JobSummary }) {
   const { isSaved, toggle } = useSavedJobs();
@@ -69,7 +70,7 @@ export function JobCard({ job }: { job: JobSummary }) {
             fontWeight: 600,
           }}
         >
-          Apply
+          {t('job_apply')}
         </Link>
       </div>
     </div>

--- a/src/product/ui/FilterBar.tsx
+++ b/src/product/ui/FilterBar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useRouter } from 'next/router';
+import { t } from '../../lib/t';
 
 type Props = {
   q?: string; loc?: string; cat?: string; sort?: string;
@@ -19,7 +20,7 @@ export default function FilterBar({ q='', loc='', cat='', sort='relevant' }: Pro
   }
   return (
     <form onSubmit={(e)=>{e.preventDefault(); push(state);}} style={{display:'grid', gap:12, gridTemplateColumns:'1fr 1fr 1fr 1fr auto'}}>
-      <input placeholder="Search keywords" value={state.q} onChange={e=>set(s=>({...s,q:e.target.value}))}/>
+      <input placeholder={t('search_placeholder')} value={state.q} onChange={e=>set(s=>({...s,q:e.target.value}))}/>
       <input placeholder="Location" value={state.loc} onChange={e=>set(s=>({...s,loc:e.target.value}))}/>
       <select value={state.cat} onChange={e=>set(s=>({...s,cat:e.target.value}))}>
         {cats.map(c=><option key={c} value={c}>{c||'All categories'}</option>)}


### PR DESCRIPTION
## Summary
- add t() copy helper with english/taglish bundles and runtime variant detection
- provide LocaleSwitch and expose in navbar
- update top pages to use localized copy (home, find-work, job details, employer post, login)

## Testing
- `npm run lint --silent`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dba424c08327a3993929cd7c31d7