### PR TITLE
chore(domain): canonicalize to app.quickgig.ph + DNS/HTTP guards

### DIFF
--- a/.github/workflows/cutover.yml
+++ b/.github/workflows/cutover.yml
@@ -1,57 +1,27 @@
-name: Cutover app.quickgig.ph
+name: Cutover & Canonical Checks
 
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   cutover:
     runs-on: ubuntu-latest
-    env:
-      APP_DOMAIN: ${{ vars.APP_DOMAIN }}
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
-      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - name: Check credentials
-        run: |
-          : "${APP_DOMAIN:?APP_DOMAIN missing}" >/dev/null
-          : "${VERCEL_PROJECT_ID:?VERCEL_PROJECT_ID missing}" >/dev/null
-          : "${VERCEL_ORG_ID:?VERCEL_ORG_ID missing}" >/dev/null
-          : "${VERCEL_TOKEN:?VERCEL_TOKEN missing}" >/dev/null
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Install tools
+      - run: npm ci
+      - name: Ensure Vercel domains are attached (idempotent)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          sudo apt-get update && sudo apt-get install -y bind9-dnsutils jq
-          npm install -g vercel
-      - name: Add domain if missing
-        run: |
-          npx vercel --token "$VERCEL_TOKEN" projects ls >/dev/null 2>&1 || true
-          if ! npx vercel domains ls --token "$VERCEL_TOKEN" | grep -q "$APP_DOMAIN"; then
-            npx vercel domains add "$APP_DOMAIN" --token "$VERCEL_TOKEN" || echo "::warning::Could not auto-attach domain (missing perms?)."
-          fi
-          npx vercel domains inspect "$APP_DOMAIN" --token "$VERCEL_TOKEN" || true
-      - name: DNS must point to Vercel
-        run: |
-          set -e
-          TARGET="$(dig +short cname $APP_DOMAIN | sed 's/\.$//')"
-          if [ -z "$TARGET" ]; then
-            echo "::error::CNAME for $APP_DOMAIN not found. Point it to cname.vercel-dns.com"; exit 1
-          fi
-          if [ "$TARGET" != "cname.vercel-dns.com" ]; then
-            echo "::error::CNAME points to $TARGET (expected cname.vercel-dns.com)"; exit 1
-          fi
-      - name: Runtime verification
-        run: |
-          HTML=$(curl -fsSL "https://$APP_DOMAIN")
-          echo "$HTML" | grep -q "/_next/" || { echo "::error::No Next.js assets found in HTML"; exit 1; }
-          curl -I -s "https://$APP_DOMAIN" | grep -qi "x-vercel-id" || { echo "::error::x-vercel-id header missing (not a Vercel edge)"; exit 1; }
-          curl -s -o /dev/null -w "%{http_code}" "https://$APP_DOMAIN/api/session/me" | grep -Eq "200|401" || { echo "::error::/api/session/me not reachable"; exit 1; }
-      - name: Expose build metadata
-        run: |
-          echo "NEXT_PUBLIC_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "NEXT_PUBLIC_BUILD_TS=$(date +%s)000" >> $GITHUB_ENV
+          npx -y vercel --token "$VERCEL_TOKEN" domains add "${{ vars.APP_DOMAIN }}" --project "${{ vars.VERCEL_PROJECT_ID }}" || true
+          npx -y vercel --token "$VERCEL_TOKEN" domains add "${{ vars.APEX_DOMAIN }}" --project "${{ vars.VERCEL_PROJECT_ID }}" || true
+          npx -y vercel alias ls --token "$VERCEL_TOKEN" || true
+      - name: Verify DNS
+        run: npm run verify:dns
+      - name: Verify HTTP canonical behavior
+        run: npm run verify:http

--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
 - `quickgig.ph` and `www.quickgig.ph` are served by Vercel and issue a 308 to `https://app.quickgig.ph/:path*`
 - `app.quickgig.ph` is served by Vercel and hosts the modern app.
 
+## Cutover to Canonical Domain
+
+Configure the following DNS records on Hostinger:
+
+| Type | Host | Value |
+| --- | --- | --- |
+| A | @ | 76.76.21.21 |
+| CNAME | www | cname.vercel-dns.com |
+| CNAME | app | cname.vercel-dns.com |
+| A | api | 89.116.53.39 |
+
+Verify locally:
+
+```bash
+dig +short quickgig.ph A
+dig +short www.quickgig.ph CNAME
+dig +short app.quickgig.ph CNAME
+dig +short api.quickgig.ph A
+curl -I https://quickgig.ph/status
+curl -I https://www.quickgig.ph/status
+curl -I https://app.quickgig.ph/status
+```
+
+Redirects in [`vercel.json`](./vercel.json) guarantee canonical behavior even before the Vercel dashboard "Primary" setting is toggled.
+
 ### Cutover Checklist
 
 * Attach domain to project (Action attempts this automatically).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "playwright:install": "playwright install --with-deps",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/check_links.mjs",
