### PR TITLE
test(emails): Bulk rejection email dry-run harness (flagged, mock-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,9 @@ NEXT_PUBLIC_ENABLE_HIRING_EMAILS=false
 NEXT_PUBLIC_ENABLE_JOB_CLOSEOUT=false
 NEXT_PUBLIC_ENABLE_BULK_REJECTION_EMAILS=false
 
+# Bulk rejection email QA harness (OFF by default)
+NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=false
+
 # Buttons/Links sanity checker (OFF by default)
 NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY=false
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ Rollback: set `NEXT_PUBLIC_ENABLE_INTERVIEW_REMINDERS_QA=false` and redeploy.
 
 Notes: dev/test only, mock-safe. Page `/qa/interview-reminders` renders `invite-sent` and `reminder-sent` markers.
 
+### Bulk Rejection Email Dry-Run Harness (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA` – generate mock bulk rejection emails and expose test markers.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=true
+```
+
+Then run:
+
+```
+npx playwright test tests/bulkRejectionEmailHarness.spec.ts
+BASE=http://localhost:3000 node tools/smoke.mjs
+```
+
+Rollback: set `NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=false` and redeploy.
+
+Notes: mock/test only, no live emails sent. Page `/qa/bulk-rejection` renders `bulk-email-preview` markers.
+
 ## Staging auth & engine flows
 
 Engine-backed auth and data wiring is gated behind flags and off by default.

--- a/src/components/employer/BulkActions.tsx
+++ b/src/components/employer/BulkActions.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import RejectionEmail from '@/emails/templates/rejection';
+
+interface Applicant { id: string; name: string; }
+interface Job { id: string; title: string; }
+
+export default function BulkActions({ applicants, job, auto = false }: { applicants: Applicant[]; job: Job; auto?: boolean }) {
+  const [show, setShow] = useState(false);
+  const run = () => setShow(true);
+  useEffect(() => {
+    if (auto) run();
+  }, [auto]);
+  return (
+    <div className="space-y-2">
+      {!auto && (
+        <button
+          onClick={run}
+          className="bg-qg-accent text-white px-3 py-1 rounded"
+          data-testid="bulk-trigger"
+        >
+          Send bulk rejection
+        </button>
+      )}
+      {show && (
+        <div>
+          {applicants.map((a) => (
+            <div key={a.id} data-testid="bulk-email-preview" className="border p-2 my-2">
+              <RejectionEmail applicantName={a.name} jobTitle={job.title} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -94,6 +94,8 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_JOB_CLOSEOUT ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_BULK_REJECTION_EMAILS:
     String(process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_EMAILS ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA:
+    String(process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY:
     String(process.env.NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_STATUS_PAGE:

--- a/src/emails/templates/rejection.tsx
+++ b/src/emails/templates/rejection.tsx
@@ -1,0 +1,16 @@
+import { t } from '@/lib/i18n';
+
+export function RejectionEmail({ applicantName, jobTitle }: { applicantName: string; jobTitle: string }) {
+  return (
+    <div>
+      <p>
+        {t('email.bulkRejectionGreeting')} {applicantName},
+      </p>
+      <p>
+        {t('email.bulkRejectionBody')} {jobTitle}.
+      </p>
+    </div>
+  );
+}
+
+export default RejectionEmail;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -182,11 +182,14 @@ const strings = {
       interviewRemindersTitle: 'Interview Reminders QA',
       inviteSent: 'Invite sent',
       reminderSent: 'Reminder sent',
+      bulkRejectionTitle: 'Bulk Rejection Email QA',
     },
     email: {
       apply_subject: 'New application received',
       interview_subject: 'Interview update',
       digest_subject: 'Daily QuickGig digest',
+      bulkRejectionGreeting: 'Hi',
+      bulkRejectionBody: 'Thanks for applying to',
     },
   },
   tl: {
@@ -370,11 +373,14 @@ const strings = {
       interviewRemindersTitle: 'Interview Reminders QA',
       inviteSent: 'Na-send ang invite',
       reminderSent: 'Na-send ang reminder',
+      bulkRejectionTitle: 'Bulk Rejection Email QA',
     },
     email: {
       apply_subject: 'May bagong application',
       interview_subject: 'Update sa interview',
       digest_subject: 'Daily QuickGig digest',
+      bulkRejectionGreeting: 'Hi',
+      bulkRejectionBody: 'Salamat sa pag-apply sa',
     },
   },
 };

--- a/src/pages/qa/bulk-rejection.tsx
+++ b/src/pages/qa/bulk-rejection.tsx
@@ -1,0 +1,30 @@
+import BulkActions from '@/components/employer/BulkActions';
+import { t } from '@/lib/i18n';
+
+const applicants = [
+  { id: 'a1', name: 'Alice' },
+  { id: 'a2', name: 'Bob' },
+  { id: 'a3', name: 'Carlo' },
+  { id: 'a4', name: 'Dana' },
+  { id: 'a5', name: 'Eli' },
+];
+const job = { id: 'j1', title: 'Sample Job' };
+
+export default function BulkRejectionQA({ auto }: { auto: boolean }) {
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-xl font-semibold">{t('qa.bulkRejectionTitle')}</h1>
+      <BulkActions applicants={applicants} job={job} auto={auto} />
+    </main>
+  );
+}
+
+export async function getServerSideProps(ctx: { query: { [k: string]: string } }) {
+  if (
+    process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA !== 'true' ||
+    process.env.ENGINE_MODE === 'php'
+  ) {
+    return { notFound: true };
+  }
+  return { props: { auto: ctx.query.auto === '1' } };
+}

--- a/tests/bulkRejectionEmailHarness.spec.ts
+++ b/tests/bulkRejectionEmailHarness.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import applicants from './fixtures/bulkApplicants.json';
+import job from './fixtures/bulkJob.json';
+
+const enabled = process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA === 'true';
+const mode = process.env.ENGINE_MODE || 'mock';
+
+test.skip(!enabled || mode !== 'mock', 'Bulk rejection QA disabled');
+
+test('bulk rejection emails include applicant names and job title', async ({ page }) => {
+  await page.goto('/qa/bulk-rejection');
+  await page.getByTestId('bulk-trigger').click();
+  const previews = page.getByTestId('bulk-email-preview');
+  await expect(previews).toHaveCount(applicants.length);
+  for (const a of applicants) {
+    const preview = previews.filter({ hasText: a.name });
+    await expect(preview).toContainText(a.name);
+    await expect(preview).toContainText(job.title);
+  }
+  expect(await previews.first().innerText()).toMatchSnapshot('bulk-email-preview.txt');
+});

--- a/tests/bulkRejectionEmailHarness.spec.ts-snapshots/bulk-email-preview.txt
+++ b/tests/bulkRejectionEmailHarness.spec.ts-snapshots/bulk-email-preview.txt
@@ -1,0 +1,2 @@
+Hi Alice,
+Thanks for applying to Sample Job.

--- a/tests/fixtures/bulkApplicants.json
+++ b/tests/fixtures/bulkApplicants.json
@@ -1,0 +1,7 @@
+[
+  { "id": "a1", "name": "Alice" },
+  { "id": "a2", "name": "Bob" },
+  { "id": "a3", "name": "Carlo" },
+  { "id": "a4", "name": "Dana" },
+  { "id": "a5", "name": "Eli" }
+]

--- a/tests/fixtures/bulkJob.json
+++ b/tests/fixtures/bulkJob.json
@@ -1,0 +1,1 @@
+{ "id": "j1", "title": "Sample Job" }

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -251,6 +251,21 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
   } else {
     console.log('[smoke] interview reminders qa skipped');
   }
+  if (process.env.NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA === 'true') {
+    try {
+      const r = await fetchImpl(base + '/qa/bulk-rejection?auto=1');
+      const txt = await r.text();
+      if (r.status === 200 && /data-testid="bulk-email-preview"/.test(txt)) {
+        console.log('[smoke] bulk rejection qa ok');
+      } else {
+        console.log('[smoke] bulk rejection qa', r.status);
+      }
+    } catch {
+      console.log('[smoke] bulk rejection qa failed');
+    }
+  } else {
+    console.log('[smoke] bulk rejection qa skipped');
+  }
   console.log('Smoke OK');
   if (process.env.SMOKE_REPORTS === '1') {
     try {


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA flag and QA page to preview bulk rejection emails
- wire mock rejection template and BulkActions component with data-testid markers
- extend smoke and docs to cover bulk rejection QA flow

## Testing
- `npm run lint`
- `npm run typecheck`
- `NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=true npm run build`
- `NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=true BASE=http://localhost:3000 npx playwright test tests/bulkRejectionEmailHarness.spec.ts` *(fails: Executable doesn't exist)*
- `npx playwright install --with-deps chromium` *(fails: repository not signed)*
- `NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=true BASE=http://localhost:3000 node tools/smoke.mjs` *(fails: HEAD / should not redirect)*

------
https://chatgpt.com/codex/tasks/task_e_68a3344dd0108327b5ea541bfc2132b4