### PR TITLE
chore(domain): canonicalize to app.quickgig.ph via Next.js redirects (+ docs + verify script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,3 +864,15 @@ Preview/Production builds skip smoke by default. To force:
 - Set build env `RUN_SMOKE=1`
 - Provide `SMOKE_BASE_URL` (e.g., your deployed URL)
 Locally, start the app then run: `SMOKE_BASE_URL=http://127.0.0.1:3000 RUN_SMOKE=1 npm run postbuild`
+
+## Canonical host & DNS
+
+### DNS required
+- `app.quickgig.ph` → `CNAME cname.vercel-dns.com`
+- `quickgig.ph` (apex) → `A 76.76.21.21` (Vercel)
+- `www.quickgig.ph` → `CNAME cname.vercel-dns.com`
+- Remove any `A` records for `app`/`www` that point to old IPs (e.g., `89.116.53.39`)
+
+### Redirect behavior
+- `quickgig.ph/*` and `www.quickgig.ph/*` → 308 to `https://app.quickgig.ph/*`
+- Implemented in `next.config.mjs`, **not** `vercel.json`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,13 +5,24 @@ const enableSecurity =
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async redirects() {
-    return [
+    const rules = [
+      // quickgig.ph → app.quickgig.ph
       {
         source: '/:path*',
+        has: [{ type: 'host', value: 'quickgig.ph' }],
         destination: 'https://app.quickgig.ph/:path*',
-        permanent: true, // use 308 on Vercel
+        permanent: true,
+      },
+      // www.quickgig.ph → app.quickgig.ph
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'www.quickgig.ph' }],
+        destination: 'https://app.quickgig.ph/:path*',
+        permanent: true,
       },
     ];
+
+    return [...rules];
   },
   async headers() {
     if (!enableSecurity) return [];
@@ -35,4 +46,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/next.config.mjs.bak
+++ b/next.config.mjs.bak
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "playwright:install": "playwright install --with-deps",
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/check_links.mjs",
-    "guard:auth-proxy": "node tools/guard_auth_proxy.mjs"
+    "guard:auth-proxy": "node tools/guard_auth_proxy.mjs",
+    "verify:http:apex": "node scripts/verify_http.mjs quickgig.ph",
+    "verify:http:www": "node scripts/verify_http.mjs www.quickgig.ph"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/verify_http.mjs
+++ b/scripts/verify_http.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Usage:
+ *   node scripts/verify_http.mjs quickgig.ph
+ *   node scripts/verify_http.mjs www.quickgig.ph
+ *
+ * Exits 0 if host 308-redirects to https://app.quickgig.ph/, else 1.
+ */
+import { execSync } from 'node:child_process';
+
+const host = process.argv[2];
+if (!host) {
+  console.error('Host required'); process.exit(2);
+}
+
+try {
+  const out = execSync(`curl -sSI https://${host}/ | tr -d '\r'`, { stdio: 'pipe' }).toString();
+  const has308 = /HTTP\/\d\.\d 308/.test(out);
+  const toApp = /Location:\s*https:\/\/app\.quickgig\.ph\//i.test(out);
+  if (has308 && toApp) {
+    console.log(`[ok] ${host} → app.quickgig.ph (308)`);
+    process.exit(0);
+  }
+  console.error('[fail] Unexpected response:\n' + out);
+  process.exit(1);
+} catch (e) {
+  console.error('[fail] Request error:\n' + (e.stdout?.toString() || e.message));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- canonicalize quickgig.ph and www.quickgig.ph to app.quickgig.ph using host-based Next.js redirects
- document DNS expectations and redirect behavior
- add curl-based verify_http helper and npm scripts

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run verify:http:apex` *(fails: HTTP/1.1 403 Forbidden)*
- `npm run verify:http:www` *(fails: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a412ab3f888327b5dfc8d57c9ac0b6