### PR TITLE
feat: add cookie auth pages

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { updateProfile, type User } from '../../../lib/auth';
+import { toast } from '@/lib/toast';
+
+export default function AccountPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+
+  useEffect(() => {
+    fetch('/api/auth/me')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((u) => {
+        if (!u) {
+          router.push('/login');
+          return;
+        }
+        setUser(u);
+        setName(u.name || '');
+        setPhone(u.phone || '');
+      });
+  }, [router]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const res = await updateProfile({ name, phone });
+      setUser(res.user);
+      toast('Profile saved');
+    } catch {
+      toast('Update failed');
+    }
+  }
+
+  if (!user) return <p className="p-4">Loading...</p>;
+
+  return (
+    <main className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Account</h1>
+      <form onSubmit={onSubmit} className="flex flex-col gap-2">
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="tel"
+          placeholder="Phone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white p-2 mt-2">
+          Save
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,67 +1,48 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { login } from '../../../lib/auth';
+import { toast } from '@/lib/toast';
 
 export default function LoginPage() {
   const router = useRouter();
-  const [identifier, setIdentifier] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
 
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setLoading(true);
-    setError('');
-    const res = await fetch('/api/session/login', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ identifier, password }),
-    });
-    if (res.ok) {
-      const next =
-        typeof window !== 'undefined'
-          ? new URLSearchParams(window.location.search).get('next')
-          : null;
-      router.push(next || '/dashboard');
-    } else {
-      const data = await res.json().catch(() => null);
-      setError(data?.error || 'Login failed');
+    try {
+      await login(email, password);
+      router.push('/account');
+    } catch {
+      toast('Login failed');
     }
-    setLoading(false);
   }
 
   return (
-    <div className="qg-container py-12">
-      <div className="max-w-md mx-auto bg-white/70 rounded-2xl p-6 shadow">
-        <h1 className="text-2xl font-bold mb-2">Login</h1>
-          <form onSubmit={onSubmit} className="space-y-3">
-            <div>
-              <label className="block text-sm font-medium mb-1">Identifier</label>
-              <input
-                className="w-full border rounded-lg p-2"
-                type="text"
-                value={identifier}
-                onChange={(e) => setIdentifier(e.target.value)}
-                required
-              />
-            </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Password</label>
-            <input
-              className="w-full border rounded-lg p-2"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          {error && <p className="text-red-600 text-sm">{error}</p>}
-          <button type="submit" disabled={loading} className="btn btn-primary w-full">
-            {loading ? 'Signing in…' : 'Login'}
-          </button>
-        </form>
-      </div>
-    </div>
+    <main className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form onSubmit={onSubmit} className="flex flex-col gap-2">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <button type="submit" className="bg-blue-500 text-white p-2 mt-2">
+          Login
+        </button>
+      </form>
+    </main>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,60 +1,57 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { env } from '@/config/env';
-import { track } from '@/lib/track';
-import { register } from '@/lib/auth';
+import { register } from '../../../lib/auth';
+import { toast } from '@/lib/toast';
 
 export default function RegisterPage() {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setError(null);
-    if (!name || !email || !password) { setError('All fields are required'); return; }
-    setLoading(true);
     try {
-      await register({ name, email, password });
-      if (env.NEXT_PUBLIC_ENABLE_ANALYTICS) track('signup_success');
-      router.push('/dashboard');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
-    } finally {
-      setLoading(false);
+      await register(email, password, name);
+      router.push('/account');
+    } catch {
+      toast('Registration failed');
     }
   }
 
   return (
-    <div className="qg-container py-12">
-      <div className="max-w-md mx-auto bg-white/70 rounded-2xl p-6 shadow">
-        <h1 className="text-2xl font-bold mb-2">Register</h1>
-        <p className="text-sm text-gray-600 mb-4">Create your QuickGig account.</p>
-        {error && <div className="bg-red-100 text-red-700 border border-red-200 rounded-lg p-3 mb-3">{error}</div>}
-        <form onSubmit={onSubmit} className="space-y-3">
-          <div>
-            <label className="block text-sm font-medium mb-1">Full name</label>
-            <input className="w-full border rounded-lg p-2" value={name} onChange={e=>setName(e.target.value)} required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
-            <input className="w-full border rounded-lg p-2" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Password</label>
-            <input className="w-full border rounded-lg p-2" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
-          </div>
-          <button className="w-full bg-yellow-400 font-semibold rounded-lg py-2" type="submit" disabled={loading}>
-            {loading ? 'Creating account…' : 'Sign Up'}
-          </button>
-        </form>
-        <p className="text-sm mt-3">Already have an account? <Link className="text-sky-600 font-semibold" href="/login">Login</Link></p>
-      </div>
-    </div>
+    <main className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Register</h1>
+      <form onSubmit={onSubmit} className="flex flex-col gap-2">
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <button type="submit" className="bg-blue-500 text-white p-2 mt-2">
+          Register
+        </button>
+      </form>
+    </main>
   );
 }

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { BASE } from '../../../../lib/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const r = await fetch(`${BASE}/auth/logout.php`, {
+    method: 'POST',
+    headers: { cookie: req.headers.cookie || '' },
+    credentials: 'include',
+  });
+  const data = await r.json();
+  res.status(r.status).json(data);
+}


### PR DESCRIPTION
## Summary
- add minimal login, register, and account pages wired to cookie-auth backend
- proxy logout endpoint and verify account access via middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `BASE=https://api.quickgig.ph` `curl -i "$BASE/status"` *(CONNECT tunnel failed, response 403)*
- `curl -i "https://api.quickgig.ph/tools/install.php?token=RUN_ONCE"` *(CONNECT tunnel failed, response 403)*
- `curl -i -X POST "$BASE/auth/register.php" -H 'Content-Type: application/json' --data '{"email":"you+demo@quickgig.ph","password":"P@ssw0rd!","name":"Marlon"}' --cookie-jar c.txt` *(CONNECT tunnel failed, response 403)*
- `curl -s "$BASE/auth/me.php" --cookie c.txt` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a51e98e1188327a9dd58d4258e748d