### PR TITLE
Refactor API proxy and lazy socket connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-NEXT_PUBLIC_API_URL=https://app.quickgig.ph
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph
 API_URL=https://api.quickgig.ph
 JWT_COOKIE_NAME=auth_token
 JWT_MAX_AGE_SECONDS=1209600

--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
    ```
 2. Copy `.env.example` to `.env.local` and adjust as needed. Sensible
    defaults are included for local development:
-   ```env
-NEXT_PUBLIC_API_URL=https://app.quickgig.ph
+```env
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph
+NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph
 API_URL=https://api.quickgig.ph
 JWT_COOKIE_NAME=auth_token
 JWT_MAX_AGE_SECONDS=1209600
 ```
+
+Socket.IO is hosted by the backend at `NEXT_PUBLIC_SOCKET_URL`; the frontend
+only connects after authentication and does not serve `/socket.io` itself.
 
 ### Authentication
 
@@ -81,11 +85,11 @@ headers intact.
 
 ### API proxy
 
-Set `NEXT_PUBLIC_GATE_ORIGIN` in Vercel → Environment Variables. All API
-requests should use `/gate/...`, which rewrites to the external API origin.
-Optionally verify locally with `npm run verify:api` while the dev server is running.
+Client requests should use same-origin `/api/*` routes or the helpers in
+`src/config/api.ts`, which proxy to `NEXT_PUBLIC_API_URL`. The legacy `/gate`
+prefix is no longer used.
 
-### Smoke Gate on Vercel
+### Smoke tests on Vercel
 
 - Preview/Production builds skip smoke by default.
 - To force smoke on Vercel, set build env `RUN_SMOKE=1` and `SMOKE_BASE_URL` to your deployed URL.
@@ -673,7 +677,7 @@ Session routes in `src/app/api/session` proxy to the backend and set an HTTP-onl
 
 ### Auth
 
