### PR TITLE
go-live: add secure revalidate route, tag event fetches, and finalize workflow

### DIFF
--- a/.github/workflows/go-live.yml
+++ b/.github/workflows/go-live.yml
@@ -1,0 +1,17 @@
+name: Go Live
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Revalidate frontend caches
+        env:
+          APP_ORIGIN: https://app.quickgig.ph
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST "$APP_ORIGIN/api/revalidate?secret=$REVALIDATE_SECRET&tag=events"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ A Next.js application for QuickGig.ph configured for deployment on Vercel.
 * Ensure DevTools Network shows no calls to `quickgig.ph/*.php` (only `/api/session/*`).
 - Rollback: revert this PR to restore any previous behavior.
 
+## Go Live
+
+Configure the following in Vercel before going live:
+
+- `NEXT_PUBLIC_API_URL=https://api.quickgig.ph`
+- `REVALIDATE_SECRET=<random-long-secret>`
+
+To refresh event pages after updates:
+
+```bash
+curl -X POST "https://app.quickgig.ph/api/revalidate?secret=$REVALIDATE_SECRET&tag=events"
+```
+
+The Go Live workflow triggers this revalidation automatically after deploy.
+
 ## Setup
 
 1. Install dependencies:

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+export async function POST(req: NextRequest) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get('secret');
+  if (token !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+  const tag = url.searchParams.get('tag') ?? 'events';
+  try {
+    revalidateTag(tag);
+    return NextResponse.json({ ok: true, tag });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,0 +1,43 @@
+interface TicketType {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface Event {
+  id: number;
+  slug: string;
+  name: string;
+  description?: string;
+  ticket_types?: TicketType[];
+}
+
+export default async function EventPage({ params }: { params?: { slug?: string } }) {
+  const slug = params?.slug;
+  if (!slug) {
+    return <div>Not found</div>;
+  }
+
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/events/show.php?slug=${encodeURIComponent(slug)}`,
+      { next: { tags: ['events'] } }
+    );
+    if (!res.ok) {
+      return <div>Not found</div>;
+    }
+    const event: Event = await res.json();
+    if (!event || !event.name) {
+      return <div>Not found</div>;
+    }
+    return (
+      <div>
+        <h1>{event.name}</h1>
+        {event.description && <p>{event.description}</p>}
+      </div>
+    );
+  } catch {
+    return <div>Not found</div>;
+  }
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+
+interface Event {
+  id: number;
+  slug: string;
+  name: string;
+  description?: string;
+}
+
+export default async function EventsPage() {
+  let events: Event[] = [];
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/events/index.php`,
+      { next: { tags: ['events'] } }
+    );
+    if (res.ok) {
+      events = await res.json();
+    }
+  } catch {
+    // ignore fetch/parse errors
+  }
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return <div>No events.</div>;
+  }
+
+  return (
+    <div>
+      <h1>Events</h1>
+      <ul>
+        {events.map((ev) => (
+          <li key={ev.id}>
+            <Link href={`/events/${ev.slug}`}>{ev.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add secure /api/revalidate endpoint protected by REVALIDATE_SECRET
- tag event list and detail fetches for cache revalidation
- document go-live env vars and curl command
- call revalidate endpoint in go-live workflow

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a57fc64b0c832798b93c7aaeded5c2