### PR TITLE
feat(status): Engine wiring status page (flagged, mock-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,6 @@ NEXT_PUBLIC_ENABLE_BULK_REJECTION_EMAILS=false
 
 # Buttons/Links sanity checker (OFF by default)
 NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY=false
+
+# Engine wiring status page (OFF by default)
+NEXT_PUBLIC_ENABLE_STATUS_PAGE=false

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ NEXT_PUBLIC_ENABLE_APP_SHELL_V2=true
 
 Rollback: remove or set `NEXT_PUBLIC_ENABLE_APP_SHELL_V2=false` and redeploy.
 
+### Engine Wiring Status Page (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_STATUS_PAGE` – expose internal `/status` page showing engine and DB health.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_STATUS_PAGE=true
+```
+
+Rollback: set `NEXT_PUBLIC_ENABLE_STATUS_PAGE=false` and redeploy.
+
+Notes: internal health check, not for SEO.
+
 ## Staging auth & engine flows
 
 Engine-backed auth and data wiring is gated behind flags and off by default.

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,35 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { env } from '@/config/env';
+import { t } from '@/lib/i18n';
+import { health } from '@/lib/engineAdapter';
+
+export const dynamic = 'force-dynamic';
+
+export default async function StatusPage() {
+  if (!env.NEXT_PUBLIC_ENABLE_STATUS_PAGE) notFound();
+  const info = await health();
+  const hdrs = headers();
+  (hdrs as unknown as Headers).set('X-Robots-Tag', 'noindex');
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold">{t('status.title')}</h1>
+      <table className="mt-4">
+        <tbody>
+          <tr>
+            <td>{t('status.engine_ok')}</td>
+            <td data-testid="status-engine">{info.engine ? 'ok' : 'down'}</td>
+          </tr>
+          <tr>
+            <td>{t('status.db_ok')}</td>
+            <td data-testid="status-db">{info.db ? 'ok' : 'down'}</td>
+          </tr>
+          <tr>
+            <td>{t('status.timestamp')}</td>
+            <td>{info.timestamp}</td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -94,6 +94,8 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_EMAILS ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY:
     String(process.env.NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_STATUS_PAGE:
+    String(process.env.NEXT_PUBLIC_ENABLE_STATUS_PAGE ?? 'false').toLowerCase() === 'true',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/lib/engineAdapter.ts
+++ b/src/lib/engineAdapter.ts
@@ -1,0 +1,23 @@
+export interface EngineHealth {
+  engine: boolean;
+  db: boolean;
+  timestamp: string;
+}
+
+export async function health(): Promise<EngineHealth> {
+  if (process.env.ENGINE_MODE !== 'php') {
+    return { engine: true, db: true, timestamp: new Date().toISOString() };
+  }
+  const base = process.env.ENGINE_BASE_URL || '';
+  try {
+    const res = await fetch(`${base}/_health`);
+    const json: Record<string, unknown> = await res.json().catch(() => ({}));
+    return {
+      engine: res.ok,
+      db: (json as { db?: boolean }).db !== false,
+      timestamp: (json as { timestamp?: string }).timestamp || new Date().toISOString(),
+    };
+  } catch {
+    return { engine: false, db: false, timestamp: new Date().toISOString() };
+  }
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -95,6 +95,12 @@ const strings = {
         admin: 'No admin notices',
       },
     },
+    status: {
+      title: 'Status',
+      engine_ok: 'Engine reachable',
+      db_ok: 'DB reachable',
+      timestamp: 'Timestamp',
+    },
     settings: {
       title: 'Account Settings',
       language: {
@@ -271,6 +277,12 @@ const strings = {
         alert: 'Walang alerts',
         admin: 'Walang admin notices',
       },
+    },
+    status: {
+      title: 'Status',
+      engine_ok: 'Engine ok',
+      db_ok: 'DB ok',
+      timestamp: 'Oras',
     },
     settings: {
       title: 'Settings',

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -19,6 +19,20 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
   } else {
     console.log('[smoke] link map sanity skipped');
   }
+  if (process.env.SMOKE_URL && process.env.NEXT_PUBLIC_ENABLE_STATUS_PAGE === 'true') {
+    try {
+      const s = await fetchImpl(base + '/status');
+      const txt = await s.text();
+      if (
+        s.status === 200 &&
+        /data-testid="status-engine">ok/.test(txt) &&
+        /data-testid="status-db">ok/.test(txt)
+      ) console.log('[smoke] status ok');
+      else console.log('[smoke] status', s.status);
+    } catch {
+      console.log('[smoke] status check failed');
+    }
+  }
   const runEngine = process.argv.includes('--engine');
   if (runEngine) {
     try {


### PR DESCRIPTION
## Summary
- add engine wiring status page behind `NEXT_PUBLIC_ENABLE_STATUS_PAGE`
- expose `engineAdapter.health()` for engine + DB checks
- document flag and update smoke test

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3256875bc8327b4c38a9aecb015bb