-- `NEXT_PUBLIC_GATE_ORIGIN` – upstream API origin for gateway calls
+- `NEXT_PUBLIC_SOCKET_URL` – backend Socket.IO endpoint
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_DEMO_LOGIN=1` (preview only) – enables the “Continue as Demo” button on `/login`
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,11 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { env } from '@/config/env';
 
 export function middleware(req: NextRequest) {
-  if (req.nextUrl.pathname.startsWith('/api') || req.nextUrl.pathname === '/login') {
+  if (
+    req.nextUrl.pathname.startsWith('/api') ||
+    req.nextUrl.pathname.startsWith('/socket.io') ||
+    req.nextUrl.pathname === '/login'
+  ) {
     return NextResponse.next();
   }
   const token = req.cookies.get(env.JWT_COOKIE_NAME)?.value;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,10 +4,6 @@ const enableSecurity =
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async rewrites() {
-    const GATE = process.env.NEXT_PUBLIC_GATE_ORIGIN || 'https://api.quickgig.ph';
-    return [{ source: '/gate/:path*', destination: `${GATE}/:path*` }];
-  },
   async redirects() {
     const rules = [
       // quickgig.ph → app.quickgig.ph

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scan:links": "node tools/check_links.mjs",
     "guard:auth-proxy": "node tools/guard_auth_proxy.mjs",
     "verify:http": "node scripts/verify_http.mjs",
-    "verify:api": "node -e \"fetch('http://127.0.0.1:3000/gate/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\""
+    "verify:api": "node -e \"fetch('http://127.0.0.1:3000/api/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\""
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/src/app/api/system/status/route.ts
+++ b/src/app/api/system/status/route.ts
@@ -1,0 +1,20 @@
+import { env } from '@/config/env';
+
+export async function GET() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    const res = await fetch(`${env.API_URL}/system/status`, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    if (!res.ok) return Response.json({ ok: false });
+    const data = await res.json().catch(() => ({}));
+    const degraded = Boolean((data as { degraded?: boolean }).degraded);
+    return Response.json({ ok: true, ...(degraded ? { degraded: true } : {}) });
+  } catch {
+    return Response.json({ ok: false });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { api } from '@/config/api';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -13,7 +14,7 @@ export default function LoginPage() {
     e.preventDefault();
     setLoading(true);
     setError('');
-    const res = await fetch('/api/session/login', {
+    const res = await fetch(api.session.login, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ identifier, password }),

--- a/src/auth/getUser.ts
+++ b/src/auth/getUser.ts
@@ -1,12 +1,13 @@
 import { cookies } from 'next/headers';
 import type { User } from '@/types';
+import { api } from '@/config/api';
 
 export async function getUser(): Promise<User | null> {
   const cookie = cookies().toString();
   const base = process.env.NEXT_PUBLIC_SITE_URL
     || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
   try {
-    const res = await fetch(`${base}/api/session/me`, {
+    const res = await fetch(`${base}${api.session.me}`, {
       headers: { Cookie: cookie },
       cache: 'no-store',
     });

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useSession } from '@/hooks/useSession';
+import { api } from '@/config/api';
 import NotificationsBell from './NotificationsBell';
 import NotifyBell from './NotifyBell';
 import { NotifyProvider } from '@/app/notify/store';
@@ -24,7 +25,7 @@ const Navigation: React.FC = () => {
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 
   const handleLogout = async () => {
-    await fetch('/api/session/logout', { method: 'POST' });
+    await fetch(api.session.logout, { method: 'POST' });
     setIsMenuOpen(false);
     router.push('/login');
   };

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,9 +1,13 @@
-import { env } from './env';
-
-export const GATE = new URL(env.API_URL);
-export function gate(path: string) {
-  return new URL(path, GATE).toString();
-}
+export const api = {
+  session: {
+    login: '/api/session/login',
+    me: '/api/session/me',
+    logout: '/api/session/logout',
+  },
+  system: {
+    status: '/api/system/status',
+  },
+};
 
 export function passThroughSetCookie(from: Response, to: Headers) {
   const raw = (from.headers as unknown as { raw?: () => Record<string, string[]> }).raw?.()[

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const env: {
   NEXT_PUBLIC_API_URL: string;
+  NEXT_PUBLIC_SOCKET_URL: string;
   API_URL: string;
   JWT_COOKIE_NAME: string;
   JWT_MAX_AGE_SECONDS: number;
@@ -10,7 +11,14 @@ export const env: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 } = {
-  NEXT_PUBLIC_API_URL: z.string().url().parse(process.env.NEXT_PUBLIC_API_URL ?? 'https://app.quickgig.ph'),
+  NEXT_PUBLIC_API_URL: z
+    .string()
+    .url()
+    .parse(process.env.NEXT_PUBLIC_API_URL ?? 'https://api.quickgig.ph'),
+  NEXT_PUBLIC_SOCKET_URL: z
+    .string()
+    .url()
+    .parse(process.env.NEXT_PUBLIC_SOCKET_URL ?? 'wss://api.quickgig.ph'),
   API_URL: z.string().url().parse(process.env.API_URL ?? 'https://api.quickgig.ph'),
   JWT_COOKIE_NAME: z.string().min(1).parse(process.env.JWT_COOKIE_NAME ?? 'auth_token'),
   JWT_MAX_AGE_SECONDS: z.coerce.number().default(60 * 60 * 24 * 14).parse(process.env.JWT_MAX_AGE_SECONDS),

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, LoginData, SignupData, UpdateUserData } from '@/types';
 import { login as loginApi, register as registerApi, me as meApi } from '@/lib/auth';
+import { api } from '@/config/api';
 import { apiPut } from '@/lib/api';
 
 interface AuthContextType {
@@ -60,7 +61,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   const logout = async () => {
-    await fetch('/api/session/logout', { method: 'POST' });
+    await fetch(api.session.logout, { method: 'POST' });
     setUser(null);
   };
 

--- a/src/hooks/useAuthedSocket.ts
+++ b/src/hooks/useAuthedSocket.ts
@@ -1,0 +1,23 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+import { connectSocket, disconnectSocket } from '@/lib/socket';
+import { useAuth } from '@/context/AuthContext';
+
+export function useAuthedSocket() {
+  const { user } = useAuth();
+  const [socket, setSocket] = useState<Socket | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      setSocket(connectSocket());
+      return () => {
+        disconnectSocket();
+      };
+    }
+    disconnectSocket();
+    setSocket(null);
+  }, [user]);
+
+  return socket;
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { api } from '@/config/api';
 
 interface SessionUser {
   isEmployer?: boolean;
@@ -15,7 +16,7 @@ export function useSession() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/api/session/me', { cache: 'no-store' })
+    fetch(api.session.me, { cache: 'no-store' })
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: unknown) => {
         const obj = data as Record<string, unknown>;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ import { toast } from './toast';
 import { report } from './report';
 import type { Job } from '../../types/jobs';
 
-const BASE = '/gate';
+const BASE = '/api';
 
 async function apiRequest(path: string, init?: RequestInit) {
   return fetch(`${BASE}${path}`, {
@@ -129,5 +129,4 @@ export async function fetchJobs(): Promise<Job[]> {
   return apiFetch<Job[]>('/jobs');
 }
 
-export const API_BASE = BASE;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,8 @@
 import { guardAgainstPhpOrigin } from './fetchGuard';
+import { api } from '@/config/api';
 
 export async function login(payload: Record<string, string>) {
-  const url = '/api/session/login';
+  const url = api.session.login;
   guardAgainstPhpOrigin(url);
   const res = await fetch(url, {
     method: 'POST',
@@ -34,7 +35,7 @@ export async function register(
 }
 
 export async function me() {
-  const url = '/api/session/me';
+  const url = api.session.me;
   guardAgainstPhpOrigin(url);
   const r = await fetch(url, { credentials: 'include', cache: 'no-store' });
   return r.json().catch(() => ({}));

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -1,4 +1,5 @@
 import { env } from '@/config/env';
+import { api } from '@/config/api';
 
 let inited = false;
 
@@ -98,12 +99,12 @@ export async function checkApiHealth(): Promise<ApiHealthStatus> {
   const internal = fetch('/api/system/ping', { cache: 'no-store' })
     .then((r) => (r.ok ? r.json().catch(() => null) : null))
     .catch(() => null);
-  const external = fetch('/gate/system/status', { cache: 'no-store' })
+  const external = fetch(api.system.status, { cache: 'no-store' })
     .then((r) => (r.ok ? r.json().catch(() => null) : null))
     .catch(() => null);
   const [i, e] = await Promise.all([internal, external]);
   const internalOk = Boolean(i && (i.ok === true || i.status === 'ok'));
-  const externalOk = Boolean(e && (e.ok === true || e.status === 'ok'));
+  const externalOk = Boolean(e && e.ok === true);
   if (externalOk) return 'ok';
   if (internalOk) return 'degraded';
   return 'error';

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,0 +1,24 @@
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export function connectSocket(token?: string) {
+  if (socket) return socket;
+  const url =
+    process.env.NEXT_PUBLIC_SOCKET_URL ||
+    `${process.env.NEXT_PUBLIC_API_URL}`;
+  socket = io(url, {
+    path: '/socket.io',
+    transports: ['websocket'],
+    withCredentials: true,
+    auth: token ? { token } : undefined,
+  });
+  return socket;
+}
+
+export function disconnectSocket() {
+  socket?.disconnect();
+  socket = null;
+}
+
+export const getSocket = () => socket;

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -5,12 +5,13 @@ import type { GetServerSideProps } from 'next';
 import type { ApplicationSummary } from '@/types/application';
 import { fetchApplications } from '@/lib/applicationsApi';
 import { env } from '@/config/env';
+import { api } from '@/config/api';
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   if (!env.NEXT_PUBLIC_ENABLE_APPLICANT_APPS) return { notFound: true } as const;
   try {
     const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-    const res = await fetch(`${base}/api/session/me`, {
+    const res = await fetch(`${base}${api.session.me}`, {
       headers: { cookie: req.headers.cookie || '' },
     });
     if (!res.ok) {

--- a/src/pages/applications/[id].tsx
+++ b/src/pages/applications/[id].tsx
@@ -9,12 +9,13 @@ import type { ApplicationDetail, ApplicationEvent, ApplicationStatus } from '@/t
 import type { Interview } from '@/src/types/interview';
 import InterviewForm from '@/product/interviews/InterviewForm';
 import { interviewsEnabled } from '@/src/lib/interviews';
+import { api } from '@/config/api';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, params }) => {
   if (!env.NEXT_PUBLIC_ENABLE_APPLICATION_DETAIL) return { notFound: true } as const;
   try {
     const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-    const r = await fetch(`${base}/api/session/me`, {
+    const r = await fetch(`${base}${api.session.me}`, {
       headers: { cookie: req.headers.cookie || '' },
     });
     if (!r.ok) {

--- a/src/pages/employer/interviews/index.tsx
+++ b/src/pages/employer/interviews/index.tsx
@@ -7,6 +7,7 @@ import { t } from '@/lib/i18n';
 import { toast } from '@/lib/toast';
 import { env } from '@/config/env';
 import type { GetServerSidePropsContext } from 'next';
+import { api } from '@/config/api';
 
 export default function EmployerInterviewsPage() {
   const [items, setItems] = useState<Interview[]>([]);
@@ -62,7 +63,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const base =
     process.env.NEXT_PUBLIC_SITE_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-  const userRes = await fetch(base + '/api/session/me', {
+  const userRes = await fetch(base + api.session.me, {
     headers: { cookie },
   });
   const user = userRes.ok ? await userRes.json() : null;

--- a/src/pages/interviews/index.tsx
+++ b/src/pages/interviews/index.tsx
@@ -7,6 +7,7 @@ import { t } from '@/lib/i18n';
 import { toast } from '@/lib/toast';
 import { env } from '@/config/env';
 import type { GetServerSidePropsContext } from 'next';
+import { api } from '@/config/api';
 
 export default function ApplicantInterviewsPage() {
   const [items, setItems] = useState<Interview[]>([]);
@@ -62,7 +63,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const base =
     process.env.NEXT_PUBLIC_SITE_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-  const userRes = await fetch(base + '/api/session/me', {
+  const userRes = await fetch(base + api.session.me, {
     headers: { cookie },
   });
   const user = userRes.ok ? await userRes.json() : null;

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -7,6 +7,7 @@ import type { NotificationKind, NotificationList } from '@/types/notification';
 import Pagination from '@/components/Pagination';
 import { env } from '@/config/env';
 import { t } from '@/lib/i18n';
+import { api } from '@/config/api';
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   if (!env.NEXT_PUBLIC_ENABLE_NOTIFICATION_CENTER) return { notFound: true } as const;
@@ -14,7 +15,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
     const base =
       process.env.NEXT_PUBLIC_SITE_URL ||
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-    const res = await fetch(`${base}/api/session/me`, {
+    const res = await fetch(`${base}${api.session.me}`, {
       headers: { cookie: req.headers.cookie || '' },
     });
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- centralize session and system status routes under `config/api.ts`
- add auth-aware lazy Socket.IO client and disconnect on logout
- avoid unauthenticated status checks and expose system status proxy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a4666e6c8083279772a0e9dceda14a