### PR TITLE
test(hiring): Hiring decisions + closeout QA harness (flagged, mock-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,9 @@ NEXT_PUBLIC_ENABLE_BULK_REJECTION_QA=false
 # Notifications Center QA harness (OFF by default)
 NEXT_PUBLIC_ENABLE_NOTIFY_CENTER_QA=false
 
+# Hiring decisions QA harness (OFF by default)
+NEXT_PUBLIC_ENABLE_HIRING_QA=false
+
 # Buttons/Links sanity checker (OFF by default)
 NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY=false
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ Rollback: set `NEXT_PUBLIC_ENABLE_NOTIFY_CENTER_QA=false` and redeploy.
 
 Notes: dev/test only, mock-safe. Page `/qa/notifications-center` renders `toast-msg` and `notify-list` markers.
 
+### Hiring Decisions QA Harness (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_HIRING_QA` – simulate hiring decisions and job closeout in mock mode.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_HIRING_QA=true
+```
+
+Then run:
+
+```
+npx playwright test tests/hiringDecisionsQA.spec.ts
+BASE=http://localhost:3000 node tools/smoke.mjs
+```
+
+Rollback: set `NEXT_PUBLIC_ENABLE_HIRING_QA=false` and redeploy.
+
+Notes: mock/test only, no live applicant impact.
+
 ## Staging auth & engine flows
 
 Engine-backed auth and data wiring is gated behind flags and off by default.

--- a/src/app/employer/jobs/[id]/applicants/page.tsx
+++ b/src/app/employer/jobs/[id]/applicants/page.tsx
@@ -68,8 +68,12 @@ export default function ApplicantsList({ params }: { params: { id: string } }) {
       </div>
       <ul className="space-y-2">
         {filtered.map((a) => (
-          <li key={a.id} className="border p-2 rounded flex justify-between items-center">
-            <span>
+          <li
+            key={a.id}
+            className="border p-2 rounded flex justify-between items-center"
+            data-testid={`app-${a.id}`}
+          >
+            <span data-testid={`status-${a.status}`}>
               {a.id} - {a.status}
             </span>
             <button

--- a/src/components/employer/BulkActions.tsx
+++ b/src/components/employer/BulkActions.tsx
@@ -13,7 +13,7 @@ export default function BulkActions({ applicants, job, auto = false }: { applica
     if (auto) run();
   }, [auto]);
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" data-testid="bulk-actions">
       {!auto && (
         <button
           onClick={run}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -188,6 +188,8 @@ const strings = {
       toastStatusChanged: 'Status changed',
       toastNewApplicant: 'New applicant',
       toastNewMessage: 'New message',
+      hiringQATitle: 'Hiring Decisions QA',
+      closeoutDone: 'Closeout complete',
     },
     email: {
       apply_subject: 'New application received',
@@ -384,6 +386,8 @@ const strings = {
       toastStatusChanged: 'Nagbago ang status',
       toastNewApplicant: 'May bagong applicant',
       toastNewMessage: 'May bagong message',
+      hiringQATitle: 'Hiring Decisions QA',
+      closeoutDone: 'Tapos na ang closeout',
     },
     email: {
       apply_subject: 'May bagong application',

--- a/src/pages/qa/hiring-decisions.tsx
+++ b/src/pages/qa/hiring-decisions.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import BulkActions from '@/components/employer/BulkActions';
+import { t } from '@/lib/i18n';
+import type { ApplicationSummary } from '@/types/application';
+
+interface Props { auto: boolean }
+
+export default function HiringDecisionsQA({ auto }: Props) {
+  const [apps, setApps] = useState<ApplicationSummary[]>([]);
+  const [closed, setClosed] = useState(false);
+  useEffect(() => {
+    (async () => {
+      const list = await fetch('/api/applications');
+      const arr: ApplicationSummary[] = await list.json();
+      setApps(arr.filter((a) => a.jobId === '1'));
+      if (!auto) return;
+      await fetch('/api/applications/1/hire', { method: 'POST' });
+      await fetch('/api/employer/jobs/1/bulk/reject', { method: 'POST' });
+      await fetch('/api/employer/jobs/1/close', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reason: 'filled', bulkNotify: false }),
+      });
+      const after = await fetch('/api/applications');
+      const arr2: ApplicationSummary[] = await after.json();
+      setApps(arr2.filter((a) => a.jobId === '1'));
+      setClosed(true);
+    })();
+  }, [auto]);
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-xl font-semibold">{t('qa.hiringQATitle')}</h1>
+      <ul className="space-y-2">
+        {apps.map((a) => (
+          <li key={a.id} data-testid={`status-${a.status}`}>
+            {a.id} - {a.status}
+          </li>
+        ))}
+      </ul>
+      {closed && (
+        <div data-testid="closeout-preview">{t('qa.closeoutDone')}</div>
+      )}
+      <BulkActions
+        applicants={apps
+          .filter((a) => a.status === 'not_selected')
+          .map((a) => ({ id: a.id, name: a.id }))}
+        job={{ id: '1', title: 'Sample Job' }}
+        auto={auto}
+      />
+    </main>
+  );
+}
+
+export async function getServerSideProps(ctx: { query: { [k: string]: string } }) {
+  if (
+    process.env.NEXT_PUBLIC_ENABLE_HIRING_QA !== 'true' ||
+    process.env.ENGINE_MODE === 'php'
+  ) {
+    return { notFound: true };
+  }
+  return { props: { auto: ctx.query.auto === '1' } };
+}

--- a/tests/fixtures/hiringApplicants.json
+++ b/tests/fixtures/hiringApplicants.json
@@ -1,0 +1,4 @@
+{
+  "accepted": [{ "id": "1" }],
+  "rejected": [{ "id": "2" }]
+}

--- a/tests/hiringDecisionsQA.spec.ts
+++ b/tests/hiringDecisionsQA.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import data from './fixtures/hiringApplicants.json';
+
+const enabled = process.env.NEXT_PUBLIC_ENABLE_HIRING_QA === 'true';
+const mode = process.env.ENGINE_MODE || 'mock';
+
+test.skip(!enabled || mode !== 'mock', 'Hiring decisions QA disabled');
+
+test('hiring decisions closeout harness renders markers', async ({ page }) => {
+  await page.goto('/qa/hiring-decisions?auto=1');
+  const hired = page.getByTestId('status-hired');
+  await expect(hired).toHaveCount(data.accepted.length);
+  const rejected = page.getByTestId('status-not_selected');
+  await expect(rejected).toHaveCount(data.rejected.length);
+  await expect(page.getByTestId('closeout-preview')).toBeVisible();
+});

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -266,6 +266,26 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
   } else {
     console.log('[smoke] bulk rejection qa skipped');
   }
+  if (process.env.NEXT_PUBLIC_ENABLE_HIRING_QA === 'true') {
+    try {
+      const r = await fetchImpl(base + '/qa/hiring-decisions?auto=1');
+      const txt = await r.text();
+      if (
+        r.status === 200 &&
+        /data-testid="status-hired"/.test(txt) &&
+        /data-testid="status-not_selected"/.test(txt) &&
+        /data-testid="closeout-preview"/.test(txt)
+      ) {
+        console.log('[smoke] hiring decisions qa ok');
+      } else {
+        console.log('[smoke] hiring decisions qa', r.status);
+      }
+    } catch {
+      console.log('[smoke] hiring decisions qa failed');
+    }
+  } else {
+    console.log('[smoke] hiring decisions qa skipped');
+  }
   if (process.env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER_QA === 'true') {
     try {
       const r = await fetchImpl(base + '/qa/notifications-center?auto=1');


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_ENABLE_HIRING_QA` flag and docs
- expose `data-testid` markers for employer applicant list and bulk actions
- introduce hiring decisions QA page, Playwright spec, and smoke check

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx playwright test tests/hiringDecisionsQA.spec.ts`
- `BASE=https://app.quickgig.ph node tools/smoke.mjs` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a33d66b5ec8327ae4814bc0a74d008