-    "guard:auth-proxy": "node tools/guard_auth_proxy.mjs"
+    "guard:auth-proxy": "node tools/guard_auth_proxy.mjs",
+    "verify:dns": "node scripts/verify_dns.mjs",
+    "verify:http": "node scripts/verify_http.mjs",
+    "cutover:explain": "node -e \"console.log('A     @     76.76.21.21\\nCNAME www   cname.vercel-dns.com\\nCNAME app   cname.vercel-dns.com\\nA     api   89.116.53.39')\""
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/verify_dns.mjs
+++ b/scripts/verify_dns.mjs
@@ -1,0 +1,54 @@
+import { Resolver } from 'dns/promises';
+
+const resolver = new Resolver();
+
+const records = [
+  { name: 'quickgig.ph', type: 'A', expected: ['76.76.21.21'] },
+  { name: 'www.quickgig.ph', type: 'CNAME', expected: ['cname.vercel-dns.com'] },
+  { name: 'app.quickgig.ph', type: 'CNAME', expected: ['cname.vercel-dns.com'] },
+  { name: 'api.quickgig.ph', type: 'A', expected: ['89.116.53.39'] }
+];
+
+const table = [];
+let allOk = true;
+
+function compare(a, b) {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+for (const rec of records) {
+  let actual = [];
+  try {
+    if (rec.type === 'A') {
+      actual = await resolver.resolve4(rec.name);
+    } else if (rec.type === 'CNAME') {
+      actual = await resolver.resolveCname(rec.name);
+    }
+  } catch (err) {
+    actual = [];
+  }
+  const ok = compare(actual, rec.expected);
+  const actualStr = actual.join(', ') || '(none)';
+  const expectedStr = rec.expected.join(', ');
+  if (ok) {
+    console.log(`\u2705 ${rec.name} ${rec.type} \u2192 ${actualStr}`);
+  } else {
+    console.log(`\u274C ${rec.name} ${rec.type} expected ${expectedStr} but got ${actualStr}`);
+  }
+  table.push({ record: `${rec.name} ${rec.type}`, expected: expectedStr, actual: actualStr });
+  if (!ok) allOk = false;
+}
+
+if (!allOk) {
+  console.log('\nExpected DNS records:');
+  console.table(table);
+  console.log('\nPlease configure Hostinger with the following records:');
+  console.log('A     @     76.76.21.21');
+  console.log('CNAME www   cname.vercel-dns.com');
+  console.log('CNAME app   cname.vercel-dns.com');
+  console.log('A     api   89.116.53.39');
+  process.exit(1);
+}

--- a/scripts/verify_http.mjs
+++ b/scripts/verify_http.mjs
@@ -1,0 +1,49 @@
+import https from 'node:https';
+
+function head(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method: 'HEAD' }, (res) => {
+      resolve({ status: res.statusCode, location: res.headers.location });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function safeHead(url) {
+  try {
+    return await head(url);
+  } catch (error) {
+    return { error };
+  }
+}
+
+let ok = true;
+
+const app = await safeHead('https://app.quickgig.ph/');
+if (!app.error && (app.status === 200 || ([301, 308].includes(app.status) && app.location && new URL(app.location).host === 'app.quickgig.ph'))) {
+  console.log(`\u2705 app.quickgig.ph responded with status ${app.status}`);
+} else {
+  const msg = app.error ? `request failed: ${app.error.code || app.error.message}` : `status ${app.status}${app.location ? ' and Location ' + app.location : ''}`;
+  console.log(`\u274C app.quickgig.ph ${msg}`);
+  ok = false;
+}
+const apex = await safeHead('https://quickgig.ph/any');
+if (!apex.error && [301, 308].includes(apex.status) && apex.location === 'https://app.quickgig.ph/any') {
+  console.log('\u2705 quickgig.ph redirects to app.quickgig.ph');
+} else {
+  const msg = apex.error ? `request failed: ${apex.error.code || apex.error.message}` : `status ${apex.status}${apex.location ? ' and Location ' + apex.location : ''}`;
+  console.log(`\u274C quickgig.ph ${msg}`);
+  ok = false;
+}
+
+const www = await safeHead('https://www.quickgig.ph/any');
+if (!www.error && [301, 308].includes(www.status) && www.location === 'https://app.quickgig.ph/any') {
+  console.log('\u2705 www.quickgig.ph redirects to app.quickgig.ph');
+} else {
+  const msg = www.error ? `request failed: ${www.error.code || www.error.message}` : `status ${www.status}${www.location ? ' and Location ' + www.location : ''}`;
+  console.log(`\u274C www.quickgig.ph ${msg}`);
+  ok = false;
+}
+
+if (!ok) process.exit(1);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "redirects": [
+    { "source": "https://quickgig.ph/:path*", "destination": "https://app.quickgig.ph/:path*", "permanent": true },
+    { "source": "https://www.quickgig.ph/:path*", "destination": "https://app.quickgig.ph/:path*", "permanent": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- enforce app.quickgig.ph as canonical via Vercel redirects
- add DNS/HTTP verification scripts and CI workflow
- document Hostinger DNS records and verification commands

## Testing
- `npm run verify:dns` *(fails: quickgig.ph A expected 76.76.21.21 but got 89.116.53.39; www/app CNAME missing)*
- `npm run verify:http` *(fails: ENETUNREACH for app.quickgig.ph, quickgig.ph, www.quickgig.ph)*

## Checklist
- [ ] DNS records updated on Hostinger
- [ ] `npm run verify:dns`
- [ ] `npm run verify:http`

## How to cut over
1. Point Hostinger DNS as documented in README.
2. Run the "Cutover & Canonical Checks" workflow or push to main to validate DNS/HTTP.
3. Once green, the app will redirect all traffic to https://app.quickgig.ph.


------
https://chatgpt.com/codex/tasks/task_e_68a41051b51883279c6085126a5ee7c3