### PR TITLE
ci: deploy PHP API to Hostinger via FTPS (lftp) + verify & seed

### DIFF
--- a/.github/workflows/deploy-api-ftp.yml
+++ b/.github/workflows/deploy-api-ftp.yml
@@ -1,0 +1,70 @@
+name: Deploy PHP API to Hostinger (FTP)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lftp jq
+
+      - name: Deploy api/ via FTPS
+        env:
+          FTP_SERVER:   ${{ secrets.FTP_SERVER }}
+          FTP_PORT:     ${{ secrets.FTP_PORT }}
+          FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
+          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
+          REMOTE_DIR:   ${{ secrets.HOSTINGER_SERVER_DIR }}
+        run: |
+          set -euo pipefail
+          test -d api || { echo "api/ not found"; exit 1; }
+          # lftp settings: force TLS, passive mode, retries
+          lftp -e "
+            set ftp:ssl-allow true;
+            set ftp:ssl-force true;
+            set ftp:passive-mode true;
+            set net:max-retries 2;
+            set net:timeout 30;
+            mkdir -p ${REMOTE_DIR};
+            mirror -R --delete --only-newer --verbose api/ ${REMOTE_DIR};
+            bye
+          " -u \"$FTP_USERNAME\",\"$FTP_PASSWORD\" -p \"$FTP_PORT\" \"$FTP_SERVER\"
+
+      - name: Verify endpoints & run installer
+        run: |
+          set -euo pipefail
+          BASE="https://api.quickgig.ph"
+          echo "== status =="
+          curl -fsS "$BASE/status" | jq .
+          echo "== health =="
+          curl -fsS "$BASE/health.php" | jq .
+          echo "== installer (run-once) =="
+          curl -fsS "$BASE/tools/install.php?token=RUN_ONCE" | tee /tmp/install.json | jq .
+
+      - name: Seed sample event
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE="https://api.quickgig.ph"
+          PAYLOAD=$(jq -n \
+            --arg slug "launch-party" \
+            --arg title "Launch Party" \
+            --arg venue "Makati" \
+            --arg start "2025-09-10 19:00:00" \
+            --arg status "published" \
+            --argjson ticket_types '[{"name":"General","price_cents":50000,"quantity_total":100}]' \
+            '{slug:$slug,title:$title,venue:$venue,start_time:$start,status:$status,ticket_types:$ticket_types}')
+          curl -fsS -X POST "$BASE/admin/events/create.php" \
+            -H "Content-Type: application/json" \
+            -H "X-Admin-Token: $ADMIN_TOKEN" \
+            --data "$PAYLOAD" | tee /tmp/seed.json | jq .
+          echo "== list events =="
+          curl -fsS "$BASE/events/index.php" | jq .

--- a/README.md
+++ b/README.md
@@ -968,11 +968,22 @@ Set the following variables on the server:
 - `HOSTINGER_SSH_KEY`
 - `HOSTINGER_REMOTE_DIR`
 
-### GitHub Secrets (FTP fallback)
+### Deploy backend via FTP
 
-- `HOSTINGER_FTP_SERVER`
-- `HOSTINGER_FTP_USER`
-- `HOSTINGER_FTP_PASSWORD`
+If SSH is unavailable, use the FTPS workflow.
+
+Required secrets:
+
+- `FTP_SERVER`
+- `FTP_PORT` *(usually 21)*
+- `FTP_USERNAME`
+- `FTP_PASSWORD`
+- `HOSTINGER_SERVER_DIR`
+- `ADMIN_TOKEN`
+
+Trigger: Actions → **Deploy PHP API to Hostinger (FTP)** → **Run workflow**.
+
+Verify: open `https://api.quickgig.ph/status`, `https://api.quickgig.ph/health.php`, and `https://api.quickgig.ph/events/index.php`.
 
 ### Installer
 
@@ -987,6 +998,7 @@ https://api.quickgig.ph/tools/install.php?token=RUN_ONCE
 ```
 BASE=https://api.quickgig.ph
 curl -s "$BASE/status"
+curl -s "$BASE/health.php"
 curl -s "$BASE/events/index.php"
 ```
 

--- a/scripts/deploy_api_ftp.sh
+++ b/scripts/deploy_api_ftp.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${FTP_SERVER:?}"; : "${FTP_PORT:?}"; : "${FTP_USERNAME:?}"; : "${FTP_PASSWORD:?}"; : "${HOSTINGER_SERVER_DIR:?}"
+test -d api || { echo "api/ not found"; exit 1; }
+lftp -e "
+  set ftp:ssl-allow true;
+  set ftp:ssl-force true;
+  set ftp:passive-mode true;
+  set net:max-retries 2;
+  set net:timeout 30;
+  mkdir -p ${HOSTINGER_SERVER_DIR};
+  mirror -R --delete --only-newer --verbose api/ ${HOSTINGER_SERVER_DIR};
+  bye
+" -u "$FTP_USERNAME","$FTP_PASSWORD" -p "$FTP_PORT" "$FTP_SERVER"


### PR DESCRIPTION
## Summary
- add manual workflow to deploy api/ via FTPS using lftp, run installer, verify endpoints, and seed a sample event
- provide scripts/deploy_api_ftp.sh to mirror deploy behavior locally
- document FTP deployment workflow and required secrets in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a574be5d548327ba5130a56d2ef922