### PR TITLE
feat: add status endpoint

### DIFF
--- a/api.quickgig.ph/.htaccess
+++ b/api.quickgig.ph/.htaccess
@@ -1,6 +1,7 @@
 DirectoryIndex index.php index.html
 RewriteEngine On
 RewriteRule ^health$ health.php [L]
+RewriteRule ^status$ health.php [L,QSA]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]

--- a/api.quickgig.ph/status.php
+++ b/api.quickgig.ph/status.php
@@ -1,0 +1,4 @@
+<?php
+require __DIR__ . '/health.php';
+exit;
+


### PR DESCRIPTION
## Summary
- expose `/status` endpoint returning same JSON as health check
- map `/status` to `health.php` via `.htaccess` rewrite

## Testing
- `php -l api.quickgig.ph/status.php`
- `php -l api.quickgig.ph/health.php`
- `npm test` *(fails: Missing script: "test")*
- `curl -i http://127.0.0.1:8321/status`
- `curl -i http://127.0.0.1:8321/health.php`

## How to Verify
- `curl -i https://api.quickgig.ph/status`
- `curl -i https://api.quickgig.ph/health.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5070965a4832784abed4eb8ec3aaf