### PR TITLE
Add /status endpoint forwarding to health check

### DIFF
--- a/api.quickgig.ph/index.php
+++ b/api.quickgig.ph/index.php
@@ -39,6 +39,10 @@ function authUser($db) {
 }
 
 try {
+  if ($method==='GET' && $path==='/status') {
+    require __DIR__ . '/health.php';
+    return;
+  }
   // Auth routes
   if ($method==='POST' && $path==='/auth/register') {
     $name = trim($body['name'] ?? '');


### PR DESCRIPTION
## Summary
- Add `/status` route in backend that forwards to existing `health.php` to return the same JSON health check

## Testing
- `php -l api.quickgig.ph/index.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4fce0e9b083278aa7d3da2a7b3b42