### PR TITLE
Proxy API calls through /gate and improve health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ headers intact.
 - A global client interceptor rewrites accidental `quickgig.ph/*.php` calls.
 - CI fails if `.php` auth endpoints are referenced from client code.
 
+### API proxy
+
+Set `NEXT_PUBLIC_GATE_ORIGIN` in Vercel → Environment Variables. All API
+requests should use `/gate/...`, which rewrites to the external API origin.
+Optionally verify locally with `npm run verify:api` while the dev server is running.
+
 ### Smoke Gate on Vercel
 
 - Preview/Production builds skip smoke by default.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,10 @@ const enableSecurity =
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async rewrites() {
+    const GATE = process.env.NEXT_PUBLIC_GATE_ORIGIN || 'https://api.quickgig.ph';
+    return [{ source: '/gate/:path*', destination: `${GATE}/:path*` }];
+  },
   async redirects() {
     const rules = [
       // quickgig.ph → app.quickgig.ph

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "scan:appdomain": "node tools/scan_app_domain.mjs",
     "scan:links": "node tools/check_links.mjs",
     "guard:auth-proxy": "node tools/guard_auth_proxy.mjs",
-    "verify:http": "node scripts/verify_http.mjs"
+    "verify:http": "node scripts/verify_http.mjs",
+    "verify:api": "node -e \"fetch('http://127.0.0.1:3000/gate/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\""
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { API } from '@/config/api';
-import { env } from '@/config/env';
+import { apiGet } from '@/lib/api';
 
 interface AuditItem {
   at: string;
@@ -17,9 +17,8 @@ export default function AdminAuditPage() {
   const [view, setView] = useState<AuditItem | null>(null);
 
   useEffect(() => {
-    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminAuditList}`)
-      .then((r) => r.json())
-      .then((d) => setItems((d.items as AuditItem[]) || d))
+    apiGet<{ items?: AuditItem[] }>(API.adminAuditList)
+      .then((d) => setItems(d.items || (d as unknown as AuditItem[])))
       .catch(() => setItems([]));
   }, []);
 

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { API } from '@/config/api';
-import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
+import { apiGet, apiPost } from '@/lib/api';
 
 interface Job {
   id: string | number;
@@ -16,9 +16,8 @@ export default function AdminJobsPage() {
   const [jobs, setJobs] = useState<Job[] | null>(null);
 
   const load = () => {
-    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobsPending}`)
-      .then((r) => r.json())
-      .then((d) => setJobs((d.jobs as Job[]) || d))
+    apiGet<{ jobs?: Job[] }>(API.adminJobsPending)
+      .then((d) => setJobs(d.jobs || (d as unknown as Job[])))
       .catch(() => setJobs([]));
   };
 
@@ -36,10 +35,7 @@ export default function AdminJobsPage() {
   };
 
   const approve = async (id: string | number) => {
-    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobApprove(id)}`, {
-      method: 'POST',
-    });
-    const data = await res.json().catch(() => ({}));
+    const data = await apiPost<{ email?: string }>(API.adminJobApprove(id), {}).catch(() => ({}) as { email?: string });
     notify(data.email, 'Job approved', 'Your job was approved.');
     toast('Job approved');
     load();
@@ -47,12 +43,7 @@ export default function AdminJobsPage() {
 
   const reject = async (id: string | number) => {
     const reason = prompt('Reason (optional)') || '';
-    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminJobReject(id)}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ reason }),
-    });
-    const data = await res.json().catch(() => ({}));
+    const data = await apiPost<{ email?: string }>(API.adminJobReject(id), { reason }).catch(() => ({}) as { email?: string });
     notify(data.email, 'Job rejected', 'Your job was rejected.');
     toast('Job rejected');
     load();

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { API } from '@/config/api';
-import { env } from '@/config/env';
+import { apiGet } from '@/lib/api';
 
 interface Summary {
   counts?: { pendingJobs?: number; reports?: number; users?: number };
@@ -13,8 +13,7 @@ export default function AdminDashboard() {
   const [summary, setSummary] = useState<Summary | null>(null);
 
   useEffect(() => {
-    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminSummary}`)
-      .then((r) => r.json())
+    apiGet<Summary>(API.adminSummary)
       .then(setSummary)
       .catch(() => setSummary({}));
   }, []);

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { API } from '@/config/api';
-import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
+import { apiGet, apiPost } from '@/lib/api';
 
 interface UserRow {
   id: string | number;
@@ -22,9 +22,8 @@ export default function AdminUsersPage() {
     const params = new URLSearchParams();
     if (q) params.set('q', q);
     if (status) params.set('status', status);
-    fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUsersList}?${params.toString()}`)
-      .then((r) => r.json())
-      .then((d) => setUsers((d.users as UserRow[]) || d))
+    apiGet<{ users?: UserRow[] }>(`${API.adminUsersList}?${params.toString()}`)
+      .then((d) => setUsers(d.users || (d as unknown as UserRow[])))
       .catch(() => setUsers([]));
   };
 
@@ -44,22 +43,14 @@ export default function AdminUsersPage() {
 
   const ban = async (id: string | number) => {
     const reason = prompt('Reason (optional)') || '';
-    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUserBan(id)}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ reason }),
-    });
-    const data = await res.json().catch(() => ({}));
+    const data = await apiPost<{ email?: string }>(API.adminUserBan(id), { reason }).catch(() => ({}) as { email?: string });
     notify(data.email, 'Account banned', 'Your account was banned.');
     toast('User banned');
     load();
   };
 
   const unban = async (id: string | number) => {
-    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${API.adminUserUnban(id)}`, {
-      method: 'POST',
-    });
-    const data = await res.json().catch(() => ({}));
+    const data = await apiPost<{ email?: string }>(API.adminUserUnban(id), {}).catch(() => ({}) as { email?: string });
     notify(data.email, 'Account unbanned', 'Your account was unbanned.');
     toast('User unbanned');
     load();

