### PR TITLE
feat(monitoring): Post-launch monitoring & analytics (flagged)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,10 @@ NEXT_PUBLIC_ENABLE_SECURITY_AUDIT=false
 
 # Localization + content polish (OFF by default)
 NEXT_PUBLIC_ENABLE_I18N_POLISH=false
+
+# Post-launch monitoring & analytics (OFF by default)
+NEXT_PUBLIC_ENABLE_MONITORING=false
+
+# Optional integrations
+SENTRY_DSN=
+MIXPANEL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -158,6 +158,28 @@ Rollback: set `NEXT_PUBLIC_ENABLE_SECURITY_AUDIT=false` and redeploy.
 
 Notes: works in mock and php engine modes; logs request metrics to console.
 
+### Post-Launch Monitoring & Analytics (Flagged)
+
+- `NEXT_PUBLIC_ENABLE_MONITORING` – enable Sentry error tracking, basic performance metrics, and product analytics stubs.
+
+Enable locally by setting in `.env.local`:
+
+```
+NEXT_PUBLIC_ENABLE_MONITORING=true
+SENTRY_DSN=your-sentry-dsn
+MIXPANEL_TOKEN=your-mixpanel-token
+```
+
+Then run:
+
+```
+BASE=http://localhost:3000 npm run smoke
+```
+
+Rollback: set `NEXT_PUBLIC_ENABLE_MONITORING=false` and redeploy.
+
+Notes: skips integrations when env vars are missing; logs to console in mock mode only.
+
 ### Localization & Content Polish (Flagged)
 
 - `NEXT_PUBLIC_ENABLE_I18N_POLISH` – refine EN/Taglish strings and marketing copy on landing pages.

