### PR TITLE
feat(taglish+seo): localize remaining pages + HeadSEO; complete EN/Taglish bundles; polish locale switch (legacy-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ NEXT_PUBLIC_LEGACY_STRICT_SHELL=true
 NEXT_PUBLIC_SHOW_API_BADGE=false
 # Optional banner HTML (sanitized) for top notice
 NEXT_PUBLIC_BANNER_HTML=
-## Copy variant (english|taglish). Can be overridden by ?lang=, or localStorage('copyVariant')
+## Copy variant (english|taglish). ?lang=tl|en overrides and persists in localStorage
 NEXT_PUBLIC_COPY_VARIANT=english
 # Optional: set a job id for smoke to also hit /jobs/{id} and /jobs/{id}/apply
 # SMOKE_JOB_ID=123

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,13 +2,17 @@ import * as React from 'react';
 import ProductShell from '../src/components/layout/ProductShell';
 import { HeadSEO } from '../src/components/HeadSEO';
 import Link from 'next/link';
+import { t } from '../src/lib/t';
 
 export default function NotFound() {
   return (
     <ProductShell>
-      <HeadSEO title="Page not found • QuickGig" noIndex />
-      <h1>Page not found</h1>
-      <p>We couldn’t find that page. Try <Link href="/">the homepage</Link> or <Link href="/find-work">find work</Link>.</p>
+      <HeadSEO titleKey="err404_title" descKey="err404_body" noIndex />
+      <h1>{t('err404_title')}</h1>
+      <p>
+        {t('err404_body')}{' '}
+        <Link href="/">Home</Link>
+      </p>
     </ProductShell>
   );
 }

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -2,13 +2,17 @@ import * as React from 'react';
 import ProductShell from '../src/components/layout/ProductShell';
 import { HeadSEO } from '../src/components/HeadSEO';
 import Link from 'next/link';
+import { t } from '../src/lib/t';
 
 export default function AppError() {
   return (
     <ProductShell>
-      <HeadSEO title="Something went wrong • QuickGig" noIndex />
-      <h1>Something went wrong</h1>
-      <p>Please retry, or go back to <Link href="/">the homepage</Link>.</p>
+      <HeadSEO titleKey="err500_title" descKey="err500_body" noIndex />
+      <h1>{t('err500_title')}</h1>
+      <p>
+        {t('err500_body')}{' '}
+        <Link href="/">Home</Link>
+      </p>
     </ProductShell>
   );
 }

--- a/pages/employer/post.tsx
+++ b/pages/employer/post.tsx
@@ -35,7 +35,7 @@ export default function PostJobPage({ legacyHtml }: { legacyHtml:string }) {
   };
   return (
     <ProductShell>
-      <HeadSEO title={`${t('employer_post')} • QuickGig`} />
+      <HeadSEO titleKey="employer_post" descKey="employer_post" />
       <h1>{t('employer_post')}</h1>
       <p style={{opacity:.8, marginTop:-8}}>Share your opportunity with QuickGig talent.</p>
       <form onSubmit={onSubmit} style={{display:'grid', gap:12, maxWidth:720}}>

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -20,17 +20,18 @@ export default function FindWork({ legacyHtml, items=[], total, q, loc, cat, sor
   const hasNext = total ? (page*size < total) : (items.length===size);
   return (
     <ProductShell>
-      <HeadSEO title={`${t('nav_find')} • QuickGig`} />
-      <h1>{t('nav_find')}</h1>
+      <HeadSEO titleKey="search_title" descKey="search_title" />
+      <h1>{t('search_title')}</h1>
       <FilterBar q={q} loc={loc} cat={cat} sort={sort} />
       {items.length ? (
         <>
+          <p style={{margin:'8px 0'}}>{t('search_results_count', { total: total ?? items.length })}</p>
           <JobGrid jobs={items} />
           <Pagination page={page} hasNext={hasNext} hrefBase="/find-work" qs={qs} />
         </>
       ) : (
         <div style={{padding:'24px 0'}}>
-          <p>No results yet. Try different keywords or clearing filters.</p>
+          <p>{t('search_empty')}</p>
         </div>
       )}
     </ProductShell>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,11 +32,11 @@ export default function Home({ legacyHtml, jobs }: Props){
   }
   return (
     <ProductShell>
-      <HeadSEO title={t('site_title')} canonical="/" />
+      <HeadSEO titleKey="home_hero_title" descKey="home_hero_cta" canonical="/" />
       <div style={{display:'grid', gap:16}}>
           <Card>
             <h1 style={{fontFamily:T.font.ui, fontSize:28, margin:'0 0 8px'}}>{t('home_hero_title')}</h1>
-            <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>{t('home_hero_tag')}</p>
+            <p style={{color:T.colors.subtle, margin:'0 0 16px'}}>{t('home_hero_cta')}</p>
             <div style={{display:'flex', gap:12}}>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
               <a href="/find-work"><Button>{t('nav_find')}</Button></a>

--- a/pages/jobs/[id].tsx
+++ b/pages/jobs/[id].tsx
@@ -37,7 +37,7 @@ export default function JobDetailsPage({ job, legacyHtml }: Props) {
   if (!job) {
     return (
       <ProductShell>
-        <HeadSEO title={`${t('not_found')} • QuickGig`} />
+        <HeadSEO titleKey="not_found" descKey="search_title" />
         <div style={{background:'#fff', border:`1px solid ${T.colors.border}`, padding:16, borderRadius:8}}>
           {t('not_found')}
         </div>
@@ -48,7 +48,7 @@ export default function JobDetailsPage({ job, legacyHtml }: Props) {
   const saved = isSaved(String(job.id));
   return (
     <ProductShell>
-      <HeadSEO title={`${job.title} • QuickGig`} />
+      <HeadSEO title={job.title} descKey="search_title" />
       <article style={{background:'#fff', border:`1px solid ${T.colors.border}`, borderRadius:12, padding:20, display:'grid', gap:12}}>
         <div style={{display:'flex', alignItems:'center', gap:12}}>
           <h1 style={{margin:'0 0 4px'}}>{job.title}</h1>

--- a/pages/jobs/[id]/apply.tsx
+++ b/pages/jobs/[id]/apply.tsx
@@ -8,6 +8,7 @@ import { HeadSEO } from '../../../src/components/HeadSEO';
 import { getJobDetails, type JobDetail } from '../../../src/lib/api';
 import { legacyFlagFromEnv, legacyFlagFromQuery } from '../../../src/lib/legacyFlag';
 import { tokens as T } from '../../../src/theme/tokens';
+import { t } from '../../../src/lib/t';
 
 type Props = { job: JobDetail|null; legacyHtml?: string };
 
@@ -33,7 +34,7 @@ export default function ApplyPage({ job, legacyHtml }: Props) {
 
   return (
     <ProductShell>
-      <HeadSEO title={job ? `Apply • ${job.title} • QuickGig` : 'Apply • QuickGig'} />
+      <HeadSEO title={job ? `${t('job_apply_title')} • ${job.title}` : t('job_apply_title')} descKey="search_title" />
       <section style={{display:'grid', gap:16}}>
         {job ? (
           <header style={{display:'grid', gap:4}}>
@@ -43,7 +44,7 @@ export default function ApplyPage({ job, legacyHtml }: Props) {
             </div>
           </header>
         ) : (
-          <h1>Apply</h1>
+          <h1>{t('job_apply_title')}</h1>
         )}
 
         <ApplyForm jobId={String(job?.id ?? '')} />
@@ -88,15 +89,15 @@ function ApplyForm({ jobId }: { jobId: string }) {
   return (
     <form onSubmit={onSubmit}
       style={{background:'#fff', border:`1px solid ${T.colors.border}`, borderRadius:12, padding:16, display:'grid', gap:12, maxWidth:560}}>
-      {field('Full name',
+      {field(t('apply_name'),
         <input value={name} onChange={e=>setName(e.target.value)} placeholder="Juan Dela Cruz"
                style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
       )}
-      {field('Email',
+      {field(t('apply_email'),
         <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="you@example.com"
                style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
       )}
-      {field('Message (optional)',
+      {field(t('apply_resume'),
         <textarea value={message} onChange={e=>setMessage(e.target.value)} rows={5}
                   placeholder="Short note to the employer"
                   style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`, resize:'vertical'}} />
@@ -106,13 +107,13 @@ function ApplyForm({ jobId }: { jobId: string }) {
         <button type="submit" disabled={disabled}
           style={{padding:'10px 14px', borderRadius:8, background: disabled? '#9aa5b1': T.colors.brand, color:'#fff',
                   border:'none', fontWeight:700, cursor: disabled? 'not-allowed':'pointer'}}>
-          {status==='sending' ? 'Sending…' : 'Submit application'}
+          {status==='sending' ? 'Sending…' : t('apply_submit')}
         </button>
         <Link href="/login" style={{padding:'10px 14px', borderRadius:8, border:`1px solid ${T.colors.border}`, textDecoration:'none'}}>Sign in</Link>
       </div>
 
-      {status==='ok' && <p role="status" style={{color:'green', margin:0}}>Thanks! Your application was received.</p>}
-      {status==='err' && <p role="status" style={{color:'crimson', margin:0}}>Something went wrong. Please try again.</p>}
+      {status==='ok' && <p role="status" style={{color:'green', margin:0}}>{t('apply_success')}</p>}
+      {status==='err' && <p role="status" style={{color:'crimson', margin:0}}>{t('apply_error')}</p>}
     </form>
   );
 }

--- a/pages/saved.tsx
+++ b/pages/saved.tsx
@@ -4,6 +4,7 @@ import { HeadSEO } from '../src/components/HeadSEO';
 import { useSavedJobs } from '../src/product/useSavedJobs';
 import { JobGrid } from '../src/product/JobCard';
 import { searchJobs, type JobSummary } from '../src/lib/api';
+import { t } from '../src/lib/t';
 
 export default function SavedPage() {
   const { ids } = useSavedJobs();
@@ -24,9 +25,9 @@ export default function SavedPage() {
   }, [ids]);
   return (
     <ProductShell>
-      <HeadSEO title="Saved Jobs • QuickGig" />
-      <h1>Saved jobs</h1>
-      {!ids.length ? <p>You haven’t saved any jobs yet.</p> : <JobGrid jobs={jobs} />}
+      <HeadSEO titleKey="saved_title" descKey="saved_title" />
+      <h1>{t('saved_title')}</h1>
+      {!ids.length ? <p>{t('saved_empty')}</p> : <JobGrid jobs={jobs} />}
     </ProductShell>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { tokens as T } from '../theme/tokens';
 import Link from 'next/link';
+import { t } from '../lib/t';
 
 export default function Footer() {
   return (
@@ -11,11 +12,11 @@ export default function Footer() {
       color: T.colors.subtle
     }}>
       <div style={{display:'flex', gap:12, flexWrap:'wrap', alignItems:'center', justifyContent:'space-between'}}>
-        <div>© {new Date().getFullYear()} QuickGig.ph</div>
+        <div>{t('footer_copyright', { year: new Date().getFullYear() })}</div>
         <nav style={{display:'flex', gap:12}}>
-          <Link href="/find-work">Find work</Link>
-          <Link href="/login">Sign in</Link>
-          <Link href="/__health">Health</Link>
+          <Link href="/about">{t('footer_about')}</Link>
+          <Link href="/terms">{t('footer_terms')}</Link>
+          <Link href="/privacy">{t('footer_privacy')}</Link>
         </nav>
       </div>
     </footer>

--- a/src/components/HeadSEO.tsx
+++ b/src/components/HeadSEO.tsx
@@ -1,24 +1,31 @@
 import Head from 'next/head';
+import { t } from '../lib/t';
 
 export function HeadSEO({
   title,
+  titleKey,
   description = 'Browse flexible gigs in the Philippines and apply in minutes.',
+  descKey,
   image = '/legacy/img/og.jpg',
   canonical = '',
   noIndex = false,
 }: {
-  title: string;
+  title?: string;
+  titleKey?: Parameters<typeof t>[0];
   description?: string;
+  descKey?: Parameters<typeof t>[0];
   image?: string;
   canonical?: string;
   noIndex?: boolean;
 }) {
+  const finalTitle = titleKey ? t(titleKey) : (title || '');
+  const finalDesc = descKey ? t(descKey) : description;
   return (
     <Head>
-      <title>{title}</title>
-      <meta name="description" content={description} />
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
+      <title>{finalTitle}</title>
+      <meta name="description" content={finalDesc} />
+      <meta property="og:title" content={finalTitle} />
+      <meta property="og:description" content={finalDesc} />
       <meta property="og:type" content="website" />
       <meta property="og:image" content={image} />
       {canonical ? <link rel="canonical" href={canonical} /> : null}

--- a/src/components/LocaleSwitch.tsx
+++ b/src/components/LocaleSwitch.tsx
@@ -6,7 +6,9 @@ export default function LocaleSwitch() {
   function set(lang: "english"|"taglish") {
     setVariantRuntime(lang);
     setV(lang);
-    location.reload();
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', lang === 'taglish' ? 'tl' : 'en');
+    window.location.href = url.toString();
   }
   return (
     <div style={{display:'inline-flex', gap:8, alignItems:'center'}}>

--- a/src/components/product/NavBar.tsx
+++ b/src/components/product/NavBar.tsx
@@ -22,7 +22,7 @@ export default function NavBar() {
       <Link href="/" style={linkStyle(is('/'))}>Home</Link>
       <Link href="/find-work" style={linkStyle(is('/find-work'))}>{t('nav_find')}</Link>
       <Link href="/saved" style={linkStyle(is('/saved'))}>{t('nav_saved')}</Link>
-      <Link href="/employer/post" style={linkStyle(is('/employer/post'))}>{t('nav_post')}</Link>
+      <Link href="/employer/post" style={linkStyle(is('/employer/post'))}>{t('nav_post_job')}</Link>
       <div style={{flex:1}} />
       <Link href="/login" style={linkStyle(is('/login'))}>{t('nav_signin')}</Link>
       <span style={{marginLeft:12}}><LocaleSwitch /></span>

--- a/src/lib/t.ts
+++ b/src/lib/t.ts
@@ -7,22 +7,41 @@ const english: Messages = {
   nav_find: "Find work",
   nav_saved: "Saved",
   nav_post: "Post a job",
+  nav_post_job: "Post a job",
   nav_signin: "Sign in",
   nav_signout: "Sign out",
   nav_language: "Language",
   home_hero_title: "Hanap trabaho made simple",
-  home_hero_tag: "Search gigs near you and apply in minutes.",
+  home_hero_cta: "Search gigs near you and apply in minutes.",
   search_placeholder: "Search jobs (keyword, company…)",
   search_filters: "Filters",
+  search_title: "Find work",
+  search_empty: "No results yet. Try different keywords or clearing filters.",
+  search_results_count: "{total} results",
   jobs_featured: "Featured jobs",
   saved_title: "Saved jobs",
+  saved_empty: "You haven’t saved any jobs yet.",
   job_apply: "Apply now",
   job_applied: "Applied",
   job_save: "Save",
   job_saved: "Saved",
+  job_apply_title: "Apply to this job",
+  apply_name: "Full name",
+  apply_email: "Email",
+  apply_resume: "Resume or note",
+  apply_submit: "Submit application",
+  apply_success: "Thanks! Your application was received.",
+  apply_error: "Something went wrong. Please try again.",
   login_title: "Sign in",
-  apply_title: "Apply to this job",
   employer_post: "Post a job",
+  footer_about: "About",
+  footer_terms: "Terms",
+  footer_privacy: "Privacy",
+  footer_copyright: "© {year} QuickGig.ph",
+  err404_title: "Page not found",
+  err404_body: "We couldn’t find that page. Try the homepage.",
+  err500_title: "Something went wrong",
+  err500_body: "Please retry or go back to the homepage.",
   not_found: "Page not found",
 };
 
@@ -31,22 +50,41 @@ const taglish: Messages = {
   nav_find: "Hanap trabaho",
   nav_saved: "Na-save",
   nav_post: "Mag-post ng trabaho",
+  nav_post_job: "Mag-post ng trabaho",
   nav_signin: "Mag-log in",
   nav_signout: "Mag-log out",
   nav_language: "Wika",
   home_hero_title: "Hanap trabaho, walang abala",
-  home_hero_tag: "Mag-search ng gigs malapit sa’yo at mag-apply agad.",
+  home_hero_cta: "Mag-search ng gigs malapit sa’yo at mag-apply agad.",
   search_placeholder: "Maghanap ng trabaho (keyword, company…)",
   search_filters: "Mga filter",
+  search_title: "Hanap trabaho",
+  search_empty: "Wala pang resulta. Subukan ibang keywords o linisin ang filters.",
+  search_results_count: "{total} resulta",
   jobs_featured: "Mga tampok na trabaho",
   saved_title: "Mga na-save na trabaho",
+  saved_empty: "Wala ka pang na-save na trabaho.",
   job_apply: "Mag-apply ngayon",
   job_applied: "Nakapag-apply na",
   job_save: "I-save",
   job_saved: "Na-save",
+  job_apply_title: "Mag-apply sa trabahong ito",
+  apply_name: "Buong pangalan",
+  apply_email: "Email",
+  apply_resume: "Resume o mensahe",
+  apply_submit: "Isumite ang application",
+  apply_success: "Salamat! Natanggap na ang application mo.",
+  apply_error: "May nangyaring mali. Pakisubukang muli.",
   login_title: "Mag-log in",
-  apply_title: "Mag-apply sa trabahong ito",
   employer_post: "Mag-post ng trabaho",
+  footer_about: "Tungkol",
+  footer_terms: "Terms",
+  footer_privacy: "Privacy",
+  footer_copyright: "© {year} QuickGig.ph",
+  err404_title: "Hindi makita ang page",
+  err404_body: "Wala kaming mahanap na ganyang page. Balik sa homepage.",
+  err500_title: "May aberya",
+  err500_body: "Paki-reload o bumalik sa homepage.",
   not_found: "Hindi makita ang page",
 };
 
@@ -62,8 +100,14 @@ export function getVariantRuntime(): keyof Bundle {
   if (typeof window === "undefined") return readVariantFromEnv();
   const u = new URL(window.location.href);
   const q = u.searchParams.get("lang");
-  if (q === "tl") return "taglish";
-  if (q === "en") return "english";
+  if (q === "tl") {
+    window.localStorage.setItem("copyVariant", "taglish");
+    return "taglish";
+  }
+  if (q === "en") {
+    window.localStorage.setItem("copyVariant", "english");
+    return "english";
+  }
   const saved = window.localStorage.getItem("copyVariant");
   if (saved === "taglish" || saved === "english") return saved as keyof Bundle;
   return readVariantFromEnv();
@@ -75,7 +119,8 @@ export function setVariantRuntime(v: "english" | "taglish") {
   }
 }
 
-export function t(key: keyof typeof english): string {
+export function t(key: keyof typeof english, vars?: Record<string, string | number>): string {
   const v = getVariantRuntime();
-  return (bundle[v][key] ?? bundle.english[key] ?? key) as string;
+  const str = (bundle[v][key] ?? bundle.english[key] ?? key) as string;
+  return str.replace(/\{(\w+)\}/g, (_, k) => (vars?.[k] ?? "") as string);
 }

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -40,4 +40,19 @@ const fetchJson = async (url) => {
   } catch (e) {
     console.log('404-check error', String(e));
   }
+
+  // Optional locale smoke checks
+  const check = async (path, re, label) => {
+    try {
+      const r = await fetch(BASE.replace(/\/+$/,'') + path);
+      const txt = await r.text();
+      if (re.test(txt)) console.log('\u2705', label);
+      else console.log('\u26a0\ufe0f', label, 'missing');
+    } catch (e) {
+      console.log('\u26a0\ufe0f', label, String(e));
+    }
+  };
+  await check('/?lang=tl', /Hanap|Trabaho|Mag-apply/i, 'home tl');
+  await check('/find-work?lang=tl&q=zzzzzz', /Wala pang resulta/i, 'find-work tl empty');
+  await check('/saved?lang=en', /Saved jobs/i, 'saved en');
 })();


### PR DESCRIPTION
## Summary
- extend translation helper with full EN/TL bundles, query-param detection, and interpolation
- allow `HeadSEO` to receive translation keys; localize search, apply, saved, and error pages and footer
- add optional locale smoke checks

## Testing
- `npm run lint --silent || true`
- `npm run build`
- `node tools/smoke.mjs || true`


------
https://chatgpt.com/codex/tasks/task_e_68a1df3d2eec8327bb2533dbf0917868