### PR TITLE
chore(release): Public launch prep (enable core flags in prod)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,31 @@
+# Production environment example
+ENGINE_MODE=php
+ENGINE_BASE_URL=https://api.quickgig.ph
+ENGINE_LOGIN_PATH=/api/session/login
+ENGINE_LOGOUT_PATH=/api/session/logout
+NEXT_PUBLIC_CANONICAL_HOST=app.quickgig.ph
+ALLOW_ENGINE_FALLBACK=true
+
+# Backend base URLs
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+API_URL=https://api.quickgig.ph
+
+# Auth
+JWT_COOKIE_NAME=auth_token
+
+# Core launch flags (ON by default in production)
+NEXT_PUBLIC_ENABLE_EMAILS=true
+NEXT_PUBLIC_ENABLE_NOTIFY_CENTER=true
+NEXT_PUBLIC_ENABLE_INTERVIEWS=true
+NEXT_PUBLIC_ENABLE_INTERVIEW_INVITES=true
+NEXT_PUBLIC_ENABLE_INTERVIEW_REMINDERS=true
+NEXT_PUBLIC_ENABLE_PAYMENTS=true
+
+# Engine-backed features
+NEXT_PUBLIC_ENABLE_ENGINE_AUTH=true
+NEXT_PUBLIC_ENABLE_ENGINE_PROFILE=true
+NEXT_PUBLIC_ENABLE_ENGINE_APPS=true
+NEXT_PUBLIC_ENABLE_ENGINE_APPLY=true
+
+# Security + monitoring
+NEXT_PUBLIC_ENABLE_SECURITY_AUDIT=true

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 !.env.example
 !.env.local
 !.env.staging
+!.env.production.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -66,6 +66,32 @@ The app targets a PHP engine in staging but keeps mock flows as a safety net.
 When the engine is unreachable or returns non‑2xx responses, the app
 automatically falls back to existing mock or legacy flows.
 
+## Public Launch Prep
+
+The production build enables core launch features by default when `NODE_ENV=production`:
+
+- Emails
+- Unified Notifications Center
+- Interviews with invites and reminders
+- Payments
+
+### Rollout
+
+1. Copy `.env.production.example` to `.env.production` and add secrets.
+2. Deploy with `NODE_ENV=production`.
+3. Run smoke tests:
+
+   ```bash
+   NODE_ENV=production BASE=https://app.quickgig.ph npm run smoke
+   ```
+
+### Rollback
+
+1. Set the launch flags above to `false` in `.env.production`.
+2. Redeploy.
+
+Security headers and monitoring remain active via `NEXT_PUBLIC_ENABLE_SECURITY_AUDIT` and are covered by the smoke script.
+
 ## Flags
 
 ### Beta Release Toggle (Flagged)

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -12,12 +12,20 @@ export const flags = {
   stripe: env.NEXT_PUBLIC_ENABLE_STRIPE,
 };
 
-if (flags.beta) {
+const enableCore = () => {
   flags.emails = true;
   flags.notifyCenter = true;
   flags.interviews = true;
   flags.interviewInvites = true;
   flags.interviewReminders = true;
   flags.payments = true;
+};
+
+if (process.env.NODE_ENV === 'production') {
+  enableCore();
+}
+
+if (flags.beta) {
+  enableCore();
 }
 

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -2,13 +2,15 @@ const base = process.env.SMOKE_URL || process.env.BASE || 'http://localhost:3000
 const fetchImpl = globalThis.fetch;
 const bail = (m)=>{ console.error(m); process.exit(1); };
 const beta = process.env.NEXT_PUBLIC_ENABLE_BETA_RELEASE === 'true';
-if (beta) {
+const isProd = process.env.NODE_ENV === 'production';
+if (beta || isProd) {
   process.env.NEXT_PUBLIC_ENABLE_EMAILS = 'true';
   process.env.NEXT_PUBLIC_ENABLE_NOTIFY_CENTER = 'true';
   process.env.NEXT_PUBLIC_ENABLE_INTERVIEWS = 'true';
   process.env.NEXT_PUBLIC_ENABLE_INTERVIEW_INVITES = 'true';
   process.env.NEXT_PUBLIC_ENABLE_INTERVIEW_REMINDERS = 'true';
   process.env.NEXT_PUBLIC_ENABLE_PAYMENTS = 'true';
+  process.env.NEXT_PUBLIC_ENABLE_SECURITY_AUDIT = 'true';
 }
 (async () => {
   const r1 = await fetchImpl(base + '/', { method: 'HEAD', redirect: 'manual' });


### PR DESCRIPTION
## Summary
- enable emails, notifications center, interviews (invites & reminders), and payments when `NODE_ENV=production`
- add production env example and ensure smoke script runs full suite in production
- document public launch rollout/rollback steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39f86608c83279bd273e187404588