### PR TITLE
feat(account+apply): Applicant Profile (SSR), mock store + API, apply form prefill, i18n, nav link

### DIFF
--- a/pages/account/profile.tsx
+++ b/pages/account/profile.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { HeadSEO } from '../../src/components/HeadSEO';
+import ProductShell from '../../src/components/layout/ProductShell';
+import { t } from '../../src/lib/t';
+import { toast } from '../../src/lib/toast';
+import { ApplicantProfile } from '../../src/types/profile';
+import { requireAuthSSR } from '@/lib/auth';
+
+export const getServerSideProps = requireAuthSSR();
+
+function field(label:string, el:React.ReactNode){
+  return (
+    <label style={{display:'grid', gap:6}}>
+      <span style={{fontWeight:600}}>{label}</span>
+      {el}
+    </label>
+  );
+}
+
+export default function ProfilePage(){
+  const [profile,setProfile] = React.useState<ApplicantProfile|null>(null);
+  const [rolesText,setRolesText] = React.useState('');
+
+  React.useEffect(()=>{
+    (async()=>{
+      try{
+        const r = await fetch('/api/account/profile');
+        const p = await r.json();
+        setProfile(p);
+        setRolesText((p.roles||[]).join(', '));
+      }catch{}
+    })();
+  },[]);
+
+  const update = <K extends keyof ApplicantProfile>(key: K, value: ApplicantProfile[K]) => {
+    setProfile(p => (p ? { ...p, [key]: value } : p));
+  };
+
+  const onSave = async (e:React.FormEvent)=>{
+    e.preventDefault();
+    if(!profile) return;
+    const payload = { ...profile, roles: rolesText.split(',').map(r=>r.trim()).filter(Boolean) };
+    try{
+      const r = await fetch('/api/account/profile',{ method:'PUT', headers:{'content-type':'application/json'}, body: JSON.stringify(payload)});
+      if(r.ok){
+        const j = await r.json().catch(()=>payload);
+        setProfile(j);
+        setRolesText((j.roles||[]).join(', '));
+        toast(t('saved_success'));
+      }
+    }catch{}
+  };
+
+  if(!profile) return (
+    <ProductShell>
+      <HeadSEO titleKey="profile.title" descKey="profile.subtitle" noIndex />
+      <p>Loading…</p>
+    </ProductShell>
+  );
+
+  return (
+    <ProductShell>
+      <HeadSEO titleKey="profile.title" descKey="profile.subtitle" noIndex />
+      <form onSubmit={onSave} style={{display:'grid', gap:12, maxWidth:600}}>
+        <h1 style={{margin:0}}>{t('profile.title')}</h1>
+        <p>{t('profile.subtitle')}</p>
+        {field(t('field.name'), <input value={profile.name} onChange={e=>update('name',e.target.value)} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.email'), <input value={profile.email} readOnly style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc', background:'#eee'}} />)}
+        {field(t('field.phone'), <input value={profile.phone||''} onChange={e=>update('phone',e.target.value)} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.city'), <input value={profile.city||''} onChange={e=>update('city',e.target.value)} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.barangay'), <input value={profile.barangay||''} onChange={e=>update('barangay',e.target.value)} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.roles'), <input value={rolesText} onChange={e=>setRolesText(e.target.value)} placeholder="e.g. Barista, Cook" style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.expectedRate'), <input value={profile.expectedRate||''} onChange={e=>update('expectedRate',e.target.value)} placeholder="₱800/day" style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.resumeUrl'), <input value={profile.resumeUrl||''} onChange={e=>update('resumeUrl',e.target.value)} placeholder="https://..." style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
+        {field(t('field.bio'), <textarea value={profile.bio||''} onChange={e=>update('bio',e.target.value)} rows={4} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc', resize:'vertical'}} />)}
+        <div>
+          <button type="submit" style={{padding:'10px 14px', borderRadius:8, background:'#0069d1', color:'#fff', border:'none', fontWeight:700}}>{t('action.save')}</button>
+        </div>
+      </form>
+    </ProductShell>
+  );
+}

