### PR TITLE
fix(build): guard checkout params and serve legacy font via CSS

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Suspense, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+type Item = { ticket_type_id: number; quantity: number };
+
+function CheckoutContent() {
+  const search = useSearchParams();
+  const { eventId, items } = useMemo(() => {
+    const s = search;
+    const eventStr = s?.get('event') ?? '';
+    const eventId = Number.isFinite(Number(eventStr)) ? Number(eventStr) : 0;
+    const itemsJson = s?.get('items') ?? '[]';
+    let items: Item[] = [];
+    try { items = JSON.parse(itemsJson); } catch { items = []; }
+    return { eventId, items };
+  }, [search]);
+
+  if (!eventId) {
+    return (
+      <main className="p-6">
+        <h1 className="text-xl font-semibold">Invalid checkout link</h1>
+        <p className="mt-2"><a className="underline" href="/events">Browse events</a></p>
+      </main>
+    );
+  }
+
+  void items; // items will be used for order summary and creation.
+
+  return (
+    <main className="p-6">
+      {/* TODO: summary, order create, polling, etc. */}
+      <h1 className="text-xl font-semibold">Checkout</h1>
+    </main>
+  );
+}
+
+export default function CheckoutPage() {
+  return (
+    <Suspense fallback={<main className="p-6">Loading...</main>}>
+      <CheckoutContent />
+    </Suspense>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,3 +159,23 @@ html {
   background-color: var(--qg-accent-yellow);
   color: var(--qg-navy);
 }
+
+@font-face {
+  font-family: 'LegacySans';
+  src: url('/legacy/fonts/LegacySans-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'LegacySans';
+  src: url('/legacy/fonts/LegacySans-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  --font-legacy-sans: 'LegacySans', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
 import Link from "next/link";
 import "./globals.css";
 import "../styles/tokens-legacy.css";
@@ -14,16 +13,6 @@ import { SEO } from "@/config/seo";
 import { canonical } from "@/lib/canonical";
 import AppShellV2 from '@/components/layouts/AppShellV2';
 import { env } from '@/config/env';
-
-const legacySans = localFont({
-  variable: "--font-legacy-sans",
-  display: "swap",
-  fallback: ["system-ui", "Arial", "sans-serif"],
-  src: [
-    { path: "../../public/legacy/fonts/LegacySans-Regular.woff2", weight: "400", style: "normal" },
-    { path: "../../public/legacy/fonts/LegacySans-Medium.woff2", weight: "500", style: "normal" },
-  ],
-});
 
 if (process.env.NODE_ENV !== 'production' && env.NEXT_PUBLIC_ENABLE_LINK_MAP_SANITY) {
   import('../../tools/linkMapSanity').then((m) => m.linkMapSanity?.());
@@ -101,7 +90,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const skin = process.env.NEXT_PUBLIC_SKIN;
-  const legacy = skin === "legacy" ? legacySans.variable : "";
+  const legacy = skin === "legacy" ? 'font-[var(--font-legacy-sans)]' : '';
   return (
     <html lang="en" className={skin === 'legacy' ? 'legacy scroll-smooth' : 'scroll-smooth'}>
       <head>


### PR DESCRIPTION
## Summary
- safeguard checkout query parsing and handle invalid links
- load legacy font via CSS variables instead of `next/font`

## Testing
- `npm run check:routes`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a52cd117d88327b1d9a0be4ab46bc5