--- a/src/app/reset/page.tsx
+++ b/src/app/reset/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import { Input } from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
-import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { toast } from '@/lib/toast';
+import { apiPost } from '@/lib/api';
 
 export default function ResetPage() {
   const [email, setEmail] = useState('');
@@ -15,7 +15,7 @@ export default function ResetPage() {
     e.preventDefault();
     setLoading(true);
     try {
-      await api.post(API.requestPasswordReset, { email });
+      await apiPost(API.requestPasswordReset, { email });
       toast('If that email exists, a reset link has been sent.');
     } catch (err) {
       console.warn('password reset', err);

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { Input } from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
-import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
+import { apiPost } from '@/lib/api';
 
 export default function AccountSettingsPage() {
   const [current, setCurrent] = useState('');
@@ -18,7 +18,7 @@ export default function AccountSettingsPage() {
     e.preventDefault();
     setLoading(true);
     try {
-      await api.post(API.changePassword, { current, next });
+      await apiPost(API.changePassword, { current, next });
       toast('Password changed');
       setCurrent('');
       setNext('');
@@ -31,7 +31,7 @@ export default function AccountSettingsPage() {
 
   const handleLogoutAll = async () => {
     try {
-      await api.post('/auth/logoutAll.php', {});
+      await apiPost('/auth/logoutAll.php', {});
       toast('Logged out of all devices');
     } catch {
       toast('Failed to log out');

--- a/src/app/settings/alerts/page.tsx
+++ b/src/app/settings/alerts/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { api } from '@/lib/apiClient';
 import { API, JobFilters } from '@/config/api';
 import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
 import Button from '@/components/ui/Button';
 import AlertModal, { AlertData } from '@/components/alerts/AlertModal';
 import { notFound } from 'next/navigation';
+import { apiGet, apiPost } from '@/lib/api';
 
 interface Alert extends AlertData {
   id: string | number;
@@ -24,9 +24,9 @@ export default function AlertsSettingsPage() {
   useEffect(() => {
     (async () => {
       try {
-        const res = await api.get(API.alertsList);
-        const items = Array.isArray(res.data) ? res.data : res.data?.items || [];
-        setAlerts(items);
+        const res = await apiGet<{ items?: Alert[] }>(API.alertsList);
+        const items = Array.isArray(res) ? res : res.items || [];
+        setAlerts(items as Alert[]);
       } catch {
         toast('Failed to load alerts');
       } finally {
@@ -64,7 +64,7 @@ export default function AlertsSettingsPage() {
     const next = !a.email;
     setAlerts((prev) => prev.map((p) => (p.id === a.id ? { ...p, email: next } : p)));
     try {
-      await api.post(API.alertsToggle(a.id), { email: next });
+      await apiPost(API.alertsToggle(a.id), { email: next });
       toast('Alert updated');
     } catch {
       toast('Failed to update');
@@ -77,7 +77,7 @@ export default function AlertsSettingsPage() {
     const prev = alerts;
     setAlerts((p) => p.filter((a) => a.id !== id));
     try {
-      await api.post(API.alertsDelete(id), {});
+      await apiPost(API.alertsDelete(id), {});
       toast('Alert deleted');
     } catch {
       toast('Failed to delete');

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect } from 'react';
 import { Input, Textarea } from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
-import { api } from '@/lib/apiClient';
 import { API } from '@/config/api';
 import { toast } from '@/lib/toast';
 import { me } from '@/lib/auth';
+import { apiPost } from '@/lib/api';
 
 interface ProfileData {
   name: string;
@@ -62,7 +62,7 @@ export default function ProfileSettingsPage() {
     e.preventDefault();
     setSaving(true);
     try {
-      await api.post(API.updateProfile, {
+      await apiPost(API.updateProfile, {
         ...data,
         skills: data.skills
           .split(',')
@@ -105,7 +105,7 @@ export default function ProfileSettingsPage() {
 
   const handleRemove = async () => {
     try {
-      await api.post(API.deleteResume, {});
+      await apiPost(API.deleteResume, {});
       setResume(null);
       toast('Resume removed');
     } catch {

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { API } from '@/config/api';
 import { env } from '@/config/env';
 import { toast } from '@/lib/toast';
+import { apiPost } from '@/lib/api';
 
 interface Props {
   targetId: string | number;
@@ -22,11 +23,7 @@ export default function ReportButton({ targetId, type }: Props) {
     e.preventDefault();
     setLoading(true);
     try {
-      await fetch(`${env.NEXT_PUBLIC_API_URL}${API.reportCreate}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type, targetId, reason, details }),
-      });
+      await apiPost(API.reportCreate, { type, targetId, reason, details });
       toast('Thanks — our moderators will review.');
       setOpen(false);
       setReason('Scam');

--- a/src/components/alerts/AlertModal.tsx
+++ b/src/components/alerts/AlertModal.tsx
@@ -3,11 +3,11 @@
 import { useState, useEffect } from 'react';
 import { Input, Select } from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
-import { api } from '@/lib/apiClient';
 import { API, JobFilters } from '@/config/api';
 import { toast } from '@/lib/toast';
 import { env } from '@/config/env';
 import { track } from '@/lib/track';
+import { apiPost, apiPatch } from '@/lib/api';
 
 export interface AlertData {
   id?: string | number;
@@ -80,11 +80,11 @@ export default function AlertModal({ open, onClose, initial, onSaved }: Props) {
       const payload = { name, filters: clean, frequency, email };
       const creating = !initial?.id;
       const res = creating
-        ? await api.post(API.alertsCreate, payload)
-        : await api.patch(API.alertsUpdate(initial!.id!), payload);
+        ? await apiPost<AlertData>(API.alertsCreate, payload)
+        : await apiPatch<AlertData>(API.alertsUpdate(initial!.id!), payload);
       toast('Alert saved');
       if (creating && env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('alert_create');
-      onSaved?.(res.data);
+      onSaved?.(res as AlertData);
       onClose();
     } catch {
       toast('Failed to save alert');

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,8 +2,8 @@
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
-import { api } from '@/lib/apiClient';
 import { login as loginApi, register as registerApi, me as meApi } from '@/lib/auth';
+import { apiPut } from '@/lib/api';
 
 interface AuthContextType {
   user: User | null;
@@ -64,9 +64,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   const updateUser = async (data: UpdateUserData) => {
-    const res = await api.put<{ user?: User }>("/user/update", data);
-    if (res.data.user) {
-      setUser(res.data.user);
+    const res = await apiPut<{ user?: User }>("/user/update", data);
+    if (res.user) {
+      setUser(res.user);
     }
   };
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,8 +1,0 @@
-import axios from 'axios';
-import { env } from '@/config/env';
-
-export const api = axios.create({
-  baseURL: env.API_URL,
-  withCredentials: true,
-  headers: { 'Content-Type': 'application/json' },
-});

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -1,6 +1,6 @@
 import { API } from '@/config/api';
 import { env } from '@/config/env';
-import { api } from './apiClient';
+import { apiGet, apiPost } from './api';
 
 const KEY = 'quickgig_saved_jobs';
 
@@ -35,8 +35,7 @@ export async function hydrateSavedIds() {
   if (typeof window === 'undefined') return [];
   if (env.NEXT_PUBLIC_ENABLE_SAVED_API) {
     try {
-      const res = await api.get<string[]>(API.savedList);
-      const ids = res.data;
+      const ids = await apiGet<string[]>(API.savedList);
       localStorage.setItem(KEY, JSON.stringify(ids));
       return ids;
     } catch {
@@ -50,7 +49,7 @@ export async function toggle(id: string | number) {
   const saved = toggleLocal(id);
   if (env.NEXT_PUBLIC_ENABLE_SAVED_API) {
     try {
-      await api.post(API.savedToggle(id));
+      await apiPost(API.savedToggle(id), {});
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary
- proxy external API via Next.js rewrite and central api helpers
- unify client fetches through `/gate` and add health checks for internal/external APIs
- document API proxy usage and add `verify:api` script

## Testing
- `npm run build`
- `npm run verify:api`

------
https://chatgpt.com/codex/tasks/task_e_68a43a7890d083278f11893f4cf3458b