### PR TITLE
chore: centralize API base, add /diag status, and CI smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_SOCKET_URL=wss://api.quickgig.ph   # optional; sockets disabled if unset
 API_URL=https://api.quickgig.ph
-NEXT_PUBLIC_API_URL=https://app.quickgig.ph
+NEXT_PUBLIC_API_URL=https://api.quickgig.ph
 JWT_COOKIE_NAME=auth_token
 JWT_MAX_AGE_SECONDS=1209600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         run: npm run typecheck
       - name: Build
         run: npm run build
+      - name: Smoke API
+        run: npm run smoke:api
       - name: Smoke settings
         run: node tools/smoke_settings.mjs || echo 'settings smoke skipped'
       - name: Smoke engine

--- a/README.md
+++ b/README.md
@@ -851,8 +851,8 @@ Preflight (`OPTIONS`) should return `200`.
 
 ## Health & CI
 
-* **API health:** `https://api.quickgig.ph/health.php` → JSON `{ ok: true, ts: <unix> }`
-* Minimal CI: install + build.
+* **API health:** `https://app.quickgig.ph/api/diag/status` → JSON `{ ok: true, ... }`
+* Minimal CI: install + build + `npm run smoke:api`.
 
 ### Local/Preview Notes
 
@@ -861,13 +861,13 @@ Preflight (`OPTIONS`) should return `200`.
 ## Manual Triage
 
 * Frontend: `curl -I https://quickgig.ph/` shows `308` with `Location: https://app.quickgig.ph/`.
-* API: `https://api.quickgig.ph/health.php` in a browser.
+* API: `https://app.quickgig.ph/api/diag/status` in a browser.
 * DevTools → Application → Cookies: confirm `.quickgig.ph` cookie, `Secure`, `HttpOnly`, `SameSite=None`.
 
 ## Screenshots / Evidence (attach in PR description)
 
 * `quickgig.ph` rendering correctly
-* `api.quickgig.ph/health.php` JSON
+* `app.quickgig.ph/api/diag/status` JSON
 
 
 ## Production Domains (canonical)
@@ -885,7 +885,7 @@ Preflight (`OPTIONS`) should return `200`.
   open https://app.quickgig.ph
 
 - Verify API:
