### PR TITLE
chore(i18n): Localization polish and marketing copy update (flagged)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,3 +136,6 @@ NEXT_PUBLIC_ENABLE_STATUS_PAGE=false
 
 # Security + monitoring (OFF by default)
 NEXT_PUBLIC_ENABLE_SECURITY_AUDIT=false
+
+# Localization + content polish (OFF by default)
+NEXT_PUBLIC_ENABLE_I18N_POLISH=false

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ Rollback: set `NEXT_PUBLIC_ENABLE_SECURITY_AUDIT=false` and redeploy.
 
 Notes: works in mock and php engine modes; logs request metrics to console.
 
+### Localization & Content Polish (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_I18N_POLISH` – refine EN/Taglish strings and marketing copy on landing pages.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_I18N_POLISH=true
+```
+
+Then run:
+
+```
+BASE=http://localhost:3000 npm run smoke
+```
+
+Rollback: set `NEXT_PUBLIC_ENABLE_I18N_POLISH=false` and redeploy.
+
+Notes: polish-only, safe rollback by disabling flag.
+
 ### Apply Flow Happy Path Audit (Flagged)
 
 - `NEXT_PUBLIC_ENABLE_APPLY_FLOW_AUDIT` – run snapshot tests for the Apply flow in mock mode. Dev/test only.

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -8,6 +8,7 @@ import { Briefcase, MousePointerClick, Shield } from 'lucide-react';
 import { checkHealth } from '@/lib/api';
 import { track } from '@/lib/track';
 import { env } from '@/config/env';
+import { t } from '@/lib/i18n';
 
 type ApiStatus = 'loading' | 'ok' | 'error';
 
@@ -24,19 +25,29 @@ export default function HomePageClient() {
       });
   }, []);
 
-  const features = [
-    { title: 'Post a gig in minutes', icon: Briefcase },
-    { title: 'Apply with one tap', icon: MousePointerClick },
-    { title: 'Secure messaging & updates', icon: Shield },
-  ];
+  const enable = env.NEXT_PUBLIC_ENABLE_I18N_POLISH;
+  const features = enable
+    ? [
+        { title: t('marketing.home.features.post'), icon: Briefcase },
+        { title: t('marketing.home.features.apply'), icon: MousePointerClick },
+        { title: t('marketing.home.features.secure'), icon: Shield },
+      ]
+    : [
+        { title: 'Post a gig in minutes', icon: Briefcase },
+        { title: 'Apply with one tap', icon: MousePointerClick },
+        { title: 'Secure messaging & updates', icon: Shield },
+      ];
 
   return (
     <div>
       <section className="hero text-fg">
         <div className="qg-container text-center py-24">
           <h1 className="font-heading text-6xl font-bold mb-4">QuickGig</h1>
-          <p className="font-body text-xl mb-8 text-fg opacity-90">
-            Gigs and talent, matched fast.
+          <p
+            className="font-body text-xl mb-8 text-fg opacity-90"
+            data-testid="home-tagline"
+          >
+            {enable ? t('marketing.home.tagline') : 'Gigs and talent, matched fast.'}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/register">
@@ -45,9 +56,9 @@ export default function HomePageClient() {
                 variant="secondary"
                 className="text-lg"
                 data-cta="signup"
-                data-testid="primary-cta"
+                data-testid="home-primary-cta"
               >
-                Simulan Na!
+                {enable ? t('marketing.home.cta.primary') : 'Simulan Na!'}
               </Button>
             </Link>
             <Link href="/find-work">
@@ -56,8 +67,9 @@ export default function HomePageClient() {
                 variant="outline"
                 className="text-lg border-fg text-fg hover:bg-fg hover:text-bg"
                 data-cta="browse-jobs"
+                data-testid="home-secondary-cta"
               >
-                Browse Jobs
+                {enable ? t('marketing.home.cta.secondary') : 'Browse Jobs'}
               </Button>
             </Link>
           </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { t } from '@/lib/i18n';
+import { env } from '@/config/env';
+
+export const metadata: Metadata = {
+  title: 'About QuickGig',
+  description: env.NEXT_PUBLIC_ENABLE_I18N_POLISH
+    ? 'Learn how QuickGig connects gig workers and employers fast.'
+    : 'QuickGig connects gigs and talent fast.',
+};
+
+export default function AboutPage() {
+  const enable = env.NEXT_PUBLIC_ENABLE_I18N_POLISH;
+  return (
+    <main className="qg-container py-12">
+      <h1 className="text-3xl font-heading mb-4" data-testid="about-heading">
+        {enable ? t('marketing.about.heading') : 'About QuickGig'}
+      </h1>
+      <p className="text-lg font-body" data-testid="about-tagline">
+        {enable
+          ? t('marketing.about.body')
+          : 'QuickGig connects gig workers with employers fast.'}
+      </p>
+    </main>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 import HomePageClient from './HomePageClient';
+import { env } from '@/config/env';
 
 export const metadata: Metadata = {
   title: 'QuickGig',
-  description: 'Gigs and talent, matched fast.',
+  description: env.NEXT_PUBLIC_ENABLE_I18N_POLISH
+    ? 'Fast-track your next gig with QuickGig.'
+    : 'Gigs and talent, matched fast.',
 };
 
 export default async function Page() {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -104,6 +104,8 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_STATUS_PAGE ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_SECURITY_AUDIT:
     String(process.env.NEXT_PUBLIC_ENABLE_SECURITY_AUDIT ?? 'false').toLowerCase() === 'true',
+  NEXT_PUBLIC_ENABLE_I18N_POLISH:
+    String(process.env.NEXT_PUBLIC_ENABLE_I18N_POLISH ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_PAYMENTS:
     String(process.env.NEXT_PUBLIC_ENABLE_PAYMENTS ?? 'false').toLowerCase() === 'true',
   NEXT_PUBLIC_ENABLE_GCASH:

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,4 +1,6 @@
 import { getPrefs } from './prefs';
+import enPolish from './i18n/en.json';
+import tlPolish from './i18n/tl.json';
 
 const strings = {
   en: {
@@ -404,6 +406,11 @@ const strings = {
     },
   },
 };
+
+if (process.env.NEXT_PUBLIC_ENABLE_I18N_POLISH === 'true') {
+  Object.assign(strings.en, enPolish);
+  Object.assign(strings.tl, tlPolish);
+}
 
 function copyVariant(): 'english' | 'taglish' {
   let variant = getPrefs().copy;

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -1,0 +1,20 @@
+{
+  "marketing": {
+    "home": {
+      "tagline": "Fast-track your next gig.",
+      "features": {
+        "post": "Post gigs in minutes",
+        "apply": "Apply with one tap",
+        "secure": "Secure messaging & updates"
+      },
+      "cta": {
+        "primary": "Get started",
+        "secondary": "Browse jobs"
+      }
+    },
+    "about": {
+      "heading": "About QuickGig",
+      "body": "QuickGig connects gig workers with employers fast."
+    }
+  }
+}

--- a/src/lib/i18n/tl.json
+++ b/src/lib/i18n/tl.json
@@ -1,0 +1,20 @@
+{
+  "marketing": {
+    "home": {
+      "tagline": "Bilis ang next gig mo.",
+      "features": {
+        "post": "Mag-post ng gig nang mabilis",
+        "apply": "Mag-apply sa isang tap",
+        "secure": "Secure ang usapan at updates"
+      },
+      "cta": {
+        "primary": "Simulan na",
+        "secondary": "Hanap trabaho"
+      }
+    },
+    "about": {
+      "heading": "Tungkol sa QuickGig",
+      "body": "Kinokonekta ng QuickGig ang mga gig worker at employer nang mabilis."
+    }
+  }
+}

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -333,6 +333,28 @@ const bail = (m)=>{ console.error(m); process.exit(1); };
   } else {
     console.log('[smoke] notify center qa skipped');
   }
+  if (process.env.SMOKE_URL && process.env.NEXT_PUBLIC_ENABLE_I18N_POLISH === 'true') {
+    try {
+      const en = await fetchImpl(base + '/?lang=english');
+      const enTxt = await en.text();
+      const tl = await fetchImpl(base + '/?lang=taglish');
+      const tlTxt = await tl.text();
+      if (
+        en.status === 200 &&
+        tl.status === 200 &&
+        /data-testid="home-tagline">Fast-track your next gig\./.test(enTxt) &&
+        /data-testid="home-tagline">Bilis ang next gig mo\./.test(tlTxt)
+      ) {
+        console.log('[smoke] i18n polish ok');
+      } else {
+        console.log('[smoke] i18n polish mismatch');
+      }
+    } catch {
+      console.log('[smoke] i18n polish failed');
+    }
+  } else {
+    console.log('[smoke] i18n polish skipped');
+  }
   console.log('Smoke OK');
   if (process.env.SMOKE_REPORTS === '1') {
     try {


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_ENABLE_I18N_POLISH` flag and wiring for marketing copy polish
- refine EN/Taglish strings for home and about pages with data-testid markers
- extend smoke script to audit new strings when the flag is enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3468f2fa8832787a519276c47b46b