### PR TITLE
Minimal ops: health endpoint + tiny smoke script + lean deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,4 @@
-# Public (browser-safe)
 NEXT_PUBLIC_SITE_URL=https://app.quickgig.ph
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_STORAGE_BUCKET=assets
-
-# Server-only (never expose)
-SUPABASE_SERVICE_ROLE_KEY=

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,4 @@
+# .vercelignore
+landing_public_html/**
+docs/**
+**/*.md

--- a/docs/MINIMAL_OPERATIONS.md
+++ b/docs/MINIMAL_OPERATIONS.md
@@ -1,0 +1,14 @@
+# Minimal ops
+
+## Local
+1. `cp .env.example .env.local` and fill Supabase URL/anon key.
+2. `npm run dev`
+3. `npm run smoke:local` → expect `{ "ok": true }` in body.
+
+## Production
+- `npm run smoke:prod` (hits https://app.quickgig.ph/api/health)
+
+If smoke fails, verify Vercel envs:
+- NEXT_PUBLIC_SUPABASE_URL
+- NEXT_PUBLIC_SUPABASE_ANON_KEY
+- NEXT_PUBLIC_STORAGE_BUCKET=assets

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "smoke:health": "node -e \"(async()=>{const f=await fetch(process.env.NEXT_PUBLIC_SITE_URL+'/api/health').then(r=>r.json()).catch(e=>({ok:false,error:String(e)}));console.log(f); if(!f.ok) process.exit(1)})()\"",
-    "smoke:print": "node -e \"console.log('SITE',process.env.NEXT_PUBLIC_SITE_URL);console.log('SUPABASE',process.env.NEXT_PUBLIC_SUPABASE_URL)\""
+    "smoke": "node scripts/smoke.mjs",
+    "smoke:local": "SMOKE_BASE=http://localhost:3000 node scripts/smoke.mjs",
+    "smoke:prod": "SMOKE_BASE=https://app.quickgig.ph node scripts/smoke.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2",

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,28 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-/**
- * Health check: verifies required env vars exist and Supabase Auth health responds 200.
- * Returns: { ok: boolean, supabase?: { ok: boolean, status: number }, missing?: string[] }
- */
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  const missing: string[] = [];
-  if (!process.env.NEXT_PUBLIC_SITE_URL) missing.push("NEXT_PUBLIC_SITE_URL");
-  if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL");
-  if (!anon) missing.push("NEXT_PUBLIC_SUPABASE_ANON_KEY");
-
-  if (missing.length) {
-    return res.status(500).json({ ok: false, missing });
+  if (!url || !key) {
+    return res.status(500).json({ ok: false, error: "Missing Supabase envs" });
   }
 
   try {
-    // Supabase Auth health endpoint
-    const r = await fetch(`${url}/auth/v1/health`, { headers: { apikey: anon! } });
-    return res.status(200).json({ ok: r.ok, supabase: { ok: r.ok, status: r.status } });
+    const r = await fetch(`${url}/rest/v1/`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    });
+    const ok = r.ok;
+    return res.status(ok ? 200 : 500).json({ ok, r: `${r.status} : ${r.status}` });
   } catch (e: any) {
-    return res.status(200).json({ ok: false, supabase: { ok: false, status: 0 }, error: String(e?.message ?? e) });
+    return res.status(500).json({ ok: false, error: String(e?.message ?? e) });
   }
 }
-

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,21 @@
+// scripts/smoke.mjs
+/* Minimal smoke: hits /api/health and prints result.
+   Usage:
+     node scripts/smoke.mjs
+     SMOKE_BASE=https://app.quickgig.ph node scripts/smoke.mjs
+*/
+const base = process.env.SMOKE_BASE || "http://localhost:3000";
+const url = `${base.replace(/\/$/, "")}/api/health`;
+
+(async () => {
+  try {
+    const r = await fetch(url);
+    const body = await r.json().catch(() => ({}));
+    const ok = r.ok && body?.ok === true;
+    console.log(JSON.stringify({ base, status: r.status, body }, null, 2));
+    process.exit(ok ? 0 : 1);
+  } catch (e) {
+    console.error("SMOKE ERROR:", e?.message || e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `/api/health` (Pages Router)
- add `scripts/smoke.mjs` and npm scripts `smoke`, `smoke:local`, `smoke:prod`
- add `.vercelignore` to keep deploys fast
- confirm `next.config.js` is minimal; update `.env.example`
- doc quick runbook

## Testing
- `npm run build` *(fails: supabaseUrl is required)*
- `npm run smoke:local` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7035c36bc8327bf37b1e82198ad88