### PR TITLE
feat(ui): App Shell v2 parity with app.quickgig.ph (flagged, mock-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ NEXT_PUBLIC_ENABLE_SAVED_API=false
 # UI flags (optional)
 NEXT_PUBLIC_SHOW_LOGOUT_ALL=false
 
+# UI shell V2 (OFF by default)
+NEXT_PUBLIC_ENABLE_APP_SHELL_V2=false
+
 # Job alerts (optional)
 ALERTS_DIGEST_SECRET=change-me
 NEXT_PUBLIC_ENABLE_ALERTS=true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ automatically falls back to existing mock or legacy flows.
 
 ## Flags
 
+### App Shell V2 (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_APP_SHELL_V2` – opt-in new header/footer and tokens matching app.quickgig.ph. UI only, no route changes.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_APP_SHELL_V2=true
+```
+
+Rollback: remove or set `NEXT_PUBLIC_ENABLE_APP_SHELL_V2=false` and redeploy.
+
 ## Staging auth & engine flows
 
 Engine-backed auth and data wiring is gated behind flags and off by default.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:app:soft": "node tools/check_live_app.mjs || true",
     "check:dns:app": "node tools/check_dns_app.mjs",
     "check:jobs": "node tools/check_jobs_api.mjs || true",
-    "smoke": "node tools/smoke.mjs && (node tools/smoke_hiring.mjs || echo 'hiring smoke skipped') && (node tools/smoke_closeout.mjs || echo 'closeout smoke skipped')",
+    "smoke": "node tools/smoke.mjs && (node tools/smoke_app_shell_v2.mjs || echo 'shell v2 smoke skipped') && (node tools/smoke_hiring.mjs || echo 'hiring smoke skipped') && (node tools/smoke_closeout.mjs || echo 'closeout smoke skipped')",
     "api:check": "npm run check:api",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test -c ./playwright.config.ts --grep @smoke",

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -45,6 +45,7 @@ export default function HomePageClient() {
                 variant="secondary"
                 className="text-lg"
                 data-cta="signup"
+                data-testid="primary-cta"
               >
                 Simulan Na!
               </Button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,8 @@
   --color-secondary: #FFD451;
   --bg: #0C1720;
   --fg: #F8FAFC;
+  --muted: #64748B;
+  --accent: #FFD451;
   --hero-start: #0B3C49;
   --hero-end: #0C1720;
   --background: var(--bg);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,8 @@ import SettingsBanner from "../components/SettingsBanner";
 import ClientBootstrap from '@/app/ClientBootstrap';
 import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
+import AppShellV2 from '@/components/layouts/AppShellV2';
+import { env } from '@/config/env';
 
 export const metadata: Metadata = {
   title: "QuickGig.ph - Find Gigs Fast in the Philippines",
@@ -94,12 +96,14 @@ export default function RootLayout({
           <SocketProvider>
             <ToastProvider>
               <ErrorBoundary>
-                <Navigation />
-                <SettingsBanner />
-                <main className="min-h-screen">
-                  {children}
-                </main>
-                <footer className="qg-footer">
+                {env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 ? (
+                  <AppShellV2>{children}</AppShellV2>
+                ) : (
+                  <>
+                    <Navigation />
+                    <SettingsBanner />
+                    <main className="min-h-screen">{children}</main>
+                    <footer className="qg-footer">
               <div className="qg-container">
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
                   <div className="col-span-1 md:col-span-2">
@@ -142,7 +146,9 @@ export default function RootLayout({
                   </div>
                 </div>
               </div>
-                </footer>
+                    </footer>
+                  </>
+                )}
               </ErrorBoundary>
             </ToastProvider>
           </SocketProvider>

--- a/src/components/layouts/AppShellV2.tsx
+++ b/src/components/layouts/AppShellV2.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { t } from '@/lib/i18n';
+import SettingsBanner from '@/components/SettingsBanner';
+
+export default function AppShellV2({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <nav data-testid="navbar" className="bg-bg text-fg shadow-qg-lg">
+        <div className="qg-container flex items-center justify-between py-4">
+          <Link href="/" className="font-heading text-2xl font-bold">
+            QuickGig<span className="text-accent">.ph</span>
+          </Link>
+          <div className="space-x-4 text-sm font-medium">
+            <Link href="/" className="hover:text-accent">
+              {t('navbar.home')}
+            </Link>
+            <Link href="/find-work" className="hover:text-accent">
+              {t('navbar.jobs')}
+            </Link>
+            <Link href="/login" className="hover:text-accent">
+              {t('navbar.login')}
+            </Link>
+          </div>
+        </div>
+      </nav>
+      <SettingsBanner />
+      <main>{children}</main>
+      <footer
+        data-testid="footer"
+        className="bg-bg text-fg border-t border-muted mt-10"
+      >
+        <div className="qg-container py-8 flex flex-col sm:flex-row justify-between text-sm">
+          <p className="mb-4 sm:mb-0">© 2024 QuickGig.ph</p>
+          <div className="space-x-4">
+            <Link href="/about" className="hover:text-accent">
+              {t('footer.about')}
+            </Link>
+            <Link href="/privacy" className="hover:text-accent">
+              {t('footer.privacy')}
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { cn } from '@/lib/utils';
+import { env } from '@/config/env';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
@@ -12,20 +13,37 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'primary', size = 'md', children, loading, disabled, ...props }, ref) => {
-    const baseClasses = 'inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg disabled:opacity-50 disabled:cursor-not-allowed';
+    const baseClasses = env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+      ? 'inline-flex items-center justify-center gap-2 font-heading font-semibold rounded-full transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg disabled:opacity-50 disabled:cursor-not-allowed'
+      : 'inline-flex items-center justify-center gap-2 font-heading font-semibold transition-all duration-qg-fast focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg disabled:opacity-50 disabled:cursor-not-allowed';
 
-    const variants = {
+    const v1Variants = {
       primary: 'bg-primary text-fg hover:bg-primary/90 focus:ring-primary',
       secondary: 'bg-secondary text-fg hover:bg-secondary/90 focus:ring-secondary',
       outline: 'border border-primary text-primary hover:bg-primary hover:text-fg focus:ring-primary',
       ghost: 'bg-transparent text-primary hover:bg-primary/10 focus:ring-primary',
-    };
-    
-    const sizes = {
-      sm: 'px-3 py-1.5 text-sm rounded-qg-sm',
-      md: 'px-6 py-3 text-base rounded-qg-md',
-      lg: 'px-8 py-4 text-lg rounded-qg-lg',
-    };
+    } as const;
+
+    const v2Variants = {
+      primary: 'bg-primary text-fg hover:bg-primary/90 focus:ring-primary',
+      secondary: 'bg-secondary text-bg hover:bg-secondary/90 focus:ring-secondary',
+      outline: 'border border-fg text-fg hover:bg-fg hover:text-bg focus:ring-fg',
+      ghost: 'bg-transparent text-fg hover:bg-fg/10 focus:ring-fg',
+    } as const;
+
+    const variants = env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 ? v2Variants : v1Variants;
+
+    const sizes = env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+      ? {
+          sm: 'px-3 py-1.5 text-sm',
+          md: 'px-6 py-3 text-base',
+          lg: 'px-8 py-4 text-lg',
+        }
+      : {
+          sm: 'px-3 py-1.5 text-sm rounded-qg-sm',
+          md: 'px-6 py-3 text-base rounded-qg-md',
+          lg: 'px-8 py-4 text-lg rounded-qg-lg',
+        };
 
     return (
       <button

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { cn } from '@/lib/utils';
+import { env } from '@/config/env';
 
 interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -39,7 +40,9 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          'bg-bg text-fg rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
+          env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+            ? 'bg-fg text-bg rounded-lg shadow-qg-md transition-all duration-qg-normal'
+            : 'bg-bg text-fg rounded-qg-lg shadow-qg-md transition-all duration-qg-normal',
           hover && 'hover:shadow-qg-lg hover:-translate-y-1 cursor-pointer',
           paddingClasses[padding],
           className
@@ -54,11 +57,19 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
 
 const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
-    const variants = {
+    const v1Variants = {
       default: 'bg-bg text-fg',
       primary: 'bg-primary text-fg',
       accent: 'bg-secondary text-fg',
-    };
+    } as const;
+
+    const v2Variants = {
+      default: 'bg-fg text-bg',
+      primary: 'bg-primary text-fg',
+      accent: 'bg-secondary text-bg',
+    } as const;
+
+    const variants = env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 ? v2Variants : v1Variants;
 
     return (
       <div
@@ -106,11 +117,19 @@ const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(
 
 const CardTag = React.forwardRef<HTMLSpanElement, CardTagProps>(
   ({ className, children, variant = 'default', ...props }, ref) => {
-    const variants = {
+    const tagV1 = {
       default: 'bg-bg text-fg border border-fg',
       primary: 'bg-primary text-fg',
       accent: 'bg-secondary text-fg',
-    };
+    } as const;
+
+    const tagV2 = {
+      default: 'bg-fg text-bg border border-bg',
+      primary: 'bg-primary text-fg',
+      accent: 'bg-secondary text-bg',
+    } as const;
+
+    const variants = env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 ? tagV2 : tagV1;
 
     return (
       <span

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { cn } from '@/lib/utils';
+import { env } from '@/config/env';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -46,10 +47,17 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             type={type}
             id={inputId}
             className={cn(
-              'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-              'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
+              env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+                ? 'block w-full px-4 py-3 border border-muted rounded-md bg-fg text-bg'
+                : 'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+              env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+                ? 'focus:ring-2 focus:ring-primary focus:border-primary'
+                : 'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
               'placeholder:text-gray-400',
-              error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
+              error &&
+                (env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+                  ? 'border-red-500'
+                  : 'border-red-300 focus:border-red-500 focus:ring-red-500/20'),
               icon && iconPosition === 'left' && 'pl-10',
               icon && iconPosition === 'right' && 'pr-10',
               className
@@ -87,13 +95,20 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         <textarea
           id={textareaId}
-            className={cn(
-              'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-              'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
-              'placeholder:text-gray-400 resize-vertical min-h-[100px]',
-              error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
-              className
-            )}
+          className={cn(
+            env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+              ? 'block w-full px-4 py-3 border border-muted rounded-md bg-fg text-bg'
+              : 'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+            env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+              ? 'focus:ring-2 focus:ring-primary focus:border-primary'
+              : 'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
+            'placeholder:text-gray-400 resize-vertical min-h-[100px]',
+            error &&
+              (env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+                ? 'border-red-500'
+                : 'border-red-300 focus:border-red-500 focus:ring-red-500/20'),
+            className
+          )}
           ref={ref}
           {...props}
         />
@@ -122,10 +137,16 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         <select
           id={selectId}
           className={cn(
-            'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
-            'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
-            'bg-white cursor-pointer',
-            error && 'border-red-300 focus:border-red-500 focus:ring-red-500/20',
+            env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+              ? 'block w-full px-4 py-3 border border-muted rounded-md bg-fg text-bg cursor-pointer'
+              : 'block w-full px-4 py-3 border-2 border-gray-300 rounded-qg-md font-body',
+            env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+              ? 'focus:ring-2 focus:ring-primary focus:border-primary'
+              : 'focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-qg-fast',
+            error &&
+              (env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2
+                ? 'border-red-500'
+                : 'border-red-300 focus:border-red-500 focus:ring-red-500/20'),
             className
           )}
           ref={ref}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,8 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_SAVED_API ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_SHOW_LOGOUT_ALL:
     String(process.env.NEXT_PUBLIC_SHOW_LOGOUT_ALL ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_APP_SHELL_V2:
+    String(process.env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_APPLICANT_APPS:
     String(process.env.NEXT_PUBLIC_ENABLE_APPLICANT_APPS ?? 'true').toLowerCase() === 'true',
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -49,6 +49,14 @@ const strings = {
     add_to_calendar: 'Add to calendar',
     navbar: {
       settings: 'Settings',
+      home: 'Home',
+      jobs: 'Browse Jobs',
+      login: 'Log in',
+      signup: 'Sign up',
+    },
+    footer: {
+      about: 'About',
+      privacy: 'Privacy',
     },
     notifications: {
       title: 'Notifications',
@@ -218,6 +226,14 @@ const strings = {
     add_to_calendar: 'Add to calendar',
     navbar: {
       settings: 'Settings',
+      home: 'Home',
+      jobs: 'Hanap Trabaho',
+      login: 'Mag-Login',
+      signup: 'Sign Up',
+    },
+    footer: {
+      about: 'Tungkol',
+      privacy: 'Privacy',
     },
     notifications: {
       title: 'Notifications',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,8 @@ const config: Config = {
         secondary: 'var(--color-secondary)',
         bg: 'var(--bg)',
         fg: 'var(--fg)',
+        muted: 'var(--muted)',
+        accent: 'var(--accent)',
         background: 'var(--bg)',
         foreground: 'var(--fg)',
         // QuickGig Brand Colors

--- a/tools/smoke_app_shell_v2.mjs
+++ b/tools/smoke_app_shell_v2.mjs
@@ -1,0 +1,15 @@
+const base = process.env.SMOKE_URL || process.env.BASE || 'http://localhost:3000';
+if (process.env.NEXT_PUBLIC_ENABLE_APP_SHELL_V2 !== 'true') {
+  console.log('[smoke] app shell v2 disabled');
+  process.exit(0);
+}
+(async () => {
+  const html = await fetch(base + '/').then((r) => r.text());
+  const required = ['primary-cta', 'navbar', 'footer'];
+const missing = required.filter((id) => !html.includes(`data-testid="${id}"`));
+  if (missing.length) {
+    console.error('[smoke] missing selectors', missing.join(', '));
+    process.exit(1);
+  }
+  console.log('[smoke] shell v2 ok');
+})();


### PR DESCRIPTION
## Summary
- add App Shell V2 layout with new header and footer tokens
- wire NEXT_PUBLIC_ENABLE_APP_SHELL_V2 flag and i18n strings
- include smoke check for shell v2 and document flag usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `node tools/smoke_app_shell_v2.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a31c5c241483278020d50455169e6a