--- a/src/app/ClientBootstrap.tsx
+++ b/src/app/ClientBootstrap.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useEffect } from 'react';
+import { initMonitoring } from '@/lib/monitoring';
 
 const reAuth = /^https?:\/\/(api\.)?quickgig\.ph\/(auth\/)?(login|register|me)\.php/i;
 
 export default function ClientBootstrap() {
   useEffect(() => {
+    initMonitoring();
     // Intercept fetch
     const origFetch = window.fetch;
     window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -96,6 +96,9 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased bg-bg text-fg">
         <ClientBootstrap />
+        {env.NEXT_PUBLIC_ENABLE_MONITORING && (
+          <span data-testid="monitoring-flag" className="hidden" />
+        )}
         <AuthProvider>
           <SocketProvider>
             <ToastProvider>

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -133,6 +133,10 @@ export const env = {
     String(process.env.NEXT_PUBLIC_ENABLE_STRIPE ?? 'false').toLowerCase() === 'true',
   STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY || '',
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || '',
+  NEXT_PUBLIC_ENABLE_MONITORING:
+    String(process.env.NEXT_PUBLIC_ENABLE_MONITORING ?? 'false').toLowerCase() === 'true',
+  SENTRY_DSN: process.env.SENTRY_DSN || '',
+  MIXPANEL_TOKEN: process.env.MIXPANEL_TOKEN || '',
 };
 // In dev, warn about missing values (never throw in production)
 if (process.env.NODE_ENV !== 'production') {

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -1,0 +1,93 @@
+import { env } from '@/config/env';
+
+let inited = false;
+
+export function initMonitoring() {
+  if (inited) return;
+  inited = true;
+
+  if (!env.NEXT_PUBLIC_ENABLE_MONITORING) return;
+
+  const isMock =
+    process.env.ENGINE_MODE !== 'php' &&
+    process.env.NEXT_PUBLIC_ENGINE_MODE !== 'php';
+
+  if (typeof window !== 'undefined' && isMock) {
+    // eslint-disable-next-line no-console
+    console.log('[monitoring] active');
+  }
+
+  initSentry();
+  initMixpanel(isMock);
+  initWebVitals();
+  trackEvent('app_loaded');
+}
+
+async function initSentry() {
+  if (!env.SENTRY_DSN) return;
+  try {
+    const pkg = '@sentry/nextjs';
+    const Sentry = await import(pkg);
+    (Sentry as { init?: (opt: Record<string, unknown>) => void }).init?.({
+      dsn: env.SENTRY_DSN,
+      tracesSampleRate: 1.0,
+    });
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn('[monitoring] sentry unavailable');
+  }
+}
+
+function initMixpanel(isMock: boolean) {
+  if (!env.MIXPANEL_TOKEN) {
+    if (isMock && typeof window !== 'undefined') {
+      // eslint-disable-next-line no-console
+      console.log('[monitoring] mixpanel token missing');
+    }
+    return;
+  }
+  const mpPkg = 'mixpanel-browser';
+  import(mpPkg)
+    .then((m: { init?: (token: string) => void }) => m.init?.(env.MIXPANEL_TOKEN))
+    .catch(() => {
+      if (isMock && typeof window !== 'undefined') {
+        // eslint-disable-next-line no-console
+        console.warn('[monitoring] mixpanel init failed');
+      }
+    });
+}
+
+function initWebVitals() {
+    const vitalsPkg = 'web-vitals';
+    import(vitalsPkg)
+      .then(({ onCLS, onFID, onLCP }) => {
+        type VitalsMetric = { name: string; value: number };
+        const log = (metric: VitalsMetric) => {
+          if (typeof window !== 'undefined') {
+            // eslint-disable-next-line no-console
+            console.log('[monitoring][vitals]', metric.name, metric.value);
+          }
+        };
+        onCLS(log);
+        onFID(log);
+        onLCP(log);
+      })
+      .catch(() => {
+        /* no-op */
+      });
+}
+
+export function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (!env.NEXT_PUBLIC_ENABLE_MONITORING) return;
+  const mp =
+    (typeof window !== 'undefined' &&
+      (window as unknown as {
+        mixpanel?: { track?: (n: string, p?: Record<string, unknown>) => void };
+      }).mixpanel) ||
+    null;
+  if (mp?.track) mp.track(name, props);
+  else if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.log('[monitoring][event]', name, props);
+  }
+}

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -20,6 +20,15 @@ if (beta || isProd) {
   if (![301,302,307,308].includes(r2.status)) bail(`HEAD /app expected redirect; got ${r2.status}`);
   const loc = r2.headers.get('location') || '';
   if (loc !== '/' && loc !== base + '/') bail(`HEAD /app location must be root; got ${loc}`);
+  const home = await fetchImpl(base + '/');
+  const homeTxt = await home.text();
+  if (process.env.NEXT_PUBLIC_ENABLE_MONITORING === 'true') {
+    if (/data-testid="monitoring-flag"/.test(homeTxt)) console.log('[smoke] monitoring on');
+    else console.log('[smoke] monitoring missing');
+  } else {
+    if (/data-testid="monitoring-flag"/.test(homeTxt)) console.log('[smoke] monitoring off unexpected');
+    else console.log('[smoke] monitoring off ok');
+  }
   if (process.env.NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY === 'true') {
     try {
       const mod = await import('./linkMapSanity.mjs');

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,2 +1,23 @@
 declare global { interface Notification { read?: boolean } }
+
+declare module '@sentry/nextjs' {
+  // Minimal Sentry stub
+  export function init(options: Record<string, unknown>): void;
+}
+
+declare module '@vercel/analytics/react' {
+  import type { ComponentType } from 'react';
+  export const Analytics: ComponentType;
+}
+
+declare module 'mixpanel-browser' {
+  export function init(token: string): void;
+}
+
+declare module 'web-vitals' {
+  export function onCLS(cb: (metric: { name: string; value: number }) => void): void;
+  export function onFID(cb: (metric: { name: string; value: number }) => void): void;
+  export function onLCP(cb: (metric: { name: string; value: number }) => void): void;
+}
+
 export {};


### PR DESCRIPTION
## Summary
- add monitoring/analytics scaffolding with Sentry, web vitals, and Mixpanel stubs
- expose NEXT_PUBLIC_ENABLE_MONITORING flag with env docs
- smoke test checks monitoring flag toggle

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`
- `npm run build` (warnings: Critical dependency: the request of a dependency is an expression)
- `npm run smoke` (fails: fetch failed / ECONNREFUSED)


------
https://chatgpt.com/codex/tasks/task_e_68a3a9213fe48327b4552f7d9cc43d35