### PR TITLE
Handle missing API_URL and add diagnostic endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Optional:
 
 - `NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph`
 
+**Required in Vercel (Preview & Production):** `API_URL=https://api.quickgig.ph`
+
+Optional: `NEXT_PUBLIC_SOCKET_URL` (sockets disabled when unset).
+
+How to verify: open `/api/diag/env` on the Preview URL and look for `apiUrlSet:true`.
+
 Set these in Vercel → Project → Settings → Env Vars (Production).
 Protected routes redirect to /login when session cookie is missing.
 

--- a/src/app/api/diag/env/route.ts
+++ b/src/app/api/diag/env/route.ts
@@ -1,0 +1,13 @@
+import { env } from '@/config/env';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  return Response.json(
+    {
+      apiUrlSet: !!env.API_URL,
+      vercelEnv: process.env.VERCEL_ENV ?? 'unknown',
+    },
+    { headers: { 'cache-control': 'no-store' } }
+  );
+}

--- a/src/app/api/session/logout/route.ts
+++ b/src/app/api/session/logout/route.ts
@@ -5,6 +5,13 @@ import { gateway, copySetCookie } from '@/lib/gateway';
 export const runtime = 'nodejs';
 
 export async function POST() {
+  if (!env.API_URL) {
+    return Response.json(
+      { ok: false, error: 'misconfigured', detail: 'API_URL is not set' },
+      { status: 503 }
+    );
+  }
+
   let upstream: Response | null = null;
   try {
     upstream = await gateway('/auth/logout', { method: 'POST' });

--- a/src/app/api/session/register/route.ts
+++ b/src/app/api/session/register/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { env } from '@/config/env';
 import { proxyPhp } from '@/lib/proxyPhp';
 
 export const runtime = 'nodejs';
@@ -6,4 +7,12 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function OPTIONS() { return new Response(null, { status: 204 }); }
-export async function POST(req: NextRequest) { return proxyPhp(req, '/register.php'); }
+export async function POST(req: NextRequest) {
+  if (!env.API_URL) {
+    return Response.json(
+      { ok: false, error: 'misconfigured', detail: 'API_URL is not set' },
+      { status: 503 }
+    );
+  }
+  return proxyPhp(req, '/register.php');
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,34 +2,18 @@
 // Do NOT import "server-only" here; this module is consumed by middleware.
 
 const RUNTIME = process.env.NEXT_RUNTIME ?? 'nodejs';
+const isProd = process.env.VERCEL_ENV === 'production';
 
-type Env = {
-  API_URL?: string;                   // required in production
-  NEXT_PUBLIC_API_URL?: string;       // optional, for links/display
-  NEXT_PUBLIC_SOCKET_URL?: string;    // optional, sockets disabled if unset
-  JWT_COOKIE_NAME?: string;           // optional, defaults to "auth_token"
-  JWT_MAX_AGE_SECONDS?: string;       // optional, defaults to 1209600 (14d)
-};
-
-const raw: Env = {
+export const env = {
   API_URL: process.env.API_URL,
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   NEXT_PUBLIC_SOCKET_URL: process.env.NEXT_PUBLIC_SOCKET_URL,
   JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME ?? 'auth_token',
   JWT_MAX_AGE_SECONDS: process.env.JWT_MAX_AGE_SECONDS ?? '1209600',
-};
-
-// In production, fail fast if required server env is missing.
-// (Edge or Node runtime – both go through this file.)
-if (process.env.NODE_ENV === 'production' && !raw.API_URL) {
-  throw new Error('Missing environment variable: API_URL');
-}
-
-export const env = {
-  ...raw,
   RUNTIME,
   isEdge: RUNTIME === 'edge',
   isNode: RUNTIME !== 'edge',
+  isProd,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as Record<string, any> & {
   readonly API_URL?: string;
@@ -40,5 +24,22 @@ export const env = {
   readonly RUNTIME: string;
   readonly isEdge: boolean;
   readonly isNode: boolean;
+  readonly isProd: boolean;
 };
+
+const warned = new Set<string>();
+
+export function requireVar(name: keyof typeof process.env) {
+  const key = String(name);
+  const value = process.env[key];
+  if (value) return value;
+  if (env.isProd) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  if (!warned.has(key)) {
+    console.warn(`Missing environment variable: ${key}`);
+    warned.add(key);
+  }
+  return undefined;
+}
 


### PR DESCRIPTION
## Summary
- relax env loading with `env.isProd` and `requireVar`
- guard `/api/session/*` routes when `API_URL` is unset and forward `Set-Cookie`
- add `/api/diag/env` for runtime env checks and document configuration

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49c1352308327a3549ddf9bf68239