### PR TITLE
fix(ci): stop running smoke in postbuild on Vercel; add gated runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,3 +852,9 @@ Set the following in Vercel → Project → Settings → Environment Variables:
 
 After saving, redeploy via Vercel and verify at [`/system/status`](./src/app/system/status/page.tsx).
 To add a payment QR, upload `public/gcash-qr.png` and redeploy.
+
+### Smoke on Vercel
+Preview/Production builds skip smoke by default. To force:
+- Set build env `RUN_SMOKE=1`
+- Provide `SMOKE_BASE_URL` (e.g., your deployed URL)
+Locally, start the app then run: `SMOKE_BASE_URL=http://127.0.0.1:3000 RUN_SMOKE=1 npm run postbuild`

--- a/tools/smoke_gate.mjs
+++ b/tools/smoke_gate.mjs
@@ -1,53 +1,47 @@
 #!/usr/bin/env node
+// Decides whether to run smoke tests after build.
+// - Skips on Vercel (preview/prod) unless RUN_SMOKE=1
+// - Only runs smoke if SMOKE_BASE_URL (or local default) responds
+
 import { spawn } from 'node:child_process';
-import { setTimeout as sleep } from 'node:timers/promises';
 
 const {
-  VERCEL,
-  VERCEL_ENV,        // 'preview' | 'production' | 'development'
+  VERCEL,           // defined by Vercel
+  VERCEL_ENV,       // 'preview' | 'production' | 'development'
   CI,
-  RUN_SMOKE,         // set to '1' to force on CI/Vercel
+  RUN_SMOKE,        // set to '1' to force running smoke
   SMOKE_BASE_URL,
   SMOKE_TIMEOUT_MS = '5000',
 } = process.env;
 
-const isCI = CI === 'true' || !!VERCEL;
 const isVercel = !!VERCEL;
-const isVercelPreview = isVercel && VERCEL_ENV === 'preview';
-const isVercelProd = isVercel && VERCEL_ENV === 'production';
+const onVercelBuild = isVercel && (VERCEL_ENV === 'preview' || VERCEL_ENV === 'production');
 
-// 1) Default behavior: SKIP on Vercel builds unless explicitly enabled
-if (isVercel && RUN_SMOKE !== '1') {
-  console.log('[smoke-gate] Skipping smoke on Vercel (set RUN_SMOKE=1 to enable).');
+// Default: skip on Vercel builds unless explicitly enabled
+if (onVercelBuild && RUN_SMOKE !== '1') {
+  console.log('[smoke-gate] Skipping smoke on Vercel build (set RUN_SMOKE=1 to enable).');
   process.exit(0);
 }
 
-// 2) Decide base URL
-let base = SMOKE_BASE_URL;
-if (!base) {
-  // local default (only meaningful when you run smoke yourself)
-  base = 'http://127.0.0.1:3000';
-}
+// Choose base URL
+const base = SMOKE_BASE_URL || 'http://127.0.0.1:3000';
 
-// 3) Reachability probe (fail closed ONLY when we intended to run smoke)
-const timeoutMs = Number(SMOKE_TIMEOUT_MS);
-const controller = new AbortController();
-const t = setTimeout(() => controller.abort(), timeoutMs);
-
-async function probe(url) {
+async function reachable(url, timeoutMs) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), timeoutMs);
   try {
-    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
+    const res = await fetch(url, { signal: ctl.signal, cache: 'no-store' });
     clearTimeout(t);
     return !!res.ok || res.status >= 200;
   } catch {
     return false;
   }
 }
-const reachable = await probe(base);
 
-if (!reachable) {
+const ok = await reachable(base, Number(SMOKE_TIMEOUT_MS));
+if (!ok) {
   if (RUN_SMOKE === '1') {
-    console.error(`[smoke-gate] RUN_SMOKE=1 but ${base} is not reachable. Failing.`);
+    console.error(`[smoke-gate] RUN_SMOKE=1 but ${base} is not reachable. Failing build.`);
     process.exit(1);
   } else {
     console.log(`[smoke-gate] ${base} not reachable; skipping smoke.`);
@@ -55,7 +49,7 @@ if (!reachable) {
   }
 }
 
-// 4) Actually run our smoke script chain
 console.log(`[smoke-gate] Running smoke against ${base} ...`);
 const child = spawn('npm', ['run', 'smoke'], { stdio: 'inherit', shell: process.platform === 'win32' });
 child.on('exit', (code) => process.exit(code ?? 1));
+


### PR DESCRIPTION
## Summary
- add smoke gate script to skip tests on Vercel unless requested
- document how to run smoke on Vercel or locally

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d0fd899883279f8fd9d3529c870a