### PR TITLE
feat: add S3 signed uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,15 @@ NEXT_PUBLIC_BANNER_HTML=
 ## Copy variant (english|taglish). ?lang=tl|en overrides and persists in localStorage
 NEXT_PUBLIC_COPY_VARIANT=english
 # Client-side file size cap (MB)
-NEXT_PUBLIC_MAX_UPLOAD_MB=2
+# Optional S3 uploads
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=ap-southeast-1
+# S3_BUCKET=quickgig-uploads
+NEXT_PUBLIC_MAX_UPLOAD_MB=4
+NEXT_PUBLIC_ACCEPT_UPLOADS=pdf,jpg,jpeg,png
+# Note: if AWS_* or S3_BUCKET missing, uploads stay in mock/no-op mode.
+# Smoke: upload UI renders but submit disables with tooltip "Uploads not configured".
 # Optional: set a job id for smoke to also hit /jobs/{id} and /jobs/{id}/apply
 # SMOKE_JOB_ID=123
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "next": "14.2.31",
     "react": "^18",
     "react-dom": "^18",
+    "@aws-sdk/client-s3": "^3.637.0",
+    "@aws-sdk/s3-request-presigner": "^3.637.0",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1",
     "webpack-bundle-analyzer": "^4.10.2"

--- a/pages/account/profile.tsx
+++ b/pages/account/profile.tsx
@@ -8,6 +8,7 @@ import { requireAuthSSR } from '@/lib/auth';
 import UploadField from '../../src/components/product/UploadField';
 import { getResume, setResume, getAvatar, setAvatar } from '../../src/lib/profileStore';
 import { UploadedFile } from '@/types/upload';
+import { ACCEPT_STRING } from '@/lib/upload';
 
 export const getServerSideProps = requireAuthSSR();
 
