### PR TITLE
fix(auth+ci): PHP auth proxy (same-origin), gate smoke on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Backend base URLs
-NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+NEXT_PUBLIC_API_URL=https://quickgig.ph
 API_URL=https://api.quickgig.ph
 
 # Auth

--- a/README.md
+++ b/README.md
@@ -31,12 +31,20 @@ To verify the live API locally, run:
 BASE=https://api.quickgig.ph node tools/check_live_api.mjs
 ```
 
+### Auth Proxy
+
+Frontend auth calls use same-origin routes (`/api/session/*`) that proxy to
+`NEXT_PUBLIC_API_URL`. This removes CORS/preflight issues and keeps `Set-Cookie`
+headers intact.
+
 ### Vercel Preview
 
-Preview deployments skip smoke and live API checks unless both
-`VERCEL_ENV=production` and `NEXT_PUBLIC_API_URL` are set. To exercise the API
-in a preview, provide `NEXT_PUBLIC_API_URL`; otherwise the checks log `skip` and
-exit successfully.
+Vercel builds skip smoke tests automatically. To run smoke locally or in CI,
+set `RUN_SMOKE=1` and provide a base URL:
+
+```bash
+RUN_SMOKE=1 SMOKE_BASE_URL=http://127.0.0.1:3000 npm run build
+```
 
 ### Quick Start: Staging
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "npm run smoke",
+    "postbuild": "node tools/postbuild_smoke_gate.mjs",
     "start": "next start -p 3000",
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings=0",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { login } from '@/lib/auth/client';
 
 export default function LoginPage() {
   const r = useRouter();
@@ -14,19 +15,11 @@ export default function LoginPage() {
     setErr('');
     setLoading(true);
     try {
-      const res = await fetch('/api/session/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (json?.ok) {
-        r.replace('/dashboard');
-        return;
-      }
-      setErr(json?.message || 'Invalid email or password');
-    } catch {
-      setErr('Auth service unreachable');
+      await login({ email, password });
+      r.replace('/dashboard');
+      return;
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Auth service unreachable');
     } finally {
       setLoading(false);
     }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -19,8 +19,7 @@ export default function RegisterPage() {
     if (!name || !email || !password) { setError('All fields are required'); return; }
     setLoading(true);
     try {
-      const data = await register({ name, email, password });
-      if (!data?.ok) throw new Error(data?.message || 'Registration failed');
+      await register({ name, email, password });
       if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('signup_success');
       router.push('/dashboard');
     } catch (err) {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -49,7 +49,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const login = async (data: LoginData) => {
-    await loginApi(data.email, data.password);
+    await loginApi({ email: data.email, password: data.password });
     await fetchMe();
   };
 

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -2,23 +2,32 @@
 
 async function json(res: Response) { return res.json().catch(() => ({})); }
 
-export async function login(email: string, password: string) {
-  const r = await fetch('/api/session/login', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }), credentials: 'same-origin',
+export async function login(payload: URLSearchParams | Record<string, string>) {
+  const body = payload instanceof URLSearchParams ? payload : new URLSearchParams(payload);
+  const res = await fetch('/api/session/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    credentials: 'include',
   });
-  return json(r);
+  if (!res.ok) throw new Error(`Login failed: ${res.status}`);
+  return res;
 }
 
-export async function register(payload: { email: string; password: string; name?: string }) {
-  const r = await fetch('/api/session/register', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload), credentials: 'same-origin',
+export async function register(payload: URLSearchParams | Record<string, string>) {
+  const body = payload instanceof URLSearchParams ? payload : new URLSearchParams(payload);
+  const res = await fetch('/api/session/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    credentials: 'include',
   });
-  return json(r);
+  if (!res.ok) throw new Error(`Register failed: ${res.status}`);
+  return res;
 }
 
 export async function me() {
-  const r = await fetch('/api/session/me', { credentials: 'same-origin' });
+  const r = await fetch('/api/session/me', { credentials: 'include' });
   return json(r);
 }
+

--- a/tools/postbuild_smoke_gate.mjs
+++ b/tools/postbuild_smoke_gate.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const isVercel = !!process.env.VERCEL;
+const env = process.env.VERCEL_ENV || 'unknown';
+if (isVercel) {
+  console.log(`[postbuild] skip smoke on Vercel build (${env})`);
+  process.exit(0);
+}
+if (process.env.RUN_SMOKE !== '1') {
+  console.log('[postbuild] skip smoke: RUN_SMOKE!=1');
+  process.exit(0);
+}
+const { spawn } = await import('node:child_process');
+const base = process.env.SMOKE_BASE_URL || 'http://127.0.0.1:3000';
+process.env.SMOKE_BASE_URL = base;
+spawn('npm', ['run', 'smoke'], { stdio: 'inherit', env: process.env }).on('exit',
+  (c) => process.exit(c ?? 1)
+);

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -7,7 +7,8 @@ if (!process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_API_URL.trim() =
   console.log('skip: no API URL');
   process.exit(0);
 }
-const base = process.env.SMOKE_URL || process.env.BASE || 'http://localhost:3000';
+const base =
+  process.env.SMOKE_BASE_URL || process.env.SMOKE_URL || process.env.BASE || 'http://localhost:3000';
 const TIMEOUT = 5000;
 const fetchImpl = async (url, init) => {
   try {


### PR DESCRIPTION
## Summary
- route login and registration through same-origin `/api/session/*` proxies
- skip smoke tests on Vercel builds via `postbuild` gate and `RUN_SMOKE`
- document auth proxy usage and optional smoke step

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3beee69c48327a69d28e804dba361