### PR TITLE
Add backend bootstrap workflow and helper script

### DIFF
--- a/.github/workflows/bootstrap-backend.yml
+++ b/.github/workflows/bootstrap-backend.yml
@@ -1,0 +1,170 @@
+name: Bootstrap backend (deploy + install + seed)
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: Event slug
+        required: true
+        default: launch-party
+      title:
+        description: Event title
+        required: true
+        default: Launch Party
+      venue:
+        description: Venue
+        required: true
+        default: Makati
+      start_time:
+        description: Start time (YYYY-MM-DD HH:MM:SS)
+        required: true
+        default: 2025-09-10 19:00:00
+      price:
+        description: Ticket price (whole currency units, e.g. 5000 PHP cents or 5000)
+        required: true
+        default: "5000"
+      quantity:
+        description: Ticket quantity
+        required: true
+        default: "100"
+
+env:
+  BASE: https://api.quickgig.ph
+  REMOTE_DIR: ${{ secrets.HOSTINGER_REMOTE_DIR }}
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ---------- Deploy ----------
+      - name: Decide deploy method
+        id: method
+        run: |
+          if [[ -n "${{ secrets.HOSTINGER_SSH_KEY }}" && -n "${{ secrets.HOSTINGER_HOST }}" ]]; then
+            echo "method=ssh" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ secrets.HOSTINGER_FTP_SERVER }}" ]]; then
+            echo "method=ftp" >> $GITHUB_OUTPUT
+          else
+            echo "::error::No Hostinger credentials found. Provide SSH or FTP secrets."
+            exit 1
+          fi
+
+      - name: Deploy via SSH
+        if: steps.method.outputs.method == 'ssh'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOSTINGER_HOST }}
+          port: ${{ secrets.HOSTINGER_PORT || '22' }}
+          username: ${{ secrets.HOSTINGER_USER }}
+          key: ${{ secrets.HOSTINGER_SSH_KEY }}
+          overwrite: true
+          strip_components: 0
+          source: "api.quickgig.ph/*"
+          target: "${{ env.REMOTE_DIR }}"
+
+      - name: Deploy via FTP
+        if: steps.method.outputs.method == 'ftp'
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          username: ${{ secrets.HOSTINGER_FTP_USER }}
+          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          local-dir: api.quickgig.ph/
+          server-dir: ${{ env.REMOTE_DIR }}
+          dangerous-clean-slate: false
+
+      # ---------- Smoke ----------
+      - name: Check /status
+        id: status
+        run: |
+          set -e
+          curl -sS -w '\n%{http_code}\n' "$BASE/status" -o status.json | tee status.code
+          code=$(tail -n1 status.code)
+          echo "http_code=$code" >> $GITHUB_OUTPUT
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat status.json >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          [[ "$code" == "200" ]] || (echo "::warning::/status not 200 (got $code). Continuing.")
+
+      - name: Check /events/index.php
+        id: events_index
+        run: |
+          set -e
+          curl -sS -w '\n%{http_code}\n' "$BASE/events/index.php" -o events.json | tee events.code
+          code=$(tail -n1 events.code)
+          echo "http_code=$code" >> $GITHUB_OUTPUT
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat events.json >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          # allow 404 before install
+
+      # ---------- Install ----------
+      - name: Run installer (idempotent)
+        run: |
+          set -e
+          curl -sS -i "$BASE/tools/install.php?token=RUN_ONCE" | sed -n '1,30p' | tee -a $GITHUB_STEP_SUMMARY
+
+      # ---------- Seed event ----------
+      - name: Seed example event (try price_cents then price)
+        id: seed
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -e
+          slug="${{ github.event.inputs.slug }}"
+          title="${{ github.event.inputs.title }}"
+          venue="${{ github.event.inputs.venue }}"
+          start="${{ github.event.inputs.start_time }}"
+          price="${{ github.event.inputs.price }}"
+          qty="${{ github.event.inputs.quantity }}"
+
+          echo "Attempt 1: schema A (tickets[*].price_cents)"
+          body_a=$(jq -nc --arg slug "$slug" --arg title "$title" --arg venue "$venue" --arg start "$start" --argjson price "$price" --argjson qty "$qty" \
+            '{slug:$slug,title:$title,venue:$venue,start_time:$start,status:"published",
+              tickets:[{name:"GA",price_cents:($price*10|floor)*10,quantity_total:$qty}] }')
+          code_a=$(curl -sS -o seed_a.json -w '%{http_code}' -X POST "$BASE/admin/events/create.php" \
+            -H "X-Admin-Token: $ADMIN_TOKEN" -H "Content-Type: application/json" --data "$body_a" || true)
+          echo "Attempt 1 code: $code_a"
+
+          if [[ "$code_a" != "200" && "$code_a" != "201" ]]; then
+            echo "Attempt 2: schema B (ticket_types[*].price)"
+            body_b=$(jq -nc --arg slug "$slug" --arg title "$title" --arg venue "$venue" --arg start "$start" --argjson price "$price" --argjson qty "$qty" \
+              '{slug:$slug,name:$title,venue:$venue,start_time:$start,status:"published",
+                ticket_types:[{name:"General",price:$price,quantity_total:$qty}] }')
+            code_b=$(curl -sS -o seed_b.json -w '%{http_code}' -X POST "$BASE/admin/events/create.php" \
+              -H "X-Admin-Token: $ADMIN_TOKEN" -H "Content-Type: application/json" --data "$body_b" || true)
+            echo "Attempt 2 code: $code_b"
+            testcode="$code_b"
+            cat seed_b.json > seed.json || true
+          else
+            testcode="$code_a"
+            cat seed_a.json > seed.json || true
+          fi
+
+          echo "create_code=$testcode" >> $GITHUB_OUTPUT
+          echo '### Seed response' >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat seed.json >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Show event (by slug)
+        run: |
+          slug="${{ github.event.inputs.slug }}"
+          curl -sS "$BASE/events/show.php?slug=$slug" | tee show.json >/dev/null
+          echo '### Show event' >> $GITHUB_STEP_SUMMARY
+          echo "Event URL: $BASE/events/show.php?slug=$slug" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat show.json >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Final summary
+        run: |
+          echo "✅ Backend bootstrap completed for $BASE" >> $GITHUB_STEP_SUMMARY
+          echo "- Deploy dir: $REMOTE_DIR" >> $GITHUB_STEP_SUMMARY
+          echo "- Status HTTP: ${{ steps.status.outputs.http_code }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Events index HTTP: ${{ steps.events_index.outputs.http_code }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Seed code: ${{ steps.seed.outputs.create_code }}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -993,3 +993,18 @@ curl -s "$BASE/events/index.php"
 ### Runbook
 
 If `/events/index.php` returns HTML, deploy didn’t run or files aren’t in `public_html/api/`—rerun workflow or check server path.