@@ -77,10 +78,9 @@ export default function ProfilePage(){
         {field(t('field.barangay'), <input value={profile.barangay||''} onChange={e=>update('barangay',e.target.value)} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
         {field(t('field.roles'), <input value={rolesText} onChange={e=>setRolesText(e.target.value)} placeholder="e.g. Barista, Cook" style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
         {field(t('field.expectedRate'), <input value={profile.expectedRate||''} onChange={e=>update('expectedRate',e.target.value)} placeholder="₱800/day" style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
-        {field(t('field.resumeUrl'), <input value={profile.resumeUrl||''} onChange={e=>update('resumeUrl',e.target.value)} placeholder="https://..." style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc'}} />)}
         {field(t('field.bio'), <textarea value={profile.bio||''} onChange={e=>update('bio',e.target.value)} rows={4} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc', resize:'vertical'}} />)}
-        <UploadField label={t('profile.resume.title')} accept=".pdf,.doc,.docx" kind="resume" file={resume} onSaved={f=>{ setResumeState(f); setResume(f); }} />
-        <UploadField label={t('profile.avatar.title')} accept="image/*" kind="avatar" file={avatar} onSaved={f=>{ setAvatarState(f); setAvatar(f); }} />
+        <UploadField label={t('profile.resume.title')} accept={ACCEPT_STRING} kind="resume" file={resume} onSaved={f=>{ setResumeState(f); setResume(f); update('resumeUrl', f?.url || ''); }} />
+        <UploadField label={t('profile.avatar.title')} accept="image/*" kind="avatar" file={avatar} onSaved={f=>{ setAvatarState(f); setAvatar(f); update('avatarUrl', f?.url || ''); }} />
         <div>
           <button type="submit" style={{padding:'10px 14px', borderRadius:8, background:'#0069d1', color:'#fff', border:'none', fontWeight:700}}>{t('action.save')}</button>
         </div>

--- a/pages/api/apply.ts
+++ b/pages/api/apply.ts
@@ -6,7 +6,8 @@ type ApplyPayload = {
   name: string;
   email: string;
   message?: string;
-  resume?: UploadedFile;
+  resumeUrl?: string;
+  resume?: UploadedFile; // legacy shape
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -15,13 +16,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const payload = req.body as ApplyPayload;
     if (!payload?.jobId || !payload?.name || !payload?.email)
       return res.status(400).json({ ok:false, error:'Missing fields' });
-
+    const { resume, ...rest } = payload;
+    const legacy = resume as undefined | { url?: string; data?: string };
+    const resumeUrl = payload.resumeUrl || legacy?.url || legacy?.data;
+    const body = { ...rest, resumeUrl };
     const url = process.env.APPLY_WEBHOOK_URL;
     if (url) {
       const r = await fetch(url, {
         method: 'POST',
         headers: {'content-type':'application/json'},
-        body: JSON.stringify({ source:'quickgig-frontend', ...payload }),
+        body: JSON.stringify({ source:'quickgig-frontend', ...body }),
       });
       // tolerate non-2xx: still report accepted to not block UX
       return res.status(202).json({ ok:true, forwarded: r.ok });

--- a/pages/api/upload/index.ts
+++ b/pages/api/upload/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { UploadedFile } from '@/types/upload';
+// legacy endpoint retained for backwards compatibility
 
 const MODE = process.env.ENGINE_MODE || 'mock';
 const BASE = process.env.ENGINE_BASE_URL || '';
@@ -7,9 +7,10 @@ const BASE = process.env.ENGINE_BASE_URL || '';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
   try {
-    const { kind, file } = req.body as { kind: 'resume' | 'avatar'; file: UploadedFile };
+    const { kind, file } = req.body as { kind: 'resume' | 'avatar'; file: Record<string, unknown> };
     if (MODE === 'mock') {
-      return res.status(200).json({ ok: true, id: file.id, url: `/api/upload/${file.id}` });
+      const id = file?.id || 'mock';
+      return res.status(200).json({ ok: true, id, url: `/api/upload/${id}` });
     }
     const r = await fetch(`${BASE}/upload`, {
       method: 'POST',

--- a/pages/api/upload/sign.ts
+++ b/pages/api/upload/sign.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { AWS, MAX_UPLOAD_MB, ACCEPT_UPLOADS, UPLOADS_CONFIGURED } from '@/lib/env';
+import { randomUUID } from 'crypto';
+
+const EXT_TO_MIME: Record<string, string> = {
+  pdf: 'application/pdf',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+};
+const ALLOWED_MIME = ACCEPT_UPLOADS.map((e) => EXT_TO_MIME[e]).filter(Boolean);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { filename = '', contentType = '', size = 0 } = req.body as {
+    filename?: string;
+    contentType?: string;
+    size?: number;
+  };
+  if (size > MAX_UPLOAD_MB * 1024 * 1024)
+    return res.status(400).json({ ok: false, reason: 'too_big' });
+  if (!ALLOWED_MIME.includes(contentType))
+    return res.status(400).json({ ok: false, reason: 'bad_type' });
+  if (!UPLOADS_CONFIGURED)
+    return res.status(501).json({ ok: false, reason: 'not_configured' });
+  const client = new S3Client({
+    region: AWS.region,
+    credentials: {
+      accessKeyId: AWS.accessKeyId,
+      secretAccessKey: AWS.secretAccessKey,
+    },
+  });
+  const date = new Date();
+  const ymd = date.toISOString().slice(0, 10).replace(/-/g, '');
+  const safe = filename
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, '-')
+    .replace(/-+/g, '-');
+  const key = `uploads/${ymd}/${randomUUID()}-${safe}`;
+  const command = new PutObjectCommand({
+    Bucket: AWS.bucket,
+    Key: key,
+    ContentType: contentType,
+    ACL: 'public-read',
+  });
+  const url = await getSignedUrl(client, command, { expiresIn: 300 });
+  return res.status(200).json({ ok: true, url, key });
+}

--- a/src/components/product/NavBar.tsx
+++ b/src/components/product/NavBar.tsx
@@ -28,8 +28,12 @@ export default function NavBar() {
   const { session, logout } = useSession();
   const { enabled, completeness } = useOnboarding();
   const incomplete = enabled && completeness.score < 100;
-  const [avatar, setAvatar] = React.useState<UploadedFile|null>(null);
-  React.useEffect(()=>{ try { setAvatar(getAvatar()); } catch {} },[]);
+  const [avatar, setAvatar] = React.useState<UploadedFile | null>(null);
+  React.useEffect(() => {
+    try {
+      setAvatar(getAvatar());
+    } catch {}
+  }, []);
   const onLogout = async () => {
     await logout();
     push('/');
@@ -51,8 +55,8 @@ export default function NavBar() {
       {session ? (
         <details style={{ position: 'relative' }}>
           <summary style={{ listStyle: 'none', cursor: 'pointer', width: 32, height: 32, borderRadius: '50%', background: T.colors.brand, color: '#fff', display: 'grid', placeItems: 'center', position:'relative', overflow:'hidden' }}>
-            {avatar?.data ? (
-              <img src={avatar.data} alt="" style={{width:'100%',height:'100%',objectFit:'cover'}} />
+            {avatar?.url ? (
+              <img src={avatar.url} alt="" style={{width:'100%',height:'100%',objectFit:'cover'}} />
             ) : (
               session.name?.charAt(0).toUpperCase()
             )}

--- a/src/components/product/UploadField.tsx
+++ b/src/components/product/UploadField.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { UploadedFile } from '@/types/upload';
-import { toBase64, truncateDataUrl, validate, makeId, MAX_MB } from '@/lib/uploader';
+import { uploadFile, MAX_MB, ACCEPT_STRING } from '@/lib/upload';
 import { toast } from '@/lib/toast';
 import { t } from '@/lib/t';
 
 interface Props {
   label: string;
-  accept: string;
+  accept?: string;
   kind: 'resume' | 'avatar';
   onSaved: (f: UploadedFile | null) => void;
   file?: UploadedFile | null;
@@ -14,61 +14,150 @@ interface Props {
 
 export default function UploadField({ label, accept, kind, onSaved, file: initial }: Props) {
   const [file, setFile] = React.useState<UploadedFile | null>(initial || null);
-  const [err, setErr] = React.useState('');
+  const [uploading, setUploading] = React.useState(false);
+  const [progress, setProgress] = React.useState(0);
+  const [enabled, setEnabled] = React.useState(true);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
 
-  React.useEffect(() => { setFile(initial || null); }, [initial]);
+  React.useEffect(() => {
+    setFile(initial || null);
+  }, [initial]);
 
-  const open = () => { inputRef.current?.click(); };
+  React.useEffect(() => {
+    // detect config on mount
+    if (!ACCEPT_STRING) return;
+    (async () => {
+      try {
+        const r = await fetch('/api/upload/sign', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ filename: 'ping', contentType: 'application/pdf', size: 0 }),
+        });
+        if (r.status === 501) setEnabled(false);
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, []);
+
+  const open = () => {
+    if (enabled && !uploading) inputRef.current?.click();
+  };
 
   const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
     if (!f) return;
-    const v = validate(f);
-    if (!v.ok) {
-      setErr(t(v.reason === 'too_big' ? 'profile.resume.too_big' : 'profile.resume.bad_type', { mb: MAX_MB }));
-      return;
-    }
-    setErr('');
-    const dataUrl = await toBase64(f);
-    const up: UploadedFile = { id: makeId(), name: f.name, type: f.type, size: f.size, data: truncateDataUrl(dataUrl), createdAt: Date.now() };
+    setUploading(true);
+    setProgress(0);
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
     try {
-      const r = await fetch('/api/upload', { method: 'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ kind, file: up }) });
-      if (!r.ok) throw new Error('upload');
+      const { publicUrl } = await uploadFile(f, (p) => setProgress(p), ctrl.signal);
+      const up: UploadedFile = { name: f.name, url: publicUrl, contentType: f.type, size: f.size };
       setFile(up);
       onSaved(up);
       toast(t(kind === 'resume' ? 'profile.resume.saved' : 'profile.avatar.saved'));
-    } catch {
-      setErr('upload failed');
+    } catch (err: unknown) {
+      const code = err instanceof Error ? err.message : String(err);
+      if (code === 'too_big') toast(t('upload.too_big', { n: MAX_MB }));
+      else if (code === 'bad_type') toast(t('upload.bad_type'));
+      else if (code === 'canceled') toast(t('upload.canceled'));
+      else if (code === 'not_configured') {
+        setEnabled(false);
+        toast('Uploads not configured');
+      } else toast('Upload failed');
+    } finally {
+      setUploading(false);
+      setProgress(0);
+      if (inputRef.current) inputRef.current.value = '';
     }
   };
 
-  const onRemove = () => {
+  const cancel = () => {
+    abortRef.current?.abort();
+  };
+
+  const remove = () => {
     setFile(null);
     onSaved(null);
   };
 
   return (
-    <div style={{display:'grid', gap:4}}>
-      <label style={{fontWeight:600}}>{label}</label>
+    <div style={{ display: 'grid', gap: 4 }}>
+      <label style={{ fontWeight: 600 }}>{label}</label>
       {file ? (
-        <div style={{display:'flex', alignItems:'center', gap:8}}>
-          {kind === 'avatar' && file.data && (
-            <img src={file.data} alt="avatar" style={{width:48, height:48, borderRadius:'50%', objectFit:'cover'}} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {kind === 'avatar' && (
+            <img
+              src={file.url}
+              alt="avatar"
+              style={{ width: 48, height: 48, borderRadius: '50%', objectFit: 'cover' }}
+            />
           )}
-          <div style={{flex:1}}>
-            <div>{file.name}</div>
-            <div style={{fontSize:12,color:'#666'}}>{Math.round(file.size/1024)} KB</div>
-          </div>
-          <button type="button" onClick={open} style={{marginRight:8, textDecoration:'underline', background:'none', border:'none', cursor:'pointer'}}>{t('profile.resume.replace')}</button>
-          <button type="button" onClick={onRemove} style={{textDecoration:'underline', background:'none', border:'none', cursor:'pointer'}}>{t('profile.resume.remove')}</button>
+          {kind === 'resume' && (
+            <a href={file.url} target="_blank" rel="noreferrer" style={{ marginRight: 8 }}>
+              {t('upload.view_resume')}
+            </a>
+          )}
+          <div style={{ flex: 1 }}>{file.name}</div>
+          <button
+            type="button"
+            onClick={open}
+            style={{ marginRight: 8, textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            {t('profile.resume.replace')}
+          </button>
+          <button
+            type="button"
+            onClick={remove}
+            style={{ textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            {t('profile.resume.remove')}
+          </button>
         </div>
       ) : (
-        <button type="button" onClick={open} style={{padding:'10px 12px', borderRadius:8, border:'1px solid #ccc', background:'#fff', cursor:'pointer', textAlign:'left'}}>{t('profile.resume.replace')}</button>
+        <button
+          type="button"
+          onClick={open}
+          disabled={!enabled}
+          title={!enabled ? 'Uploads not configured' : undefined}
+          style={{
+            padding: '10px 12px',
+            borderRadius: 8,
+            border: '1px solid #ccc',
+            background: '#fff',
+            cursor: !enabled ? 'not-allowed' : 'pointer',
+            textAlign: 'left',
+          }}
+        >
+          {uploading ? t('upload.uploading') : t('profile.resume.replace')}
+        </button>
       )}
-      <input ref={inputRef} type="file" accept={accept} style={{display:'none'}} onChange={onChange} />
-      {err && <div style={{color:'crimson', fontSize:12}}>{err}</div>}
-      {kind === 'resume' && !file && <div style={{fontSize:12,color:'#666'}}>{t('profile.resume.hint',{mb:MAX_MB})}</div>}
+      {uploading && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{ flex: 1, height: 4, background: '#eee', borderRadius: 2 }}>
+            <div
+              style={{
+                width: `${Math.round(progress * 100)}%`,
+                height: '100%',
+                background: '#0069d1',
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={cancel}
+            style={{ textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+      <input ref={inputRef} type="file" accept={accept || ACCEPT_STRING} style={{ display: 'none' }} onChange={onChange} />
+      {kind === 'resume' && !file && !uploading && (
+        <div style={{ fontSize: 12, color: '#666' }}>{t('profile.resume.hint', { mb: MAX_MB })}</div>
+      )}
     </div>
   );
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,16 @@
+export const MAX_UPLOAD_MB = Number(process.env.NEXT_PUBLIC_MAX_UPLOAD_MB ?? 4);
+export const ACCEPT_UPLOADS = (process.env.NEXT_PUBLIC_ACCEPT_UPLOADS || '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+export const AWS = {
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
+  region: process.env.AWS_REGION || '',
+  bucket: process.env.S3_BUCKET || '',
+};
+
+export const UPLOADS_CONFIGURED = Boolean(
+  AWS.accessKeyId && AWS.secretAccessKey && AWS.region && AWS.bucket
+);

--- a/src/lib/profileStore.ts
+++ b/src/lib/profileStore.ts
@@ -2,8 +2,8 @@ import { ApplicantProfile } from '@/types/profile';
 import { UploadedFile } from '@/types/upload';
 
 const KEY='qq_profile';
-const RESUME_KEY='profile:resume:v1';
-const AVATAR_KEY='profile:avatar:v1';
+const RESUME_KEY='profile:resume:v2';
+const AVATAR_KEY='profile:avatar:v2';
 
 export function getProfile(seed: Partial<ApplicantProfile>): ApplicantProfile {
   const now = new Date().toISOString();
@@ -20,7 +20,16 @@ export function saveProfile(p: ApplicantProfile){ p.updatedAt=new Date().toISOSt
 
 export function getResume(): UploadedFile | null {
   if (typeof window === 'undefined') return null;
-  try { return JSON.parse(localStorage.getItem(RESUME_KEY) || 'null'); } catch { return null; }
+  try {
+    const raw = localStorage.getItem(RESUME_KEY) || localStorage.getItem('profile:resume:v1');
+    const p = raw ? JSON.parse(raw) : null;
+    if (!p) return null;
+    if (p.url) return p;
+    if (p.data) return { name: p.name, url: p.data, contentType: p.type, size: p.size };
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export function setResume(f: UploadedFile | null): void {
@@ -31,7 +40,16 @@ export function setResume(f: UploadedFile | null): void {
 
 export function getAvatar(): UploadedFile | null {
   if (typeof window === 'undefined') return null;
-  try { return JSON.parse(localStorage.getItem(AVATAR_KEY) || 'null'); } catch { return null; }
+  try {
+    const raw = localStorage.getItem(AVATAR_KEY) || localStorage.getItem('profile:avatar:v1');
+    const p = raw ? JSON.parse(raw) : null;
+    if (!p) return null;
+    if (p.url) return p;
+    if (p.data) return { name: p.name, url: p.data, contentType: p.type, size: p.size };
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export function setAvatar(f: UploadedFile | null): void {

--- a/src/lib/t.ts
+++ b/src/lib/t.ts
@@ -140,6 +140,11 @@ const english: Messages = {
   'profile.avatar.saved': 'Avatar saved',
   'apply.resume_attached': 'Attached: {name}',
   'apply.resume_optional_hint': 'Resume is optional—you can attach now or later.',
+  'upload.uploading': 'Uploading…',
+  'upload.canceled': 'Upload canceled',
+  'upload.too_big': 'File too large (max {n}MB)',
+  'upload.bad_type': 'Unsupported file type',
+  'upload.view_resume': 'View resume',
 };
 
 const taglish: Messages = {
@@ -280,6 +285,11 @@ const taglish: Messages = {
   'profile.avatar.saved': 'Na-save ang avatar',
   'apply.resume_attached': 'Naka-attach: {name}',
   'apply.resume_optional_hint': 'Optional lang ang resume—puwede mong i-attach ngayon o sa susunod.',
+  'upload.uploading': 'Nag-a-upload…',
+  'upload.canceled': 'Kinansela ang upload',
+  'upload.too_big': 'Masyadong malaki ang file (max {n}MB)',
+  'upload.bad_type': 'Hindi suportadong file type',
+  'upload.view_resume': 'Tingnan ang resume',
 };
 
 const bundle: Bundle = { english, taglish };

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,0 +1,57 @@
+import { MAX_UPLOAD_MB, ACCEPT_UPLOADS } from './env';
+
+const EXT_TO_MIME: Record<string, string> = {
+  pdf: 'application/pdf',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+};
+export const ACCEPT_STRING = ACCEPT_UPLOADS.map((e) => '.' + e).join(',');
+const ALLOWED_MIME = ACCEPT_UPLOADS.map((e) => EXT_TO_MIME[e]).filter(Boolean);
+
+function validate(file: File): { ok: boolean; reason?: string } {
+  const max = MAX_UPLOAD_MB * 1024 * 1024;
+  if (file.size > max) return { ok: false, reason: 'too_big' };
+  if (!ALLOWED_MIME.includes(file.type)) return { ok: false, reason: 'bad_type' };
+  return { ok: true };
+}
+
+async function put(url: string, file: File, onProgress?: (n: number) => void, signal?: AbortSignal) {
+  await new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && onProgress) onProgress(e.loaded / e.total);
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) resolve();
+      else reject(new Error('network'));
+    };
+    xhr.onerror = () => reject(new Error('network'));
+    xhr.onabort = () => reject(new Error('canceled'));
+    xhr.open('PUT', url);
+    xhr.setRequestHeader('Content-Type', file.type);
+    if (signal) signal.addEventListener('abort', () => xhr.abort());
+    xhr.send(file);
+  });
+}
+
+export async function uploadFile(
+  file: File,
+  onProgress?: (n: number) => void,
+  signal?: AbortSignal
+): Promise<{ key: string; publicUrl: string }> {
+  const v = validate(file);
+  if (!v.ok) throw new Error(v.reason);
+  const r = await fetch('/api/upload/sign', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ filename: file.name, contentType: file.type, size: file.size }),
+  });
+  if (r.status === 501) throw new Error('not_configured');
+  if (!r.ok) throw new Error('network');
+  const { url, key } = await r.json();
+  await put(url, file, onProgress, signal);
+  return { key, publicUrl: url.split('?')[0] };
+}
+
+export { MAX_UPLOAD_MB as MAX_MB };

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -9,5 +9,6 @@ export type ApplicantProfile = {
   expectedRate?: string;    // e.g., "₱800/day"
   bio?: string;
   resumeUrl?: string;       // GDrive/Dropbox link for now
+  avatarUrl?: string;
   updatedAt: string;
 };

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -1,8 +1,6 @@
 export type UploadedFile = {
-  id: string;
   name: string;
-  type: string;
-  size: number; // bytes
-  data?: string; // Base64 data URL (may be truncated for storage)
-  createdAt: number;
+  url: string;
+  contentType?: string;
+  size?: number;
 };


### PR DESCRIPTION
## Summary
- add optional S3 upload env config and presign API
- implement client upload helper with progress/cancel and use in profile/apply
- store uploaded avatar/resume URLs instead of base64

## Testing
- `npm run lint --silent || true`
- `npm run build` *(fails: Can't resolve '@aws-sdk/client-s3')*

------
https://chatgpt.com/codex/tasks/task_e_68a26164a96483279df1f9ce6a5b933c