### PR TITLE
fix(env): make env loader Edge-safe (remove server-only), keep strict prod checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,8 @@ Session routes in `src/app/api/session` proxy to the backend and set an HTTP-onl
 - `JWT_COOKIE_NAME` – name of the auth cookie
 - `NEXT_PUBLIC_DEMO_LOGIN=1` (preview only) – enables the “Continue as Demo” button on `/login`
 
+Env vars load via `src/config/env.ts`, which is Edge-safe and intentionally avoids importing `server-only`.
+
 Login posts to `/api/session/login` and relies on an upstream `Set-Cookie` or a token in the JSON body.
 
 ### Auth Proxy

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(req: NextRequest) {
 
   if (!needsAuth) return NextResponse.next();
 
-  const hasSession = Boolean(req.cookies.get(env.JWT_COOKIE_NAME)?.value);
+  const hasSession = Boolean(req.cookies.get(env.JWT_COOKIE_NAME!)?.value);
   if (hasSession) return NextResponse.next();
 
   const url = new URL('/login', req.url);

--- a/src/app/admin/metrics/page.tsx
+++ b/src/app/admin/metrics/page.tsx
@@ -22,7 +22,7 @@ export default function AdminMetricsPage() {
   useEffect(() => {
     async function load() {
       try {
-        const sRes = await fetch(`${env.apiUrl}${API.metricsSummary}?range=7`);
+        const sRes = await fetch(`${env.API_URL!}${API.metricsSummary}?range=7`);
         const sJson = await sRes.json();
         setSummary(sJson || {});
         const metrics = ['signups', 'applies', 'messages', 'job_posts'];
@@ -31,7 +31,7 @@ export default function AdminMetricsPage() {
           metrics.map(async (m) => {
             try {
               const r = await fetch(
-                `${env.apiUrl}${API.metricsTimeseries}?metric=${m}&range=30`,
+                `${env.API_URL!}${API.metricsTimeseries}?metric=${m}&range=30`,
               );
               const j = await r.json();
               ts[m] = Array.isArray(j) ? j : j.values || [];

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -5,7 +5,7 @@ import { env } from '@/config/env';
 const BASE = process.env.ENGINE_BASE_URL || '';
 
 export async function DELETE(req: NextRequest) {
-  if (!cookies().get(env.cookieName)) {
+  if (!cookies().get(env.JWT_COOKIE_NAME!)) {
     return NextResponse.json({ ok: false }, { status: 401 });
   }
   if (BASE) {
@@ -19,7 +19,7 @@ export async function DELETE(req: NextRequest) {
     }
   }
   const res = NextResponse.json({ ok: true }, { status: 202 });
-  res.headers.append('Set-Cookie', `${env.cookieName}=; Path=/; Max-Age=0`);
+  res.headers.append('Set-Cookie', `${env.JWT_COOKIE_NAME!}=; Path=/; Max-Age=0`);
   res.headers.append('Set-Cookie', `settings_v1=; Path=/; Max-Age=0`);
   return res;
 }

--- a/src/app/api/cron/job-alerts/route.ts
+++ b/src/app/api/cron/job-alerts/route.ts
@@ -6,7 +6,7 @@ export async function POST() {
   try {
     const body = { secret: process.env.ALERTS_DIGEST_SECRET || '' };
     if (API.alertsRunDigest) {
-      const r = await fetch(`${env.apiUrl}${API.alertsRunDigest}`, {
+      const r = await fetch(`${env.API_URL!}${API.alertsRunDigest}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/src/app/api/metrics/track/route.ts
+++ b/src/app/api/metrics/track/route.ts
@@ -8,10 +8,10 @@ export async function POST(req: NextRequest) {
     const body = await req.json().catch(() => ({}));
     const ua = req.headers.get('user-agent') || '';
     const ip = req.headers.get('x-forwarded-for') || req.ip || '';
-    const fwd = await fetch(`${env.apiUrl}${API.metricsTrack}`, {
+    const fwd = await fetch(`${env.API_URL!}${API.metricsTrack}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...body, ua, ip, secret: env.METRICS_SECRET }),
+      body: JSON.stringify({ ...body, ua, ip, secret: process.env.METRICS_SECRET }),
     });
     return NextResponse.json({ ok: fwd.ok }, { status: 200 });
   } catch {

--- a/src/app/api/msg/[id]/read/route.ts
+++ b/src/app/api/msg/[id]/read/route.ts
@@ -4,7 +4,7 @@ import { API } from '@/config/api';
 
 export async function POST(_: Request, ctx: { params: { id: string } }) {
   try {
-    const r = await fetch(`${env.apiUrl}${API.markConversationRead(ctx.params.id)}`, {
+    const r = await fetch(`${env.API_URL!}${API.markConversationRead(ctx.params.id)}`, {
       method: 'POST',
       credentials: 'include',
     });

--- a/src/app/api/msg/[id]/route.ts
+++ b/src/app/api/msg/[id]/route.ts
@@ -4,7 +4,7 @@ import { API } from '@/config/api';
 
 export async function GET(_: Request, ctx: { params: { id: string } }) {
   try {
-    const r = await fetch(`${env.apiUrl}${API.conversationById(ctx.params.id)}`, { credentials: 'include' });
+    const r = await fetch(`${env.API_URL!}${API.conversationById(ctx.params.id)}`, { credentials: 'include' });
     const json = await r.json().catch(() => ({}));
     return NextResponse.json(json, { status: 200 });
   } catch {

--- a/src/app/api/msg/[id]/send/route.ts
+++ b/src/app/api/msg/[id]/send/route.ts
@@ -5,7 +5,7 @@ import { API } from '@/config/api';
 export async function POST(req: Request, ctx: { params: { id: string } }) {
   try {
     const body = await req.json().catch(() => ({}));
-    const r = await fetch(`${env.apiUrl}${API.sendMessage(ctx.params.id)}`, {
+    const r = await fetch(`${env.API_URL!}${API.sendMessage(ctx.params.id)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/app/api/msg/list/route.ts
+++ b/src/app/api/msg/list/route.ts
@@ -4,7 +4,7 @@ import { API } from '@/config/api';
 
 export async function GET() {
   try {
-    const r = await fetch(`${env.apiUrl}${API.conversationsMine}`, { credentials: 'include' });
+    const r = await fetch(`${env.API_URL!}${API.conversationsMine}`, { credentials: 'include' });
     const json = await r.json().catch(() => ({}));
     return NextResponse.json(json, { status: 200 });
   } catch {

--- a/src/app/api/msg/start/route.ts
+++ b/src/app/api/msg/start/route.ts
@@ -5,7 +5,7 @@ import { API } from '@/config/api';
 export async function POST(req: Request) {
   try {
     const body = await req.json().catch(() => ({}));
-    const r = await fetch(`${env.apiUrl}${API.startConversation}`, {
+    const r = await fetch(`${env.API_URL!}${API.startConversation}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/app/api/session/login/route.ts
+++ b/src/app/api/session/login/route.ts
@@ -27,13 +27,13 @@ export async function POST(req: NextRequest) {
       const token = data?.token || data?.accessToken;
       if (token) {
         res.cookies.set({
-          name: env.JWT_COOKIE_NAME,
+          name: env.JWT_COOKIE_NAME!,
           value: token,
           httpOnly: true,
           secure: true,
           sameSite: 'lax',
           path: '/',
-          maxAge: env.JWT_MAX_AGE_SECONDS,
+          maxAge: Number(env.JWT_MAX_AGE_SECONDS),
         });
       }
     }

--- a/src/app/api/session/logout/route.ts
+++ b/src/app/api/session/logout/route.ts
@@ -16,7 +16,7 @@ export async function POST() {
     copySetCookie(upstream, res.headers);
   }
   res.cookies.set({
-    name: env.JWT_COOKIE_NAME,
+    name: env.JWT_COOKIE_NAME!,
     value: '',
     httpOnly: true,
     secure: true,

--- a/src/app/api/system/ping/route.ts
+++ b/src/app/api/system/ping/route.ts
@@ -15,7 +15,7 @@ async function tryFetch(url: string) {
 }
 
 export async function GET() {
-  const base = env.apiUrl.replace(/\/$/, '');
+  const base = env.API_URL!.replace(/\/$/, '');
   const paths = ['/health', '/health.php', ''];
   for (const p of paths) {
     const result = await tryFetch(`${base}${p}`);

--- a/src/app/api/system/status/route.ts
+++ b/src/app/api/system/status/route.ts
@@ -4,7 +4,7 @@ export async function GET() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 3000);
   try {
-    const res = await fetch(`${env.apiUrl}/system/status`, {
+    const res = await fetch(`${env.API_URL!}/system/status`, {
       signal: controller.signal,
       cache: 'no-store',
     });

--- a/src/app/api/upload/logo/route.ts
+++ b/src/app/api/upload/logo/route.ts
@@ -5,7 +5,7 @@ import { API } from '@/config/api';
 async function forward(req: NextRequest, target: string) {
   try {
     const form = await req.formData();
-    const res = await fetch(`${env.apiUrl}${target}`, {
+    const res = await fetch(`${env.API_URL!}${target}`, {
       method: 'POST',
       body: form,
       headers: {

--- a/src/app/api/upload/resume/route.ts
+++ b/src/app/api/upload/resume/route.ts
@@ -5,7 +5,7 @@ import { API } from '@/config/api';
 async function forward(req: NextRequest, target: string) {
   try {
     const form = await req.formData();
-    const res = await fetch(`${env.apiUrl}${target}`, {
+    const res = await fetch(`${env.API_URL!}${target}`, {
       method: 'POST',
       body: form,
       headers: {

--- a/src/app/c/[slug]/page.tsx
+++ b/src/app/c/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { env } from '@/config/env';
 import Link from 'next/link';
 
 async function fetchCompany(slug: string) {
-  const res = await fetch(`${env.apiUrl}${API.publicCompany(slug)}`, { cache: 'no-store' });
+  const res = await fetch(`${env.API_URL!}${API.publicCompany(slug)}`, { cache: 'no-store' });
   if (!res.ok) return null;
   return res.json().catch(() => null);
 }

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -13,7 +13,7 @@ interface JobPageProps {
 }
 
 async function fetchJob(id: string): Promise<Job> {
-  const res = await fetch(`${env.apiUrl}${API.jobById(id)}`, {
+  const res = await fetch(`${env.API_URL!}${API.jobById(id)}`, {
     cache: 'no-store',
   });
   if (!res.ok) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,7 +5,7 @@ import { env } from '@/config/env';
 import SettingsForm from './SettingsForm';
 
 function requireAuthSSR() {
-  const token = cookies().get(env.cookieName);
+  const token = cookies().get(env.JWT_COOKIE_NAME!);
   if (!token) {
     redirect('/login?return=/settings');
   }

--- a/src/app/system/status/page.tsx
+++ b/src/app/system/status/page.tsx
@@ -5,5 +5,5 @@ export const dynamic = 'force-dynamic';
 
 export default function StatusPage() {
   const envEntries = Object.entries(env).filter(([k]) => k.startsWith('NEXT_PUBLIC')) as [string, string][];
-  return <SystemStatusClient envEntries={envEntries} jwtCookie={env.cookieName} />;
+  return <SystemStatusClient envEntries={envEntries} jwtCookie={env.JWT_COOKIE_NAME!} />;
 }

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getUser } from '@/auth/getUser';
 
 async function fetchUser(id: string) {
   const path = id === 'me' ? API.me : API.publicUser(id);
-  const res = await fetch(`${env.apiUrl}${path}`, {
+  const res = await fetch(`${env.API_URL!}${path}`, {
     headers: { cookie: cookies().toString() },
     cache: 'no-store',
   });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,29 +1,44 @@
-import { z } from 'zod';
+// Edge-safe env helper used by both Node (route handlers) and Edge (middleware).
+// Do NOT import "server-only" here; this module is consumed by middleware.
 
-const schema = z.object({
-  API_URL: z.string(),
-  JWT_COOKIE_NAME: z.string(),
-  JWT_MAX_AGE_SECONDS: z.coerce.number().default(1209600),
-  NEXT_PUBLIC_API_URL: z.string(),
-  NEXT_PUBLIC_SOCKET_URL: z.string(),
-});
+const RUNTIME = process.env.NEXT_RUNTIME ?? 'nodejs';
 
-const parsed = schema.parse({
-  API_URL: process.env.API_URL ?? 'http://127.0.0.1:8080',
-  JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME ?? 'auth_token',
-  JWT_MAX_AGE_SECONDS: process.env.JWT_MAX_AGE_SECONDS ?? 1209600,
-  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? '',
-  NEXT_PUBLIC_SOCKET_URL: process.env.NEXT_PUBLIC_SOCKET_URL ?? '',
-});
-
-export const env = {
-  ...parsed,
-  apiUrl: parsed.API_URL,
-  publicApiUrl: parsed.NEXT_PUBLIC_API_URL ?? '',
-  socketUrl: parsed.NEXT_PUBLIC_SOCKET_URL ?? '',
-  cookieName: parsed.JWT_COOKIE_NAME,
-  maxAge: parsed.JWT_MAX_AGE_SECONDS,
+type Env = {
+  API_URL?: string;                   // required in production
+  NEXT_PUBLIC_API_URL?: string;       // optional, for links/display
+  NEXT_PUBLIC_SOCKET_URL?: string;    // optional, sockets disabled if unset
+  JWT_COOKIE_NAME?: string;           // optional, defaults to "auth_token"
+  JWT_MAX_AGE_SECONDS?: string;       // optional, defaults to 1209600 (14d)
 };
 
-export const isProd =
-  (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === 'production';
+const raw: Env = {
+  API_URL: process.env.API_URL,
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  NEXT_PUBLIC_SOCKET_URL: process.env.NEXT_PUBLIC_SOCKET_URL,
+  JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME ?? 'auth_token',
+  JWT_MAX_AGE_SECONDS: process.env.JWT_MAX_AGE_SECONDS ?? '1209600',
+};
+
+// In production, fail fast if required server env is missing.
+// (Edge or Node runtime – both go through this file.)
+if (process.env.NODE_ENV === 'production' && !raw.API_URL) {
+  throw new Error('Missing environment variable: API_URL');
+}
+
+export const env = {
+  ...raw,
+  RUNTIME,
+  isEdge: RUNTIME === 'edge',
+  isNode: RUNTIME !== 'edge',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as Record<string, any> & {
+  readonly API_URL?: string;
+  readonly NEXT_PUBLIC_API_URL?: string;
+  readonly NEXT_PUBLIC_SOCKET_URL?: string;
+  readonly JWT_COOKIE_NAME?: string;
+  readonly JWT_MAX_AGE_SECONDS?: string;
+  readonly RUNTIME: string;
+  readonly isEdge: boolean;
+  readonly isNode: boolean;
+};
+

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -22,5 +22,5 @@ export async function gateway(
     h.set('cookie', incoming);
   }
 
-  return fetch(`${env.API_URL}${path}`, { ...rest, headers: h });
+  return fetch(`${env.API_URL!}${path}`, { ...rest, headers: h });
 }

--- a/src/lib/proxyPhp.ts
+++ b/src/lib/proxyPhp.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { env } from '@/config/env';
 
-const PHP_BASE = env.publicApiUrl || 'https://quickgig.ph'; // public domain base (legacy host)
+const PHP_BASE = env.NEXT_PUBLIC_API_URL || 'https://quickgig.ph'; // public domain base (legacy host)
 
 function rewriteSetCookie(headers: Headers) {
   const all = headers.getSetCookie?.() as unknown as string[] | undefined;

--- a/src/pages/api/notifications/[id].ts
+++ b/src/pages/api/notifications/[id].ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(405).end();
     return;
   }
-  if (!req.cookies[env.cookieName]) {
+  if (!req.cookies[env.JWT_COOKIE_NAME!]) {
     res.status(401).end();
     return;
   }

--- a/src/pages/api/notifications/events.ts
+++ b/src/pages/api/notifications/events.ts
@@ -8,7 +8,7 @@ export const config = {
 };
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (!req.cookies[env.cookieName]) {
+  if (!req.cookies[env.JWT_COOKIE_NAME!]) {
     res.status(401).end();
     return;
   }

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(405).end();
     return;
   }
-  if (!req.cookies[env.cookieName]) {
+  if (!req.cookies[env.JWT_COOKIE_NAME!]) {
     res.status(401).end();
     return;
   }

--- a/src/pages/api/notifications/mark-all-read.ts
+++ b/src/pages/api/notifications/mark-all-read.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(405).end();
     return;
   }
-  if (!req.cookies[env.cookieName]) {
+  if (!req.cookies[env.JWT_COOKIE_NAME!]) {
     res.status(401).end();
     return;
   }


### PR DESCRIPTION
## Summary
- replace `src/config/env.ts` with Edge-safe loader used by middleware and server routes
- switch calls to new `env.API_URL`/`env.JWT_COOKIE_NAME`
- document Edge-safe env loader in README

## Testing
- `npm run typecheck`
- `API_URL=http://localhost npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a492dc810c832789e05fd2d16784c1