--- a/pages/api/account/profile.ts
+++ b/pages/api/account/profile.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSession } from '@/lib/auth';
+import { getProfile, saveProfile } from '@/lib/profileStore';
+const MODE = process.env.ENGINE_AUTH_MODE || 'mock';
+const BASE = process.env.ENGINE_BASE_URL || '';
+
+export default async function handler(req:NextApiRequest,res:NextApiResponse){
+  const user = await getSession(req); // or fallback mock user
+  const seed = { id:user?.id||'me', email:user?.email||'' , name:user?.name||'' };
+  if(req.method==='GET'){
+    if(MODE==='mock') return res.status(200).json(getProfile(seed));
+    const r = await fetch(`${BASE}/api/account/profile`,{ headers:{ cookie: req.headers.cookie||'' }});
+    return res.status(r.status).send(await r.text());
+  }
+  if(req.method==='PUT'){
+    if(MODE==='mock') return res.status(200).json(saveProfile({ ...getProfile(seed), ...req.body }));
+    const r = await fetch(`${BASE}/api/account/profile`,{ method:'PUT', headers:{ 'content-type':'application/json', cookie:req.headers.cookie||'' }, body: JSON.stringify(req.body)});
+    return res.status(r.status).send(await r.text());
+  }
+  res.status(405).end();
+}

