### PR TITLE
feat(account): Settings page with language + email notification preferences (flagged)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,7 @@ NEXT_PUBLIC_ENABLE_EMPLOYER_APPLICANT_DRILLDOWN=true
 NEXT_PUBLIC_ENABLE_INTERVIEWS=true
 # Optional webhook to notify ops of new interviews
 INTERVIEWS_WEBHOOK_URL=
+
+# Account settings (optional)
+NEXT_PUBLIC_ENABLE_SETTINGS=true
+NEXT_PUBLIC_DEFAULT_EMAIL_PREFS=ops_only # ops_only | all | none

--- a/src/app/api/notify/message/route.ts
+++ b/src/app/api/notify/message/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { sendMail } from '@/server/mailer';
+import { prefersEmail } from '@/lib/prefs';
 
 export async function POST(req: Request) {
   try {
@@ -7,9 +8,15 @@ export async function POST(req: Request) {
       to: string;
       subject: string;
       html: string;
+      kind?: 'apply' | 'interview' | 'digest' | 'marketing';
     } | null;
     if (body) {
-      await sendMail(body).catch(() => {});
+      if (!body.kind || body.kind === 'digest' || prefersEmail(body.kind)) {
+        await sendMail(body).catch(() => {});
+      } else {
+        // eslint-disable-next-line no-console -- best effort log
+        console.log('[notify:skipped by prefs]');
+      }
     }
   } catch {
     // ignore

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ import Button from './ui/Button';
 import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard, Bell } from 'lucide-react';
 import { env } from '@/config/env';
 import { isAdmin } from '@/auth/isAdmin';
+import { t } from '@/lib/i18n';
 
 const Navigation: React.FC = () => {
   const { user, logout, isAuthenticated } = useAuth();
@@ -156,6 +157,15 @@ const Navigation: React.FC = () => {
                       >
                         <Bell className="w-4 h-4 mr-2" />
                         <span className="hidden xl:inline">Alerts</span>
+                      </Link>
+                    )}
+                    {env.NEXT_PUBLIC_ENABLE_SETTINGS && (
+                      <Link
+                        href="/settings"
+                        className="qg-navbar-link flex items-center px-3 py-2 rounded-qg-md text-sm font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                      >
+                        <Settings className="w-4 h-4 mr-2" />
+                        <span className="hidden xl:inline">{t('navbar.settings')}</span>
                       </Link>
                     )}
                     <Link
@@ -317,6 +327,16 @@ const Navigation: React.FC = () => {
                       >
                         <Bell className="w-5 h-5 mr-3" />
                         Alerts
+                      </Link>
+                    )}
+                    {env.NEXT_PUBLIC_ENABLE_SETTINGS && (
+                      <Link
+                        href="/settings"
+                        className="qg-navbar-link flex items-center px-4 py-3 rounded-qg-md text-base font-medium transition-all duration-qg-fast hover:bg-qg-navy-light hover:text-qg-accent"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <Settings className="w-5 h-5 mr-3" />
+                        {t('navbar.settings')}
                       </Link>
                     )}
                     <Link

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,10 @@ export const env = {
     String(process.env.NEXT_PUBLIC_SHOW_LOGOUT_ALL ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_APPLICANT_APPS:
     String(process.env.NEXT_PUBLIC_ENABLE_APPLICANT_APPS ?? 'true').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_SETTINGS:
+    String(process.env.NEXT_PUBLIC_ENABLE_SETTINGS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_DEFAULT_EMAIL_PREFS:
+    (process.env.NEXT_PUBLIC_DEFAULT_EMAIL_PREFS as 'ops_only' | 'all' | 'none') || 'ops_only',
   RESEND_API_KEY: process.env.RESEND_API_KEY || '',
   NOTIFY_FROM: process.env.NOTIFY_FROM || 'QuickGig <noreply@quickgig.ph>',
   NOTIFY_ADMIN_EMAIL: process.env.NOTIFY_ADMIN_EMAIL || '',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,3 +1,5 @@
+import { getPrefs } from './prefs';
+
 const strings = {
   en: {
     dashboard: 'Dashboard',
@@ -13,7 +15,7 @@ const strings = {
     notes_optional: 'Notes (optional)',
     submit: 'Submit',
     cancel: 'Cancel',
-    report_thanks: 'Thanks! We\'ll check it.',
+    report_thanks: "Thanks! We'll check it.",
     admin_reports: 'Reports',
     resolve: 'Resolve',
     pause_job: 'Pause job',
@@ -45,6 +47,25 @@ const strings = {
     interview_confirmed: 'Interview confirmed',
     invite_declined: 'Invite declined',
     add_to_calendar: 'Add to calendar',
+    navbar: {
+      settings: 'Settings',
+    },
+    settings: {
+      title: 'Account Settings',
+      language: {
+        label: 'Language',
+      },
+      emails: {
+        label: 'Email notifications',
+        all: 'All',
+        ops_only: 'Operational only',
+        none: 'None',
+      },
+      saved: 'Save',
+      toast: {
+        saved: 'Saved',
+      },
+    },
   },
   tl: {
     dashboard: 'Dashboard',
@@ -92,10 +113,65 @@ const strings = {
     interview_confirmed: 'Kumpirmado ang interview',
     invite_declined: 'Tinanggihan ang imbitasyon',
     add_to_calendar: 'Add to calendar',
+    navbar: {
+      settings: 'Settings',
+    },
+    settings: {
+      title: 'Settings',
+      language: {
+        label: 'Language',
+      },
+      emails: {
+        label: 'Email notifications',
+        all: 'Lahat',
+        ops_only: 'Ops lang',
+        none: 'Wala',
+      },
+      saved: 'Save',
+      toast: {
+        saved: 'Nasave',
+      },
+    },
   },
 };
 
-export function t(key: keyof typeof strings['en']): string {
-  const lang = (process.env.NEXT_PUBLIC_LANG || 'en') as 'en' | 'tl';
-  return strings[lang][key] || strings.en[key] || key;
+function copyVariant(): 'english' | 'taglish' {
+  let variant = getPrefs().copy;
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('lang');
+    if (q === 'english' || q === 'taglish') {
+      variant = q;
+      try {
+        localStorage.setItem('copyV', q);
+      } catch {
+        // ignore
+      }
+    } else {
+      const legacy = localStorage.getItem('copyV');
+      if (legacy === 'english' || legacy === 'taglish') variant = legacy;
+    }
+  }
+  return variant;
+}
+
+function currentLang(): 'en' | 'tl' {
+  return copyVariant() === 'taglish' ? 'tl' : 'en';
+}
+
+export function t(key: string): string {
+  const lang = currentLang();
+  const parts = key.split('.');
+  let node: unknown = strings[lang] as unknown;
+  for (const p of parts) {
+    node = (node as Record<string, unknown>)[p];
+    if (node === undefined) break;
+  }
+  if (typeof node === 'string') return node;
+  node = strings.en as unknown;
+  for (const p of parts) {
+    node = (node as Record<string, unknown>)[p];
+    if (node === undefined) break;
+  }
+  return typeof node === 'string' ? node : key;
 }

--- a/src/lib/prefs.ts
+++ b/src/lib/prefs.ts
@@ -1,0 +1,46 @@
+import type { UserPrefs } from '@/types/prefs';
+
+const KEY = 'quickgig:prefs';
+
+function defaultPrefs(): UserPrefs {
+  return {
+    copy: process.env.NEXT_PUBLIC_COPY_VARIANT === 'taglish' ? 'taglish' : 'english',
+    emails:
+      (process.env.NEXT_PUBLIC_DEFAULT_EMAIL_PREFS as UserPrefs['emails']) ||
+      'ops_only',
+  };
+}
+
+export function getPrefs(): UserPrefs {
+  if (typeof window === 'undefined') return defaultPrefs();
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw) return { ...defaultPrefs(), ...JSON.parse(raw) } as UserPrefs;
+  } catch {
+    // ignore
+  }
+  return defaultPrefs();
+}
+
+export function savePrefs(p: UserPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(KEY, JSON.stringify(p));
+    localStorage.setItem('copyV', p.copy);
+  } catch {
+    // ignore
+  }
+}
+
+export function prefersEmail(
+  kind: 'apply' | 'interview' | 'digest' | 'marketing',
+): boolean {
+  const prefs = getPrefs();
+  if (prefs.emails === 'none') return false;
+  if (prefs.emails === 'all') return true;
+  if (prefs.emails === 'ops_only')
+    return kind === 'apply' || kind === 'interview';
+  return false;
+}
+
+export { KEY };

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { env } from '@/config/env';
+import { getPrefs, savePrefs } from '@/lib/prefs';
+import type { UserPrefs, EmailPrefs } from '@/types/prefs';
+import { t } from '@/lib/i18n';
+import { Card, CardContent } from '@/components/ui/Card';
+import Button from '@/components/ui/Button';
+import { toast } from '@/lib/toast';
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  if (!env.NEXT_PUBLIC_ENABLE_SETTINGS)
+    return { notFound: true } as const;
+  try {
+    const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    const res = await fetch(`${base}/api/session/me`, {
+      headers: { cookie: req.headers.cookie || '' },
+    });
+    if (!res.ok) {
+      return {
+        redirect: {
+          destination: `/login?return=/settings`,
+          permanent: false,
+        },
+      } as const;
+    }
+  } catch {
+    return {
+      redirect: { destination: `/login?return=/settings`, permanent: false },
+    } as const;
+  }
+  return { props: {} } as const;
+};
+
+export default function SettingsPage() {
+  const [copy, setCopy] = useState<UserPrefs['copy']>('english');
+  const [emails, setEmails] = useState<EmailPrefs>('ops_only');
+
+  useEffect(() => {
+    const p = getPrefs();
+    setCopy(p.copy);
+    setEmails(p.emails);
+  }, []);
+
+  const onSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    savePrefs({ copy, emails });
+    toast(t('settings.toast.saved'));
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>{t('settings.title')} | QuickGig</title>
+      </Head>
+      <main className="qg-container py-8 max-w-xl">
+        <Card className="p-6" hover={false}>
+          <CardContent>
+            <h1 className="text-2xl font-bold mb-4">{t('settings.title')}</h1>
+            <form onSubmit={onSave} className="space-y-6">
+              <div>
+                <p className="font-medium mb-2">{t('settings.language.label')}</p>
+                <div className="space-y-1">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="copy"
+                      value="english"
+                      checked={copy === 'english'}
+                      onChange={() => setCopy('english')}
+                    />
+                    English
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="copy"
+                      value="taglish"
+                      checked={copy === 'taglish'}
+                      onChange={() => setCopy('taglish')}
+                    />
+                    Taglish
+                  </label>
+                </div>
+              </div>
+              <div>
+                <p className="font-medium mb-2">{t('settings.emails.label')}</p>
+                <div className="space-y-1">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="emails"
+                      value="all"
+                      checked={emails === 'all'}
+                      onChange={() => setEmails('all')}
+                    />
+                    {t('settings.emails.all')}
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="emails"
+                      value="ops_only"
+                      checked={emails === 'ops_only'}
+                      onChange={() => setEmails('ops_only')}
+                    />
+                    {t('settings.emails.ops_only')}
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="emails"
+                      value="none"
+                      checked={emails === 'none'}
+                      onChange={() => setEmails('none')}
+                    />
+                    {t('settings.emails.none')}
+                  </label>
+                </div>
+              </div>
+              <Button type="submit">{t('settings.saved')}</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </main>
+    </>
+  );
+}

--- a/src/types/prefs.ts
+++ b/src/types/prefs.ts
@@ -1,0 +1,6 @@
+export type EmailPrefs = 'ops_only'|'all'|'none';
+export interface UserPrefs {
+  copy: 'english'|'taglish';
+  emails: EmailPrefs;
+  marketing?: boolean; // reserved
+}

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -9,6 +9,15 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
   if (![301,302,307,308].includes(r2.status)) bail(`HEAD /app expected redirect; got ${r2.status}`);
   const loc = r2.headers.get('location') || '';
   if (loc !== '/' && loc !== base + '/') bail(`HEAD /app location must be root; got ${loc}`);
+  if (process.env.SMOKE_URL && process.env.NEXT_PUBLIC_ENABLE_SETTINGS === 'true') {
+    try {
+      const s = await fetchImpl(base + '/settings');
+      if (s.status === 200) console.log('[smoke] settings ok');
+      else console.log('[smoke] settings', s.status);
+    } catch {
+      console.log('[smoke] settings check failed');
+    }
+  }
   if (process.env.SMOKE_APPS === '1') {
     try {
       const r3 = await fetchImpl(base + '/api/applications/TEST');


### PR DESCRIPTION
## Summary
- add user prefs model for language and email notifications and persist to localStorage
- wire copy resolution and email sending through new prefs
- add flagged /settings page and nav entry
- extend smoke test for settings route

## Testing
- `rm -rf node_modules .next && (npm ci || npm i) && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2bf9aede08327a4f2bdb296f2a815