### PR TITLE
fix(auth): enforce same-origin proxy for login/register (sweep + client interceptor + CI guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ headers intact.
 
 - Browser code **must only** call `/api/session/*` for auth.
 - A global client interceptor rewrites accidental `quickgig.ph/*.php` calls.
-- CI fails if `.php` auth endpoints are referenced from client code.
+- CI fails if `.php` auth endpoints are referenced from client code (`npm run guard:auth-proxy`).
 
 ### Vercel Preview
 

--- a/src/app/ClientBootstrap.tsx
+++ b/src/app/ClientBootstrap.tsx
@@ -2,72 +2,10 @@
 import { useEffect } from 'react';
 import { initMonitoring } from '@/lib/monitoring';
 
-const LOGIN_PHP = 'login.php';
-const REGISTER_PHP = 'register.php';
-
-function mapPhpToProxy(url: string): string | null {
-  try {
-    const u = new URL(url, window.location.origin);
-    const isPhp =
-      u.pathname.endsWith('/' + LOGIN_PHP) ||
-      u.pathname.endsWith('/' + REGISTER_PHP);
-    const isQG = /\.?quickgig\.ph$/i.test(u.hostname);
-    if (isPhp && isQG) {
-      if (u.pathname.endsWith('/' + LOGIN_PHP)) return '/api/session/login';
-      if (u.pathname.endsWith('/' + REGISTER_PHP)) return '/api/session/register';
-    }
-  } catch {}
-  return null;
-}
-
 export default function ClientBootstrap() {
   useEffect(() => {
     initMonitoring();
-
-    const origFetch = window.fetch.bind(window);
-    window.fetch = (async (
-      input: RequestInfo | URL,
-      init?: RequestInit
-    ) => {
-      const raw = typeof input === 'string' ? input : (input as Request)?.url ?? '';
-      const mapped = typeof raw === 'string' ? mapPhpToProxy(raw) : null;
-      if (mapped) {
-        init = { ...(init || {}), credentials: 'include' };
-        input = mapped;
-        // eslint-disable-next-line no-console
-        console.warn('[auth-intercept] Rewrote cross-origin PHP call to', mapped);
-      }
-      return origFetch(input as RequestInfo, init);
-    }) as typeof fetch;
-
-    const fixForms = () => {
-      document.querySelectorAll('form[action]').forEach((f) => {
-        const form = f as HTMLFormElement;
-        const a = form.getAttribute('action') || '';
-        const mapped = mapPhpToProxy(a);
-        if (mapped) {
-          form.setAttribute('action', mapped);
-          form.method = 'post';
-          form.noValidate = form.noValidate;
-          // eslint-disable-next-line no-console
-          console.warn('[auth-intercept] Rewrote form action to', mapped);
-        }
-      });
-    };
-    fixForms();
-    const obs = new MutationObserver(fixForms);
-    obs.observe(document.documentElement, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: ['action'],
-    });
-    return () => {
-      window.fetch = origFetch;
-      obs.disconnect();
-    };
   }, []);
 
   return null;
 }
-

--- a/src/app/_components/AuthIntercept.tsx
+++ b/src/app/_components/AuthIntercept.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useEffect } from 'react';
+
+function mapPhpToProxy(url: string): string | null {
+  try {
+    const u = new URL(url, window.location.origin);
+    const isPhp =
+      u.pathname.endsWith('/login.php') || u.pathname.endsWith('/register.php');
+    const isQuickGig = /\.?quickgig\.ph$/i.test(u.hostname);
+    if (isPhp && isQuickGig) {
+      if (u.pathname.endsWith('/login.php')) return '/api/session/login';
+      if (u.pathname.endsWith('/register.php')) return '/api/session/register';
+    }
+  } catch {}
+  return null;
+}
+
+export default function AuthIntercept() {
+  useEffect(() => {
+    // 1) fetch() rewrite
+    const origFetch = window.fetch.bind(window);
+    window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const raw =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+          ? input.href
+          : (input as Request).url;
+      const mapped = typeof raw === 'string' ? mapPhpToProxy(raw) : null;
+      if (mapped) {
+        init = { ...(init || {}), credentials: 'include' };
+        input = mapped;
+        console.warn('[auth-intercept] rewrote PHP auth call ->', mapped);
+      }
+      return origFetch(input, init);
+    }) as typeof fetch;
+
+    // 2) form action rewrite
+    const fixForms = () => {
+      document.querySelectorAll('form[action]').forEach((el) => {
+        const form = el as HTMLFormElement;
+        const a = form.getAttribute('action') || '';
+        const mapped = mapPhpToProxy(a);
+        if (mapped) {
+          form.setAttribute('action', mapped);
+          form.method = 'post';
+          console.warn('[auth-intercept] rewrote form action ->', mapped);
+        }
+      });
+    };
+    fixForms();
+    const obs = new MutationObserver(fixForms);
+    obs.observe(document.documentElement, { subtree: true, childList: true, attributes: true, attributeFilter: ['action'] });
+    return () => obs.disconnect();
+  }, []);
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 import { ToastProvider } from "../components/ToastProvider";
 import SettingsBanner from "../components/SettingsBanner";
 import ClientBootstrap from '@/app/ClientBootstrap';