+
+## Backend Bootstrap (deploy + install + seed)
+
+Deploys the backend, runs the installer, and seeds a sample event.
+
+1. Go to **Actions → Bootstrap backend (deploy + install + seed)**.
+2. Click "Run workflow" and adjust inputs if needed.
+
+Required secrets: `HOSTINGER_*` (SSH or FTP) and `ADMIN_TOKEN`.
+
+Local alternative:
+
+```bash
+ADMIN=<token> BASE=https://api.quickgig.ph npm run bootstrap:backend
+```

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "verify:api": "node -e \"fetch('http://127.0.0.1:3000/api/system/status').then(r=>console.log(r.status)).catch(e=>{console.error(e);process.exit(1)})\"",
     "smoke:api": "node scripts/smoke-api.mjs",
     "diag:local": "next dev -p 3000",
-    "check:routes": "node scripts/check-route-conflicts.mjs"
+    "check:routes": "node scripts/check-route-conflicts.mjs",
+    "bootstrap:backend": "bash scripts/bootstrap_backend.sh"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^15.4.6",

--- a/scripts/bootstrap_backend.sh
+++ b/scripts/bootstrap_backend.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${BASE:-https://api.quickgig.ph}"
+ADMIN="${ADMIN:-}"
+
+echo "== Smoke /status =="
+curl -sS "$BASE/status" | jq .
+
+echo "== Install =="
+curl -sS -i "$BASE/tools/install.php?token=RUN_ONCE" | sed -n '1,15p'
+
+echo "== Seed event =="
+slug="${SLUG:-launch-party}"
+title="${TITLE:-Launch Party}"
+venue="${VENUE:-Makati}"
+start="${START_TIME:-2025-09-10 19:00:00}"
+price="${PRICE:-5000}"
+qty="${QTY:-100}"
+
+if [[ -z "$ADMIN" ]]; then
+  echo "Set ADMIN=<admin token> to seed admin endpoints." >&2
+  exit 1
+fi
+
+curl -sS -X POST "$BASE/admin/events/create.php" \
+ -H "X-Admin-Token: $ADMIN" -H "Content-Type: application/json" \
+ --data "{\"slug\":\"$slug\",\"title\":\"$title\",\"venue\":\"$venue\",\"start_time\":\"$start\",\"status\":\"published\",\"tickets\":[{\"name\":\"GA\",\"price_cents\":$((price*100)),\"quantity_total\":$qty}]}" | jq . || true
+
+echo "== Show event =="
+curl -sS "$BASE/events/show.php?slug=$slug" | jq .


### PR DESCRIPTION
## Summary
- add manual "Bootstrap backend (deploy + install + seed)" workflow to deploy API, run installer and seed a sample event
- provide `bootstrap_backend.sh` and npm script for local smoke/install/seed
- document backend bootstrap steps in README

## Testing
- `npm test` (missing script)
- `npm run lint`

## Runbook
### How to verify
1. Run the workflow **Bootstrap backend (deploy + install + seed)** from Actions and ensure each step succeeds.
2. `curl -s https://api.quickgig.ph/events/index.php | jq` returns JSON.
3. Visit https://app.quickgig.ph/events and see **Launch Party**.


------
https://chatgpt.com/codex/tasks/task_e_68a545f84e4c83279e63f8f05c91e81f