### PR TITLE
feat: wire auth routes to live gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph   # optional; sockets disabled if unset
+# Required in production (set in Vercel → Project → Settings → Env Vars)
 API_URL=https://api.quickgig.ph
-NEXT_PUBLIC_API_URL=https://app.quickgig.ph
+
+# Optional
 JWT_COOKIE_NAME=auth_token
 JWT_MAX_AGE_SECONDS=1209600

--- a/README.md
+++ b/README.md
@@ -21,30 +21,23 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env.local` and adjust as needed. Sensible
-   defaults are included for local development:
+2. Copy `.env.example` to `.env.local` and adjust as needed:
 ```env
-NEXT_PUBLIC_API_URL=https://api.quickgig.ph
-NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph
 API_URL=https://api.quickgig.ph
 JWT_COOKIE_NAME=auth_token
 JWT_MAX_AGE_SECONDS=1209600
 ```
-
-Socket.IO is hosted by the backend at `NEXT_PUBLIC_SOCKET_URL`; the frontend
-only connects after authentication and does not serve `/socket.io` itself.
 
 ### Authentication
 
 Required env vars:
 
 - `API_URL=https://api.quickgig.ph`
-- `JWT_COOKIE_NAME=auth_token`
-- `JWT_MAX_AGE_SECONDS=1209600`
 
 Optional:
 
-- `NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph`
+- `JWT_COOKIE_NAME=auth_token`
+- `JWT_MAX_AGE_SECONDS=1209600`
 
 Set these in Vercel → Project → Settings → Env Vars (Production).
 Protected routes redirect to /login when session cookie is missing.
@@ -67,6 +60,17 @@ curl -i -b cookies.txt $BASE/api/session/me
 # Logout then verify cleared
 curl -i -b cookies.txt -X POST $BASE/api/session/logout
 curl -i -b cookies.txt $BASE/api/session/me
