### PR TITLE
ci(go-live): fix FTPS deploy (lftp) and keep verify/seed/revalidate

### DIFF
--- a/.github/workflows/go-live.yml
+++ b/.github/workflows/go-live.yml
@@ -42,11 +42,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install tools
-        shell: bash
         run: |
           echo "== Install tools =="
           sudo apt-get update
-          sudo apt-get install -y lftp jq
+          sudo apt-get install -y jq lftp
 
       - name: Deploy backend via FTPS
         shell: bash
@@ -66,18 +65,18 @@ jobs:
             BACKEND_DIR=_api.quickgig.ph
           elif [ -d backend ]; then
             BACKEND_DIR=backend
+          else
+            echo "Backend directory not found (expected one of: api, _api.quickgig.ph, backend)" >&2
+            exit 1
           fi
 
-          echo "== Mirror $BACKEND_DIR to \$HOSTINGER_SERVER_DIR via FTPS =="
+          echo "== Mirror backend via FTPS =="
 
-          cat >/tmp/lftp.cmd <<'EOF'
-          set ftp:ssl-force true
-          set ssl:verify-certificate no
-          mirror -R --delete "$BACKEND_DIR" "$HOSTINGER_SERVER_DIR"
-          quit
-          EOF
-
-          lftp -u "$FTP_USERNAME","$FTP_PASSWORD" -p "$FTP_PORT" "$FTP_SERVER" -f /tmp/lftp.cmd
+          lftp \
+            -u "${FTP_USERNAME},${FTP_PASSWORD}" \
+            -p "${FTP_PORT}" \
+            -e "set ftp:ssl-force true; set ftp:passive-mode true; set ssl:verify-certificate no; mirror -R --delete --parallel=2 ${BACKEND_DIR} ${HOSTINGER_SERVER_DIR}; bye" \
+            "ftps://${FTP_SERVER}"
 
       - name: Verify backend
         shell: bash


### PR DESCRIPTION
## Summary
- fix `go-live` workflow FTPS deploy by switching to `lftp -e` with `ftps://` and passive mode
- install jq and lftp early for workflow
- keep backend verification, seeding, and revalidation steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5dbd7b430832784a746eb82717415