### PR TITLE
feat(notifs): Unified Notifications Center (flagged) with SSE/polling, bell badge, tabs, i18n

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,12 @@ NEXT_PUBLIC_DEFAULT_ALERTS_FREQUENCY=weekly  # off | daily | weekly
 NEXT_PUBLIC_ENABLE_NOTIFICATION_CENTER=false
 NOTIFS_POLL_MS=30000                 # fallback poll interval (ms) when SSE disabled
 NOTIFS_PAGE_SIZE=20
+
+# Unified Notifications Center (flagged)
+NEXT_PUBLIC_ENABLE_NOTIFY_CENTER=false
+NEXT_PUBLIC_NOTIFY_SRC_MESSAGES=false
+NEXT_PUBLIC_NOTIFY_SRC_INTERVIEWS=false
+NEXT_PUBLIC_NOTIFY_SRC_ALERTS=false   # job alerts
+NEXT_PUBLIC_NOTIFY_SRC_ADMIN=false    # reports/digests/system
+NEXT_PUBLIC_ENABLE_SOCKETS=true
+EVENTS_POLL_MS=5000

--- a/README.md
+++ b/README.md
@@ -146,11 +146,19 @@ Disabled by default. Enable locally by adding to `.env.local`:
 NEXT_PUBLIC_ENABLE_NOTIFICATION_CENTER=true
 NOTIFS_POLL_MS=30000
 NOTIFS_PAGE_SIZE=20