+import AuthIntercept from './_components/AuthIntercept';
 import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
 import AppShellV2 from '@/components/layouts/AppShellV2';
@@ -95,6 +96,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
       <body className="font-body antialiased bg-bg text-fg">
+        <AuthIntercept />
         <ClientBootstrap />
         {env.NEXT_PUBLIC_ENABLE_MONITORING && (
           <span data-testid="monitoring-flag" className="hidden" />

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -6,7 +6,6 @@ import Button from '@/components/ui/Button';
 import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { toast } from '@/lib/toast';
-import { me } from '@/lib/auth';
 
 interface ProfileData {
   name: string;
@@ -36,7 +35,9 @@ export default function ProfileSettingsPage() {
   useEffect(() => {
     (async () => {
       try {
-        const d = await me();
+        const res = await fetch('/api/session/me', { credentials: 'include' });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const d: any = await res.json().catch(() => ({}));
         setData({
           name: d.name || '',
           headline: d.headline || '',

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
 import { api } from '@/lib/apiClient';
-import { login as loginApi, register as registerApi, me as meApi } from '@/lib/auth';
+import { login as loginApi, register as registerApi } from '@/lib/auth';
 
 interface AuthContextType {
   user: User | null;
@@ -35,7 +35,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const fetchMe = async () => {
     try {
-      const data = await meApi();
+      const res = await fetch('/api/session/me', { credentials: 'include' });
+      const data = await res.json().catch(() => ({}));
       const userData = (data.user || data) as User;
       if (userData && Object.keys(userData).length) setUser(userData);
       else setUser(null);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,15 +1,10 @@
-import { guardAgainstPhpOrigin } from './fetchGuard';
-
 export async function login(
   payload: URLSearchParams | Record<string, string>
 ) {
   const body =
-    payload instanceof URLSearchParams
-      ? payload
-      : new URLSearchParams(payload as Record<string, string>);
-  const url = '/api/session/login';
-  guardAgainstPhpOrigin(url);
-  const res = await fetch(url, {
+    payload instanceof URLSearchParams ? payload : new URLSearchParams(payload as Record<string, string>);
+
+  const res = await fetch('/api/session/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
@@ -23,12 +18,9 @@ export async function register(
   payload: URLSearchParams | Record<string, string>
 ) {
   const body =
-    payload instanceof URLSearchParams
-      ? payload
-      : new URLSearchParams(payload as Record<string, string>);
-  const url = '/api/session/register';
-  guardAgainstPhpOrigin(url);
-  const res = await fetch(url, {
+    payload instanceof URLSearchParams ? payload : new URLSearchParams(payload as Record<string, string>);
+
+  const res = await fetch('/api/session/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
@@ -36,32 +28,4 @@ export async function register(
   });
   if (!res.ok) throw new Error(`Register failed: ${res.status}`);
   return res;
-}
-
-export async function me() {
-  const url = '/api/session/me';
-  guardAgainstPhpOrigin(url);
-  const r = await fetch(url, { credentials: 'include' });
-  return r.json().catch(() => ({}));
-}
-
-export function saveToken(t: string) {
-  if (typeof window !== 'undefined') {
-    localStorage.setItem('auth_token', t);
-  }
-}
-
-export function getToken() {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem('auth_token');
-}
-
-export function clearAuth() {
-  if (typeof window !== 'undefined') {
-    localStorage.removeItem('auth_token');
-  }
-}
-
-export function isAuthed() {
-  return !!getToken();
 }

--- a/tools/guard_auth_proxy.mjs
+++ b/tools/guard_auth_proxy.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
-import { glob } from 'tinyglobby';
+import { glob } from 'node:fs/promises';
 import fs from 'node:fs/promises';
 
-const files = await glob(['src/**/*.{ts,tsx,js,jsx}','!src/app/api/**']);
+const files = [];
+for await (const f of glob('src/**/*.{ts,tsx,js,jsx}')) {
+  if (f.startsWith('src/app/api/')) continue;
+  if (f === 'src/app/_components/AuthIntercept.tsx') continue;
+  files.push(f);
+}
 const offenders = [];
 const re = /(https?:\/\/[^"'\s]*quickgig\.ph\/(login|register)\.php|\/(login|register)\.php)/i;
 
@@ -12,7 +17,7 @@ for (const f of files) {
 }
 
 if (offenders.length) {
-  console.error('\n[guard] Found client references to PHP auth endpoints. Use /api/session/* instead:\n');
+  console.error('\n[guard] Client references to PHP auth endpoints found. Use /api/session/* instead:\n');
   offenders.forEach((f) => console.error(' -', f));
   process.exit(1);
 } else {


### PR DESCRIPTION
## Summary
- centralize login/register helpers to call `/api/session/*`
- add client interceptor to rewrite stray PHP auth calls
- fail builds when client code references `login.php`/`register.php`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run guard:auth-proxy`


------
https://chatgpt.com/codex/tasks/task_e_68a3ca111ca48327840278bb65a5eb21