-  curl -i https://api.quickgig.ph/health.php
+  curl -i https://app.quickgig.ph/api/diag/status
 
 ### Cookies & CORS
 - Cookies from API: Domain=.quickgig.ph; Path=/; Secure; HttpOnly; SameSite=None

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,57 @@
+import { BASE } from './env';
+
+interface ApiError extends Error {
+  status?: number;
+  url?: string;
+}
+
+function timeoutSignal(ms: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
+async function request(path: string, init: RequestInit & { timeout?: number } = {}) {
+  const url = `${BASE.replace(/\/$/, '')}${path}`;
+  const { timeout = 10000, headers, body, ...rest } = init;
+  const res = await fetch(url, {
+    ...rest,
+    headers: {
+      Accept: 'application/json',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(headers || {}),
+    },
+    body,
+    signal: timeoutSignal(timeout),
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = data.message || message;
+    } catch {
+      /* ignore */
+    }
+    const err: ApiError = new Error(message);
+    err.status = res.status;
+    err.url = url;
+    throw err;
+  }
+  return res;
+}
+
+export async function apiGet<T>(path: string, opts?: RequestInit & { timeout?: number }): Promise<T> {
+  const res = await request(path, { ...opts, method: 'GET' });
+  return res.json() as Promise<T>;
+}
+
+export async function apiPost<T>(path: string, body: unknown, opts?: RequestInit & { timeout?: number }): Promise<T> {
+  const res = await request(path, {
+    ...opts,
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return res.json() as Promise<T>;
+}
+
+export { BASE };

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,9 @@
+const DEFAULT_API_URL = 'https://api.quickgig.ph';
+
+const base = process.env.NEXT_PUBLIC_API_URL;
+if (!base && process.env.NODE_ENV === 'production') {
+  throw new Error('NEXT_PUBLIC_API_URL is required in production');
+}
+
+export const API_BASE_URL = base || DEFAULT_API_URL;
+export const BASE = API_BASE_URL;

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,0 +1,3 @@
+import pkg from '../package.json';
+
+export const APP_VERSION = pkg.version;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "scan:links": "node tools/check_links.mjs",
     "guard:auth-proxy": "node tools/guard_auth_proxy.mjs",
     "verify:http": "node scripts/verify_http.mjs",
-    "verify:api": "node -e \"fetch('http://127.0.0.1:3000/api/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\""
+    "verify:api": "node -e \"fetch('http://127.0.0.1:3000/api/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\"",
+    "smoke:api": "node scripts/smoke-api.mjs",
+    "diag:local": "next dev -p 3000"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/smoke-api.mjs
+++ b/scripts/smoke-api.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const BASE = (process.env.NEXT_PUBLIC_API_URL || 'https://api.quickgig.ph').replace(/\/$/, '');
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), 10000);
+
+(async () => {
+  try {
+    const res = await fetch(BASE + '/status', { signal: controller.signal });
+    const data = await res.json();
+    console.log(JSON.stringify(data, null, 2));
+    if (res.ok && data) process.exit(0);
+    process.exit(1);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  } finally {
+    clearTimeout(timer);
+  }
+})();

--- a/src/app/api/system/ping/route.ts
+++ b/src/app/api/system/ping/route.ts
@@ -1,4 +1,4 @@
-import { env } from '@/config/env';
+import { BASE } from '../../../../../lib/api';
 
 async function tryFetch(url: string) {
   const controller = new AbortController();
@@ -15,8 +15,8 @@ async function tryFetch(url: string) {
 }
 
 export async function GET() {
-  const base = env.API_URL!.replace(/\/$/, '');
-  const paths = ['/health', '/health.php', ''];
+  const base = BASE.replace(/\/$/, '');
+  const paths = ['/status', ''];
   for (const p of paths) {
     const result = await tryFetch(`${base}${p}`);
     if (result) {

--- a/src/app/health-check/HealthCheckClient.tsx
+++ b/src/app/health-check/HealthCheckClient.tsx
@@ -92,12 +92,12 @@ export default function HealthCheckClient({
       </table>
       <p>
         <a
-          href="https://api.quickgig.ph/health"
+          href="/api/diag/status"
           target="_blank"
           rel="noopener noreferrer"
           className="underline text-blue-600"
         >
-          Open API /health
+          Open API /diag/status
         </a>
       </p>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -89,23 +89,13 @@ export interface HealthResponse {
 }
 
 export async function checkHealth(): Promise<HealthResponse> {
-  const paths = ['/health', '/health.php'];
-  for (const path of paths) {
-    const start = Date.now();
-    const res = await safeFetch(path);
-    const latency = Date.now() - start;
-    const parsed = safeJsonParse<{ status?: string }>(res.body);
-    const ok =
-      res.ok &&
-      parsed.ok &&
-      parsed.value?.status &&
-      String(parsed.value.status).toLowerCase() === 'ok';
-    if (ok) return { ...res, path, latency };
-    if (res.error) console.error(`Health check ${path} error:`, res.error);
-    if (!parsed.ok)
-      console.error(`Health check ${path} parse error:`, parsed.error);
-  }
-  return { ok: false, status: 0, body: '', path: '/health.php', latency: 0, error: 'Health check failed' };
+  const path = '/diag/status';
+  const start = Date.now();
+  const res = await safeFetch(path);
+  const latency = Date.now() - start;
+  const parsed = safeJsonParse<{ ok?: boolean }>(res.body);
+  const ok = res.ok && parsed.ok && Boolean(parsed.value?.ok);
+  return { ...res, ok, path, latency };
 }
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -36,8 +36,8 @@ export async function runHealthChecks(): Promise<HealthResult[]> {
   const health = await checkHealth();
   let hint: string | undefined;
   if (!health.ok) {
-    if (health.status === 404 && health.path === '/health')
-      hint = 'Ensure health.php exists at api docroot';
+    if (health.status === 404)
+      hint = 'Ensure /status endpoint exists on backend';
     else if (health.status === 403)
       hint = 'Check Hostinger .htaccess or WAF rule; DirectoryIndex and RewriteEngine Off';
     else if (health.status === 500)

--- a/src/pages/api/diag/status.ts
+++ b/src/pages/api/diag/status.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { BASE } from '../../../../lib/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end();
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  const baseUrl = BASE.replace(/\/$/, '');
+  try {
+    const r = await fetch(`${baseUrl}/status`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const backend = await r.json();
+    return res.status(200).json({ ok: true, backend, baseUrl, time: new Date().toISOString() });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const cause =
+      err instanceof Error && 'cause' in err && (err as { cause?: unknown }).cause
+        ? String((err as { cause?: unknown }).cause)
+        : undefined;
+    return res
+      .status(502)
+      .json({ ok: false, error: { message, cause, baseUrl } });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/pages/diag/index.tsx
+++ b/src/pages/diag/index.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { APP_VERSION } from '../../../lib/version';
+
+interface StatusResponse {
+  ok: boolean;
+  backend?: unknown;
+  baseUrl?: string;
+  time?: string;
+  error?: { message: string; cause?: string; baseUrl: string };
+}
+
+export default function DiagPage() {
+  const [data, setData] = useState<StatusResponse | null>(null);
+  const [duration, setDuration] = useState<number | null>(null);
+
+  async function load() {
+    const start = performance.now();
+    try {
+      const res = await fetch('/api/diag/status');
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setData({ ok: false, error: { message: (err as Error).message, baseUrl: '' } });
+    } finally {
+      setDuration(performance.now() - start);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const ok = data?.ok;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Frontend → Backend status</h1>
+      <p className="text-sm text-gray-600">Version: {APP_VERSION}</p>
+      <div className="flex items-center space-x-2">
+        {ok === undefined ? (
+          <span className="px-2 py-1 text-xs bg-gray-400 text-white rounded">…</span>
+        ) : ok ? (
+          <span className="px-2 py-1 text-xs bg-green-600 text-white rounded">OK</span>
+        ) : (
+          <span className="px-2 py-1 text-xs bg-red-600 text-white rounded">FAIL</span>
+        )}
+        {duration !== null && (
+          <span className="text-sm">{Math.round(duration)}ms</span>
+        )}
+      </div>
+      <div>Backend base URL: {data?.baseUrl || data?.error?.baseUrl || 'unknown'}</div>
+      <pre className="bg-gray-100 p-2 text-xs overflow-auto">
+        {data ? JSON.stringify(data.backend || data.error, null, 2) : 'Loading...'}
+      </pre>
+      <button
+        onClick={load}
+        className="px-3 py-1 border rounded"
+      >
+        Retry
+      </button>
+    </main>
+  );
+}

--- a/tools/check_api.mjs
+++ b/tools/check_api.mjs
@@ -5,9 +5,9 @@ const BASE = (process.env.NEXT_PUBLIC_API_URL || 'https://api.quickgig.ph').repl
 
 (async () => {
   try {
-    const res = await fetch(BASE + '/health.php');
+    const res = await fetch(BASE + '/status');
     const data = await res.json();
-    if (data && data.status === 'ok') {
+    if (res.ok && data) {
       console.log('API OK');
       process.exit(0);
     }

--- a/tools/check_live_api.mjs
+++ b/tools/check_live_api.mjs
@@ -52,8 +52,7 @@ async function check(path, expect) {
   rows.push(await check('/', { key: 'message', value: 'QuickGig API' }));
 
   // Health check with fallback
-  let health = await check('/health', { key: 'status', value: 'ok' });
-  if (!health.pass) health = await check('/health.php', { key: 'status', value: 'ok' });
+  const health = await check('/status', { key: 'ok', value: true });
   rows.push(health);
 
   console.log('Endpoint | Code | Result | Body');


### PR DESCRIPTION
## Summary
- add shared API client and env guard for consistent backend URL usage
- expose `/api/diag/status` and `/diag` UI to show backend health and app version
- add `smoke:api` script and wire into CI to fail fast when backend is down

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run smoke:api` *(fails: fetch failed)*
- `node -e "console.log(process.env.NEXT_PUBLIC_API_URL||'missing')"`
- `curl -sS https://app.quickgig.ph/api/diag/status | head -c 300 || true` *(CONNECT tunnel failed, response 403)*

Sample `/api/diag/status` output:
```json
{"ok":false,"error":{"message":"CONNECT tunnel failed, response 403","baseUrl":"https://api.quickgig.ph"}}
```

------
https://chatgpt.com/codex/tasks/task_e_68a50079893c8327a90750a4f5845b1d