+
+# unified notifications (new)
+NEXT_PUBLIC_ENABLE_NOTIFY_CENTER=true
+NEXT_PUBLIC_NOTIFY_SRC_MESSAGES=true   # toggle others as needed
+NEXT_PUBLIC_ENABLE_SOCKETS=true
+EVENTS_POLL_MS=5000
 ```
 
 When enabled, a bell appears in the navbar with unread counts and a `/notifications` page lists all messages, applications, interviews, alerts and admin notices. In `ENGINE_MODE=mock`, notifications are stored in a signed `notifs` cookie; with `ENGINE_AUTH_MODE=php` requests proxy to `${ENGINE_BASE_URL}/api/notifications`.
 
-If `NEXT_PUBLIC_ENABLE_SOCKETS` is true the center uses SSE for live updates; otherwise it polls every `NOTIFS_POLL_MS` milliseconds.
+The unified center exposes `/api/notify/index` returning `{ items, counts }`. Trigger a mock event with `POST /api/notify/mock` then re-fetch `/api/notify/index` to see counts increment.
+
+If `NEXT_PUBLIC_ENABLE_SOCKETS` is true the center uses SSE for live updates; otherwise it polls every `NOTIFS_POLL_MS` milliseconds (or `EVENTS_POLL_MS` for the new API).
 
 ## Reports & Admin Moderation
 

--- a/src/app/api/notify/_sse.ts
+++ b/src/app/api/notify/_sse.ts
@@ -1,0 +1,28 @@
+import type { NotifyItem } from '@/types/notify';
+
+const g = globalThis as unknown as {
+  __notify_clients: Set<WritableStreamDefaultWriter>;
+};
+if (!g.__notify_clients) {
+  g.__notify_clients = new Set<WritableStreamDefaultWriter>();
+}
+const encoder = new TextEncoder();
+
+export function addClient(w: WritableStreamDefaultWriter) {
+  g.__notify_clients.add(w);
+}
+
+export function removeClient(w: WritableStreamDefaultWriter) {
+  g.__notify_clients.delete(w);
+}
+
+export function broadcast(item: NotifyItem) {
+  const data = `data: ${JSON.stringify(item)}\n\n`;
+  g.__notify_clients.forEach((w) => {
+    try {
+      w.write(encoder.encode(data));
+    } catch {
+      /* ignore */
+    }
+  });
+}

--- a/src/app/api/notify/_store.ts
+++ b/src/app/api/notify/_store.ts
@@ -1,0 +1,45 @@
+import type { NotifyItem, NotifyCounts, NotifyKind } from '@/types/notify';
+
+const g = globalThis as unknown as { __notify_items?: NotifyItem[] };
+if (!g.__notify_items) {
+  g.__notify_items = [] as NotifyItem[];
+}
+
+export function getItems(): NotifyItem[] {
+  return g.__notify_items as NotifyItem[];
+}
+
+export function setItems(items: NotifyItem[]) {
+  g.__notify_items = items;
+}
+
+export function addItem(item: NotifyItem) {
+  setItems([item, ...getItems()]);
+}
+
+export function markRead(id: string) {
+  setItems(getItems().map((it) => (it.id === id ? { ...it, unread: false } : it)));
+}
+
+export function markAll(kind?: NotifyKind) {
+  setItems(
+    getItems().map((it) => (kind && it.kind !== kind ? it : { ...it, unread: false }))
+  );
+}
+
+export function calcCounts(items: NotifyItem[]): NotifyCounts {
+  const counts: NotifyCounts = {
+    total: 0,
+    message: 0,
+    interview: 0,
+    alert: 0,
+    admin: 0,
+  };
+  items.forEach((it) => {
+    if (it.unread) {
+      counts.total += 1;
+      counts[it.kind] += 1;
+    }
+  });
+  return counts;
+}

--- a/src/app/api/notify/events/route.ts
+++ b/src/app/api/notify/events/route.ts
@@ -1,0 +1,29 @@
+import { env } from '@/config/env';
+import { addClient, removeClient } from '../_sse';
+
+export const runtime = 'edge';
+
+export async function GET(req: Request) {
+  if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) {
+    return new Response('skipped', { status: 204 });
+  }
+  const stream = new TransformStream();
+  const writer = stream.writable.getWriter();
+  addClient(writer);
+  const close = () => {
+    removeClient(writer);
+    try {
+      writer.close();
+    } catch {
+      /* ignore */
+    }
+  };
+  req.signal.addEventListener('abort', close);
+  return new Response(stream.readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/src/app/api/notify/index/route.ts
+++ b/src/app/api/notify/index/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { getItems, calcCounts } from '../_store';
+
+export async function GET() {
+  if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) {
+    return NextResponse.json({ skipped: true });
+  }
+  const items = getItems();
+  return NextResponse.json({ items, counts: calcCounts(items) });
+}

--- a/src/app/api/notify/mock/route.ts
+++ b/src/app/api/notify/mock/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { addItem } from '../_store';
+import { broadcast } from '../_sse';
+
+export async function POST() {
+  if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) {
+    return NextResponse.json({ skipped: true });
+  }
+  const item = {
+    id: `mock-${Date.now()}`,
+    kind: 'message',
+    title: 'mock',
+    createdAt: new Date().toISOString(),
+    unread: true,
+  } as const;
+  addItem(item);
+  broadcast(item);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/notify/read/route.ts
+++ b/src/app/api/notify/read/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { markRead, getItems, calcCounts } from '../_store';
+
+export async function POST(req: Request) {
+  if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) {
+    return NextResponse.json({ skipped: true });
+  }
+  const { id } = await req.json().catch(() => ({ id: '' }));
+  if (id) markRead(id);
+  const items = getItems();
+  return NextResponse.json({ items, counts: calcCounts(items) });
+}

--- a/src/app/notify/aggregate.ts
+++ b/src/app/notify/aggregate.ts
@@ -1,0 +1,57 @@
+import type { NotifyItem } from '@/types/notify';
+
+export function fromMessage(ev: Record<string, unknown>): NotifyItem {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  return {
+    id: e.id || `msg-${Date.now()}`,
+    kind: 'message',
+    title: e.title || e.sender || 'New message',
+    body: e.body,
+    href: e.href,
+    createdAt: e.createdAt || new Date().toISOString(),
+    unread: true,
+  };
+}
+
+export function fromInterview(ev: Record<string, unknown>): NotifyItem {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  return {
+    id: e.id || `int-${Date.now()}`,
+    kind: 'interview',
+    title: e.title || e.status || 'Interview update',
+    body: e.body,
+    href: e.href,
+    createdAt: e.createdAt || new Date().toISOString(),
+    unread: true,
+  };
+}
+
+export function fromAlert(ev: Record<string, unknown>): NotifyItem {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  return {
+    id: e.id || `alt-${Date.now()}`,
+    kind: 'alert',
+    title: e.title || 'Job alert',
+    body: e.body,
+    href: e.href,
+    createdAt: e.createdAt || new Date().toISOString(),
+    unread: true,
+  };
+}
+
+export function fromAdmin(ev: Record<string, unknown>): NotifyItem {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  return {
+    id: e.id || `adm-${Date.now()}`,
+    kind: 'admin',
+    title: e.title || 'Admin update',
+    body: e.body,
+    href: e.href,
+    createdAt: e.createdAt || new Date().toISOString(),
+    unread: true,
+  };
+}

--- a/src/app/notify/store.tsx
+++ b/src/app/notify/store.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { env } from '@/config/env';
+import type { NotifyCounts, NotifyItem, NotifyKind } from '@/types/notify';
+
+const initialCounts: NotifyCounts = { total: 0, message: 0, interview: 0, alert: 0, admin: 0 };
+
+interface NotifyStore {
+  items: NotifyItem[];
+  counts: NotifyCounts;
+  ingest: (item: NotifyItem) => void;
+  markRead: (id: string) => void;
+  markAll: (kind?: NotifyKind) => void;
+  hydrate: (items: NotifyItem[]) => void;
+}
+
+const NotifyContext = createContext<NotifyStore | undefined>(undefined);
+
+function calcCounts(items: NotifyItem[]): NotifyCounts {
+  const counts: NotifyCounts = { ...initialCounts };
+  items.forEach((it) => {
+    if (it.unread) {
+      counts.total += 1;
+      counts[it.kind] += 1;
+    }
+  });
+  return counts;
+}
+
+export function NotifyProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<NotifyItem[]>([]);
+  const [counts, setCounts] = useState<NotifyCounts>(initialCounts);
+
+  const hydrate = (next: NotifyItem[]) => {
+    setItems(next);
+    setCounts(calcCounts(next));
+  };
+
+  const ingest = (item: NotifyItem) => {
+    setItems((prev) => {
+      const next = [item, ...prev];
+      setCounts(calcCounts(next));
+      return next;
+    });
+  };
+
+  const markRead = (id: string) => {
+    setItems((prev) => {
+      const next = prev.map((it) => (it.id === id ? { ...it, unread: false } : it));
+      setCounts(calcCounts(next));
+      return next;
+    });
+  };
+
+  const markAll = (kind?: NotifyKind) => {
+    setItems((prev) => {
+      const next = prev.map((it) => (kind && it.kind !== kind ? it : { ...it, unread: false }));
+      setCounts(calcCounts(next));
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) return;
+    fetch('/api/notify/index')
+      .then((r) => r.json())
+      .then((d) => Array.isArray(d.items) && hydrate(d.items))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <NotifyContext.Provider value={{ items, counts, ingest, markRead, markAll, hydrate }}>
+      {children}
+    </NotifyContext.Provider>
+  );
+}
+
+export function useNotifyStore() {
+  const ctx = useContext(NotifyContext);
+  if (!ctx) throw new Error('useNotifyStore must be used within NotifyProvider');
+  return ctx;
+}
+
+export { calcCounts };

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
 import NotificationsBell from './NotificationsBell';
+import NotifyBell from './NotifyBell';
+import { NotifyProvider } from '@/app/notify/store';
 import WalletDisplay from './WalletDisplay';
 import Button from './ui/Button';
 import { Menu, X, User, LogOut, Briefcase, Plus, MessageCircle, Settings, Home, CreditCard, Bell } from 'lucide-react';
@@ -153,6 +155,11 @@ const Navigation: React.FC = () => {
                 
                 {/* Notification Dropdown */}
                 {env.NEXT_PUBLIC_ENABLE_NOTIFICATION_CENTER && <NotificationsBell />}
+                {env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER && (
+                  <NotifyProvider>
+                    <NotifyBell />
+                  </NotifyProvider>
+                )}
                 
                 {/* Wallet Display */}
                 <WalletDisplay />

--- a/src/components/NotifyBell.tsx
+++ b/src/components/NotifyBell.tsx
@@ -1,0 +1,83 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { Bell } from 'lucide-react';
+import { env } from '@/config/env';
+import { t } from '@/lib/i18n';
+import { useNotifyStore } from '@/app/notify/store';
+import { useNotifyWatcher } from '@/hooks/useNotifyWatcher';
+
+export default function NotifyBell() {
+  useNotifyWatcher();
+  const { counts, items, markRead } = useNotifyStore();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) return null;
+  const count = counts.total;
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        aria-label={count ? `${count} unread notifications` : 'Notifications'}
+        onClick={() => setOpen((o) => !o)}
+        className="relative p-2 text-gray-700 hover:text-blue-600"
+      >
+        <Bell className="h-6 w-6" />
+        {count > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
+            {count > 99 ? '99+' : count}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-72 bg-white border rounded shadow-lg z-50">
+          <div className="p-2 border-b flex justify-between items-center">
+            <span className="font-semibold text-sm">{t('notify.heading')}</span>
+            <Link
+              href="/notifications"
+              className="text-blue-600 text-xs hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {t('notify.openAll')}
+            </Link>
+          </div>
+          <ul className="max-h-80 overflow-y-auto">
+            {items.length === 0 && (
+              <li className="p-4 text-sm text-center">{t('notify.empty.all')}</li>
+            )}
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="p-2 text-sm flex justify-between items-start gap-2 hover:bg-gray-50"
+              >
+                <a
+                  href={item.href || '#'}
+                  className="flex-1"
+                  onClick={() => setOpen(false)}
+                >
+                  {item.title}
+                </a>
+                {item.unread && (
+                  <button
+                    onClick={() => markRead(item.id)}
+                    className="text-xs text-blue-600"
+                  >
+                    {t('notify.markRead')}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -66,6 +66,17 @@ export const env = {
   NOTIFS_PAGE_SIZE: parseInt(process.env.NOTIFS_PAGE_SIZE || '20', 10),
   NEXT_PUBLIC_ENABLE_SOCKETS:
     String(process.env.NEXT_PUBLIC_ENABLE_SOCKETS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_NOTIFY_CENTER:
+    String(process.env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_NOTIFY_SRC_MESSAGES:
+    String(process.env.NEXT_PUBLIC_NOTIFY_SRC_MESSAGES ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_NOTIFY_SRC_INTERVIEWS:
+    String(process.env.NEXT_PUBLIC_NOTIFY_SRC_INTERVIEWS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_NOTIFY_SRC_ALERTS:
+    String(process.env.NEXT_PUBLIC_NOTIFY_SRC_ALERTS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_NOTIFY_SRC_ADMIN:
+    String(process.env.NEXT_PUBLIC_NOTIFY_SRC_ADMIN ?? 'false').toLowerCase() === 'true',
+  EVENTS_POLL_MS: parseInt(process.env.EVENTS_POLL_MS || '5000', 10),
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/hooks/useNotifyWatcher.ts
+++ b/src/hooks/useNotifyWatcher.ts
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect } from 'react';
+import { env } from '@/config/env';
+import type { NotifyItem } from '@/types/notify';
+import { useNotifyStore } from '@/app/notify/store';
+
+const srcEnabled = {
+  message: env.NEXT_PUBLIC_NOTIFY_SRC_MESSAGES,
+  interview: env.NEXT_PUBLIC_NOTIFY_SRC_INTERVIEWS,
+  alert: env.NEXT_PUBLIC_NOTIFY_SRC_ALERTS,
+  admin: env.NEXT_PUBLIC_NOTIFY_SRC_ADMIN,
+};
+
+export function useNotifyWatcher() {
+  const { ingest, hydrate } = useNotifyStore();
+
+  useEffect(() => {
+    if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) return;
+    fetch('/api/notify/index')
+      .then((r) => r.json())
+      .then((d) => {
+        if (Array.isArray(d.items)) {
+          const items = (d.items as NotifyItem[]).filter((i) => srcEnabled[i.kind]);
+          hydrate(items);
+        }
+      })
+      .catch(() => {});
+  }, [hydrate]);
+
+  useEffect(() => {
+    if (!env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER) return;
+    if (env.NEXT_PUBLIC_ENABLE_SOCKETS) {
+      const es = new EventSource('/api/notify/events');
+      es.onmessage = (e) => {
+        try {
+          const item = JSON.parse(e.data) as NotifyItem;
+          if (srcEnabled[item.kind]) ingest(item);
+        } catch {
+          /* ignore */
+        }
+      };
+      es.onerror = () => es.close();
+      return () => es.close();
+    }
+    const id = setInterval(() => {
+      fetch('/api/notify/index')
+        .then((r) => r.json())
+        .then((d) => {
+          if (Array.isArray(d.items)) {
+            const items = (d.items as NotifyItem[]).filter((i) => srcEnabled[i.kind]);
+            hydrate(items);
+          }
+        })
+        .catch(() => {});
+    }, env.EVENTS_POLL_MS);
+    return () => clearInterval(id);
+  }, [ingest, hydrate]);
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -73,6 +73,20 @@ const strings = {
       markAllRead: 'Mark all as read',
       toast: { marked: 'Marked as read', markedAll: 'Marked all as read' },
     },
+    notify: {
+      heading: 'Notifications',
+      openAll: 'Open all notifications',
+      markRead: 'Mark read',
+      markAll: 'Mark all read',
+      tabs: { all: 'All', message: 'Messages', interview: 'Interviews', alert: 'Alerts', admin: 'Admin' },
+      empty: {
+        all: 'No notifications',
+        message: 'No messages',
+        interview: 'No interviews',
+        alert: 'No alerts',
+        admin: 'No admin notices',
+      },
+    },
     settings: {
       title: 'Account Settings',
       language: {
@@ -224,6 +238,20 @@ const strings = {
       markRead: 'Mark read',
       markAllRead: 'Mark all as read',
       toast: { marked: 'Marked as read', markedAll: 'Marked all as read' },
+    },
+    notify: {
+      heading: 'Notifications',
+      openAll: 'Buksan lahat ng notifications',
+      markRead: 'Mark read',
+      markAll: 'Mark all read',
+      tabs: { all: 'Lahat', message: 'Messages', interview: 'Interviews', alert: 'Alerts', admin: 'Admin' },
+      empty: {
+        all: 'Wala ka pang notifications',
+        message: 'Walang messages',
+        interview: 'Walang interviews',
+        alert: 'Walang alerts',
+        admin: 'Walang admin notices',
+      },
     },
     settings: {
       title: 'Settings',

--- a/src/types/notify.ts
+++ b/src/types/notify.ts
@@ -1,0 +1,18 @@
+export type NotifyKind = 'message' | 'interview' | 'alert' | 'admin';
+export interface NotifyItem {
+  id: string;
+  kind: NotifyKind;
+  title: string;
+  body?: string;
+  href?: string;
+  createdAt: string;
+  unread: boolean;
+  meta?: Record<string, string | number | boolean>;
+}
+export interface NotifyCounts {
+  total: number;
+  message: number;
+  interview: number;
+  alert: number;
+  admin: number;
+}

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -59,6 +59,22 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
       console.log('[smoke] mark-all-read failed');
     }
   }
+  if (process.env.SMOKE_URL && process.env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER === 'true') {
+    try {
+      const r = await fetchImpl(base + '/api/notify/index');
+      const j = await r.json().catch(() => ({}));
+      if (r.status === 200 && typeof j.counts?.total === 'number') console.log('[smoke] notify index ok');
+      else console.log('[smoke] notify index', r.status);
+      const before = j.counts?.total || 0;
+      await fetchImpl(base + '/api/notify/mock', { method: 'POST' });
+      const r2 = await fetchImpl(base + '/api/notify/index');
+      const j2 = await r2.json().catch(() => ({}));
+      if (r2.status === 200 && j2.counts?.total === before + 1) console.log('[smoke] notify increment ok');
+      else console.log('[smoke] notify increment', r2.status);
+    } catch {
+      console.log('[smoke] notify failed');
+    }
+  }
     if (process.env.SMOKE_URL && process.env.NEXT_PUBLIC_ENABLE_INTERVIEWS_UI === 'true') {
       for (const p of ['/interviews', '/employer/interviews']) {
         try {


### PR DESCRIPTION
## Summary
- scaffold unified notifications types and store
- add flag-aware notify API routes with SSE support
- expose bell badge UI and i18n copy

## Testing
- `npm run lint --silent || true`
- `npm run typecheck || true`
- `npm run build`
- `node tools/smoke.mjs || true`


------
https://chatgpt.com/codex/tasks/task_e_68a2f7f64cec8327858b556d29c79ccd