### PR TITLE
Fix auth register proxy and error forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,23 @@ Optional:
 
 - `NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph`
 
-Set these in Vercel → Project → Settings → Env Vars (Production).
+Set these in Vercel → Project → Settings → Env Vars (Production). API_URL is
+required in production; defaults only apply to local/preview builds.
 Protected routes redirect to /login when session cookie is missing.
+
+`POST /api/session/register` expects `{ name, email, password }` and proxies to
+`${API_URL}/auth/register`, falling back to `/auth/signup` if the first call
+returns `404`.
+
+Example register + me smoke:
+
+```bash
+API_URL=https://api.quickgig.ph \\
+curl -sv -H 'content-type: application/json' \\
+  --data '{"name":"Smoke","email":"smoke+$(date +%s)@example.com","password":"Xx1!Xx1!"}' \\
+  -c jar.txt -b jar.txt https://app.quickgig.ph/api/session/register
+curl -sv -b jar.txt https://app.quickgig.ph/api/session/me
+```
 
 ### Verify login flow
 

--- a/src/app/api/session/logout/route.ts
+++ b/src/app/api/session/logout/route.ts
@@ -1,20 +1,52 @@
 import { NextResponse } from 'next/server';
 import { env } from '@/config/env';
-import { gateway, copySetCookie } from '@/lib/gateway';
+import { gateway } from '@/lib/gateway';
+import { copySetCookie } from '@/lib/http';
 
 export const runtime = 'nodejs';
 
 export async function POST() {
-  let upstream: Response | null = null;
+  let upstream: Response;
   try {
-    upstream = await gateway('/auth/logout', { method: 'POST' });
-  } catch {
-    upstream = null;
+    upstream = await gateway('/auth/logout', { method: 'POST', cache: 'no-store' });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error('[logout]', 500, msg.slice(0, 100));
+    const res = NextResponse.json(
+      { ok: false, error: msg, status: 500 },
+      { status: 500 },
+    );
+    res.cookies.set({
+      name: env.JWT_COOKIE_NAME,
+      value: '',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 0,
+    });
+    return res;
   }
-  const res = new NextResponse(null, { status: 204 });
-  if (upstream) {
-    copySetCookie(upstream, res.headers);
+  const cookieInit = copySetCookie(upstream);
+  if (upstream.ok) {
+    const res = new NextResponse(null, { ...cookieInit, status: 204 });
+    res.cookies.set({
+      name: env.JWT_COOKIE_NAME,
+      value: '',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 0,
+    });
+    return res;
   }
+  const text = await upstream.text();
+  console.error('[logout]', upstream.status, text.slice(0, 100));
+  const res = NextResponse.json(
+    { ok: false, error: text, status: upstream.status },
+    { ...cookieInit, status: upstream.status },
+  );
   res.cookies.set({
     name: env.JWT_COOKIE_NAME,
     value: '',

--- a/src/app/api/session/register/route.ts
+++ b/src/app/api/session/register/route.ts
@@ -1,9 +1,50 @@
-import { NextRequest } from 'next/server';
-import { proxyPhp } from '@/lib/proxyPhp';
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/config/env';
+import { copySetCookie } from '@/lib/http';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function OPTIONS() { return new Response(null, { status: 204 }); }
-export async function POST(req: NextRequest) { return proxyPhp(req, '/register.php'); }
+export async function OPTIONS() {
+  return new Response(null, { status: 204 });
+}
+
+export async function POST(req: NextRequest) {
+  let password = '';
+  try {
+    const body = await req.json();
+    const { name, email } = body || {};
+    password = body?.password ?? '';
+    const payload = JSON.stringify({ name, email, password });
+    const init: RequestInit = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: payload,
+      cache: 'no-store',
+    };
+    let upstream = await fetch(`${env.API_URL}/auth/register`, init);
+    if (upstream.status === 404) {
+      upstream = await fetch(`${env.API_URL}/auth/signup`, init);
+    }
+    const cookieInit = copySetCookie(upstream);
+    if (upstream.ok) {
+      return NextResponse.json({ ok: true }, { ...cookieInit, status: 201 });
+    }
+    const text = await upstream.text();
+    const sanitized = password ? text.replaceAll(password, '') : text;
+    console.error('[register]', upstream.status, sanitized.slice(0, 100));
+    return NextResponse.json(
+      { ok: false, error: sanitized, status: upstream.status },
+      { ...cookieInit, status: upstream.status },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const sanitized = password ? msg.replaceAll(password, '') : msg;
+    console.error('[register]', 500, String(sanitized).slice(0, 100));
+    return NextResponse.json(
+      { ok: false, error: sanitized, status: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+export const isProd =
+  (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === 'production';
+
 const schema = z.object({
   API_URL: z.string(),
   JWT_COOKIE_NAME: z.string(),
@@ -9,7 +12,8 @@ const schema = z.object({
 });
 
 const parsed = schema.parse({
-  API_URL: process.env.API_URL ?? 'http://127.0.0.1:8080',
+  API_URL:
+    process.env.API_URL ?? (isProd ? undefined : 'http://127.0.0.1:8080'),
   JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME ?? 'auth_token',
   JWT_MAX_AGE_SECONDS: process.env.JWT_MAX_AGE_SECONDS ?? 1209600,
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? '',
@@ -25,5 +29,3 @@ export const env = {
   maxAge: parsed.JWT_MAX_AGE_SECONDS,
 };
 
-export const isProd =
-  (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === 'production';

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -1,17 +1,9 @@
 import { env } from '@/config/env';
 import { headers as nextHeaders } from 'next/headers';
 
-export function copySetCookie(from: Response, to: Headers) {
-  const raw = (from.headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.();
-  const cookies = raw ?? (from.headers.get('set-cookie') ? [from.headers.get('set-cookie') as string] : []);
-  for (const c of cookies) {
-    to.append('set-cookie', c);
-  }
-}
-
 export async function gateway(
   path: string,
-  init: RequestInit & { cookies?: string[] } = {}
+  init: RequestInit & { cookies?: string[] } = {},
 ) {
   const { cookies, headers, ...rest } = init;
   const h = new Headers(headers);

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,9 @@
+export function copySetCookie(from: Response, toInit?: ResponseInit): ResponseInit {
+  const headers = new Headers(toInit?.headers);
+  const sc =
+    (from.headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.() ??
+    from.headers.get('set-cookie');
+  if (Array.isArray(sc)) sc.forEach(v => headers.append('set-cookie', v));
+  else if (sc) headers.set('set-cookie', sc);
+  return { ...toInit, headers };
+}


### PR DESCRIPTION
## Summary
- proxy register to gateway with /auth/register -> /auth/signup fallback and forward upstream errors
- require `API_URL` in production builds
- align login/logout cookie forwarding and error responses

## Testing
- `npm run lint`
- `npm run typecheck`

## Smoke
```bash
API_URL=https://api.quickgig.ph \
curl -sv -H 'content-type: application/json' \
  --data '{"name":"Smoke","email":"smoke+$(date +%s)@example.com","password":"Xx1!Xx1!"}' \
  -c jar.txt -b jar.txt https://app.quickgig.ph/api/session/register
curl -sv -b jar.txt https://app.quickgig.ph/api/session/me
```

------
https://chatgpt.com/codex/tasks/task_e_68a484bbd5648327bd7198692b0b255e