--- a/pages/jobs/[id]/apply.tsx
+++ b/pages/jobs/[id]/apply.tsx
@@ -70,9 +70,26 @@ function ApplyForm({ job }: { job: JobDetail }) {
   const router = useRouter();
   const [name,setName] = React.useState('');
   const [email,setEmail] = React.useState('');
+  const [phone,setPhone] = React.useState('');
+  const [city,setCity] = React.useState('');
+  const [resumeUrl,setResumeUrl] = React.useState('');
   const [message,setMessage] = React.useState('');
   const [status,setStatus] = React.useState<'idle'|'sending'|'ok'|'err'>('idle');
   const disabled = !job?.id || !name || !email || status==='sending';
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch('/api/account/profile');
+        const p = await r.json();
+        setName(p.name || '');
+        setEmail(p.email || '');
+        setPhone(p.phone || '');
+        setCity(p.city || '');
+        setResumeUrl(p.resumeUrl || '');
+      } catch {}
+    })();
+  }, []);
 
   async function onSubmit(e:React.FormEvent) {
     e.preventDefault();
@@ -81,7 +98,7 @@ function ApplyForm({ job }: { job: JobDetail }) {
       const r = await fetch('/api/apply', {
         method:'POST',
         headers:{'content-type':'application/json'},
-        body: JSON.stringify({ jobId: String(job.id), name, email, message }),
+        body: JSON.stringify({ jobId: String(job.id), name, email, phone, city, resumeUrl, message }),
       });
       const j = await r.json().catch(()=>({}));
       if (r.ok) {
@@ -100,12 +117,24 @@ function ApplyForm({ job }: { job: JobDetail }) {
   return (
     <form onSubmit={onSubmit}
       style={{background:'#fff', border:`1px solid ${T.colors.border}`, borderRadius:12, padding:16, display:'grid', gap:12, maxWidth:560}}>
-      {field(t('apply_name'),
+      {field(t('field.name'),
         <input value={name} onChange={e=>setName(e.target.value)} placeholder="Juan Dela Cruz"
                style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
       )}
-      {field(t('apply_email'),
+      {field(t('field.email'),
         <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="you@example.com"
+               style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
+      )}
+      {field(t('field.phone'),
+        <input value={phone} onChange={e=>setPhone(e.target.value)} placeholder="0999-000-0000"
+               style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
+      )}
+      {field(t('field.city'),
+        <input value={city} onChange={e=>setCity(e.target.value)} placeholder="Quezon City"
+               style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
+      )}
+      {field(t('field.resumeUrl'),
+        <input value={resumeUrl} onChange={e=>setResumeUrl(e.target.value)} placeholder="https://..."
                style={{padding:'10px 12px', borderRadius:8, border:`1px solid ${T.colors.border}`}} />
       )}
       {field(t('apply_resume'),

--- a/src/components/product/NavBar.tsx
+++ b/src/components/product/NavBar.tsx
@@ -41,6 +41,7 @@ export default function NavBar() {
           </summary>
           <div style={{ position: 'absolute', right: 0, marginTop: 4, background: '#fff', border: `1px solid ${T.colors.border}`, borderRadius: 8, boxShadow: '0 2px 6px rgba(0,0,0,0.1)', minWidth: 160 }}>
             <Link href="/account" style={{ display: 'block', padding: '6px 12px', textDecoration: 'none', color: T.colors.text }}>{t('navbar_account')}</Link>
+            <Link href="/account/profile" style={{ display: 'block', padding: '6px 12px', textDecoration: 'none', color: T.colors.text }}>{t('profile.title')}</Link>
             {session.role === 'employer' && (
               <Link href="/employer/jobs" style={{ display: 'block', padding: '6px 12px', textDecoration: 'none', color: T.colors.text }}>{t('my_jobs')}</Link>
             )}

--- a/src/lib/profileStore.ts
+++ b/src/lib/profileStore.ts
@@ -1,0 +1,14 @@
+import { ApplicantProfile } from '@/types/profile';
+const KEY='qq_profile';
+export function getProfile(seed: Partial<ApplicantProfile>): ApplicantProfile {
+  const now = new Date().toISOString();
+  const p = typeof window==='undefined' ? null : JSON.parse(localStorage.getItem(KEY)||'null');
+  if (p) return p;
+  const base: ApplicantProfile = {
+    id: seed.id || 'me', name: seed.name || '', email: seed.email || '',
+    roles: [], updatedAt: now
+  };
+  if (typeof window!=='undefined') localStorage.setItem(KEY, JSON.stringify(base));
+  return base;
+}
+export function saveProfile(p: ApplicantProfile){ p.updatedAt=new Date().toISOString(); if(typeof window!=='undefined') localStorage.setItem(KEY, JSON.stringify(p)); return p; }

--- a/src/lib/t.ts
+++ b/src/lib/t.ts
@@ -82,6 +82,19 @@ const english: Messages = {
   err500_title: "Something went wrong",
   err500_body: "Please retry or go back to the homepage.",
   not_found: "Page not found",
+  'profile.title': 'My Profile',
+  'profile.subtitle': 'Manage your details',
+  'field.name': 'Name',
+  'field.email': 'Email',
+  'field.phone': 'Phone',
+  'field.city': 'City',
+  'field.barangay': 'Barangay',
+  'field.roles': 'Roles',
+  'field.expectedRate': 'Expected rate',
+  'field.resumeUrl': 'Resume URL',
+  'field.bio': 'Bio',
+  'action.save': 'Save',
+  'saved_success': 'Saved',
 };
 
 const taglish: Messages = {
@@ -164,6 +177,19 @@ const taglish: Messages = {
   err500_title: "May aberya",
   err500_body: "Paki-reload o bumalik sa homepage.",
   not_found: "Hindi makita ang page",
+  'profile.title': 'Ang Aking Profile',
+  'profile.subtitle': 'Ayusin ang detalye mo',
+  'field.name': 'Pangalan',
+  'field.email': 'Email',
+  'field.phone': 'Telepono',
+  'field.city': 'Lungsod',
+  'field.barangay': 'Barangay',
+  'field.roles': 'Mga role',
+  'field.expectedRate': 'Inaasahang bayad',
+  'field.resumeUrl': 'Resume URL',
+  'field.bio': 'Bio',
+  'action.save': 'I-save',
+  'saved_success': 'Na-save',
 };
 
 const bundle: Bundle = { english, taglish };

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,13 @@
+export type ApplicantProfile = {
+  id: string;               // session user id
+  name: string;
+  email: string;            // from session; read-only in UI
+  phone?: string;
+  city?: string;
+  barangay?: string;
+  roles?: string[];         // preferred roles/titles
+  expectedRate?: string;    // e.g., "₱800/day"
+  bio?: string;
+  resumeUrl?: string;       // GDrive/Dropbox link for now
+  updatedAt: string;
+};

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -133,5 +133,24 @@ const fetchJson = async (url) => {
     } catch (e) {
       console.log('auth flow error', String(e));
     }
+
+    // applicant profile API
+    try {
+      const profGet = await fetch(`${BASE}/api/account/profile`);
+      const txt = await profGet.text();
+      console.log('profile get', profGet.status, /email/i.test(txt));
+    } catch (e) {
+      console.log('profile get error', String(e));
+    }
+    try {
+      const profPut = await fetch(`${BASE}/api/account/profile`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ phone: '0999-000-0000' })
+      });
+      console.log('profile put', profPut.status);
+    } catch (e) {
+      console.log('profile put error', String(e));
+    }
   }
 })();


### PR DESCRIPTION
## Summary
- add applicant profile type and local mock store
- expose account profile API with mock/engine modes
- implement SSR-protected profile page with i18n fields and nav link
- prefill job apply form from profile
- add i18n keys and smoke tests for profile API

## Testing
- `npm run lint --silent || true`
- `npm run build`
- `node tools/smoke.mjs >/tmp/smoke.log && tail -n 20 /tmp/smoke.log`


------
https://chatgpt.com/codex/tasks/task_e_68a1f0e14dfc832796174613422f837f