+```
+
+### Smoke (against production gateway)
+
+```bash
+API_URL=https://api.quickgig.ph \
+curl -sv -H 'content-type: application/json' \
+  --data "{\"name\":\"Smoke $(date +%s)\",\"email\":\"smoke$(date +%s)@example.com\",\"password\":\"Xx1!xX1!\"}" \
+  -c jar.txt -b jar.txt https://app.quickgig.ph/api/session/register
+
+curl -sv -b jar.txt https://app.quickgig.ph/api/session/me
 ```
 
 To verify the live API locally, run:

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,14 +22,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    '/dashboard/:path*',
-    '/messages/:path*',
-    '/applications/:path*',
-    '/settings/:path*',
-    '/dashboard',
-    '/messages',
-    '/applications',
-    '/settings',
-  ],
+  matcher: ['/dashboard/:path*', '/messages/:path*', '/applications/:path*', '/settings/:path*'],
 };

--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -1,46 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
-import { env } from '@/config/env';
-import { gateway, copySetCookie } from '@/lib/gateway';
-
-export const runtime = 'nodejs';
-
-const BodySchema = z.object({ identifier: z.string(), password: z.string() });
+import { getEnv } from '@/config/env';
+import { copySetCookie, jsonFrom } from '@/lib/proxy';
 
 export async function POST(req: NextRequest) {
-  const body = await req.json().catch(() => null);
-  const parsed = BodySchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'Invalid body' }, { status: 400 });
-  }
+  const { API_URL } = getEnv();
+  const body = await req.json().catch(() => ({}));
 
-  const upstream = await gateway('/auth/login', {
+  const res = await fetch(`${API_URL}/auth/login`, {
     method: 'POST',
-    body: JSON.stringify(parsed.data),
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    redirect: 'manual',
   });
 
-  if (upstream.ok) {
-    const res = new NextResponse(null, { status: 204 });
-    copySetCookie(upstream, res.headers);
-    if (!upstream.headers.get('set-cookie')) {
-      const data = await upstream.json().catch(() => null);
-      const token = data?.token || data?.accessToken;
-      if (token) {
-        res.cookies.set({
-          name: env.JWT_COOKIE_NAME,
-          value: token,
-          httpOnly: true,
-          secure: true,
-          sameSite: 'lax',
-          path: '/',
-          maxAge: env.JWT_MAX_AGE_SECONDS,
-        });
-      }
-    }
-    return res;
-  }
-
-  const data = await upstream.json().catch(() => null);
-  const error = data?.error || data?.message || 'Login failed';
-  return NextResponse.json({ ok: false, error }, { status: upstream.status });
+  const out = NextResponse.json(await jsonFrom(res), { status: res.status });
+  copySetCookie(res, out);
+  return out;
 }

--- a/src/app/api/session/register/route.ts
+++ b/src/app/api/session/register/route.ts
@@ -1,9 +1,30 @@
-import { NextRequest } from 'next/server';
-import { proxyPhp } from '@/lib/proxyPhp';
+import { NextRequest, NextResponse } from 'next/server';
+import { getEnv } from '@/config/env';
+import { copySetCookie, jsonFrom } from '@/lib/proxy';
 
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+export async function POST(req: NextRequest) {
+  const { API_URL } = getEnv();
+  const body = await req.json().catch(() => ({}));
 
-export async function OPTIONS() { return new Response(null, { status: 204 }); }
-export async function POST(req: NextRequest) { return proxyPhp(req, '/register.php'); }
+  // Primary endpoint
+  let res = await fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    redirect: 'manual',
+  });
+
+  // Fallback to /auth/signup on 404 (legacy backend)
+  if (res.status === 404) {
+    res = await fetch(`${API_URL}/auth/signup`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      redirect: 'manual',
+    });
+  }
+
+  const out = NextResponse.json(await jsonFrom(res), { status: res.status });
+  copySetCookie(res, out);
+  return out;
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,29 +1,48 @@
-import { z } from 'zod';
+import 'server-only';
 
-const schema = z.object({
-  API_URL: z.string(),
-  JWT_COOKIE_NAME: z.string(),
-  JWT_MAX_AGE_SECONDS: z.coerce.number().default(1209600),
-  NEXT_PUBLIC_API_URL: z.string(),
-  NEXT_PUBLIC_SOCKET_URL: z.string(),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const RUNTIME = process.env.NEXT_RUNTIME ?? 'nodejs';
+const isBuild =
+  process.env.NODE_ENV === 'production' &&
+  process.env.VERCEL === '1' &&
+  !process.env.VERCEL_URL;
 
-const parsed = schema.parse({
-  API_URL: process.env.API_URL ?? 'http://127.0.0.1:8080',
-  JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME ?? 'auth_token',
-  JWT_MAX_AGE_SECONDS: process.env.JWT_MAX_AGE_SECONDS ?? 1209600,
-  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? '',
-  NEXT_PUBLIC_SOCKET_URL: process.env.NEXT_PUBLIC_SOCKET_URL ?? '',
-});
-
-export const env = {
-  ...parsed,
-  apiUrl: parsed.API_URL,
-  publicApiUrl: parsed.NEXT_PUBLIC_API_URL ?? '',
-  socketUrl: parsed.NEXT_PUBLIC_SOCKET_URL ?? '',
-  cookieName: parsed.JWT_COOKIE_NAME,
-  maxAge: parsed.JWT_MAX_AGE_SECONDS,
+type Env = {
+  API_URL?: string;
+  JWT_COOKIE_NAME: string;
+  JWT_MAX_AGE_SECONDS: number;
 };
+
+const raw: Env = {
+  API_URL: process.env.API_URL, // required at runtime (not at build)
+  JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME || 'auth_token',
+  JWT_MAX_AGE_SECONDS: Number(process.env.JWT_MAX_AGE_SECONDS || 1209600),
+};
+
+export function getEnv() {
+  // Do not crash at build; enforce at runtime when handlers are executed.
+  if (!isBuild && !raw.API_URL) {
+    throw new Error('Missing required env: API_URL');
+  }
+  return raw as Required<Omit<Env, 'API_URL'>> & { API_URL: string };
+}
+
+// Backwards-compatible env object with lazy getters
+export const env = {
+  ...process.env,
+  get API_URL() {
+    return getEnv().API_URL;
+  },
+  get apiUrl() {
+    return getEnv().API_URL;
+  },
+  JWT_COOKIE_NAME: raw.JWT_COOKIE_NAME,
+  JWT_MAX_AGE_SECONDS: raw.JWT_MAX_AGE_SECONDS,
+  cookieName: raw.JWT_COOKIE_NAME,
+  maxAge: raw.JWT_MAX_AGE_SECONDS,
+  publicApiUrl: process.env.NEXT_PUBLIC_API_URL || '',
+  socketUrl: process.env.NEXT_PUBLIC_SOCKET_URL || '',
+} as Record<string, any>;
 
 export const isProd =
   (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === 'production';

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -1,0 +1,28 @@
+// src/lib/proxy.ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export function copySetCookie(from: Response, to: NextResponse) {
+  const setCookie = from.headers.get('set-cookie');
+  if (setCookie) to.headers.set('set-cookie', setCookie);
+}
+
+export async function jsonFrom(res: Response) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text ? { message: text } : {};
+  }
+}
+
+/** Clone incoming request cookies to outbound fetch */
+export function withCookieHeaders(init: RequestInit = {}) {
+  const jar = cookies()
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+  const headers = new Headers(init.headers);
+  if (jar) headers.set('cookie', jar);
+  return { ...init, headers };
+}


### PR DESCRIPTION
## Summary
- add runtime env loader that defers API_URL validation to runtime
- proxy auth session routes to upstream gateway with cookie passthrough
- tighten middleware matcher and document production env requirements

## Testing
- `npm run lint`
- `npm run typecheck`
- `API_URL=https://api.quickgig.ph curl -sv -H 'content-type: application/json' --data "{\"name\":\"Smoke $(date +%s)\",\"email\":\"smoke$(date +%s)@example.com\",\"password\":\"Xx1!xX1!\"}" -c jar.txt -b jar.txt https://app.quickgig.ph/api/session/register` *(fails: 403 Forbidden)*
- `curl -sv -b jar.txt https://app.quickgig.ph/api/session/me` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c62f3308327aafc603c98a5d447