### PR TITLE
feat(saved): saved gigs + alerts

### DIFF
--- a/components/NotificationsBell.tsx
+++ b/components/NotificationsBell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { listNotifications, markAllSeen, subscribeNotifications } from '@/lib/notifications'
 import { supabase } from '@/lib/supabaseClient'
 
@@ -44,15 +45,48 @@ export default function NotificationsBell() {
       </button>
       {open && (
         <div className="absolute right-0 mt-2 w-72 rounded-xl border bg-white p-2 text-black shadow">
-          {(items.length ? items : [{ kind: 'message', payload: {}, created_at: new Date().toISOString() }]).map((n, i) => (
-            <div key={n.id ?? i} className="flex items-start gap-2 p-2">
-              <span>{n.kind === 'message' ? '💬' : n.kind === 'offer' ? '📄' : '✅'}</span>
-              <div className="text-sm">
-                <div className="font-medium capitalize">{n.kind}</div>
-                {n.payload?.snippet && <div className="text-gray-600">{n.payload.snippet}</div>}
+          {(items.length ? items : [{ kind: 'message', payload: {}, created_at: new Date().toISOString() }]).map((n, i) => {
+            const icon =
+              n.kind === 'message'
+                ? '💬'
+                : n.kind === 'offer'
+                ? '📄'
+                : n.kind === 'saved_gig_activity'
+                ? '⭐'
+                : n.kind === 'alert_match'
+                ? '🔔'
+                : '✅'
+            const text =
+              n.kind === 'saved_gig_activity'
+                ? 'New application on a gig you saved.'
+                : n.kind === 'alert_match'
+                ? 'New gig matches your alert.'
+                : n.kind
+            const href =
+              n.kind === 'saved_gig_activity' && n.payload?.gig_id
+                ? `/gigs/${n.payload.gig_id}`
+                : n.kind === 'alert_match' && n.payload?.gig_id
+                ? `/gigs/${n.payload.gig_id}`
+                : undefined
+            const body = (
+              <>
+                <span>{icon}</span>
+                <div className="text-sm">
+                  <div className="font-medium">{text}</div>
+                  {n.payload?.snippet && <div className="text-gray-600">{n.payload.snippet}</div>}
+                </div>
+              </>
+            )
+            return href ? (
+              <Link key={n.id ?? i} href={href} className="flex items-start gap-2 p-2">
+                {body}
+              </Link>
+            ) : (
+              <div key={n.id ?? i} className="flex items-start gap-2 p-2">
+                {body}
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/components/SaveButton.tsx
+++ b/components/SaveButton.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react"
+import { isSaved, toggleSave } from "@/lib/saved"
+
+export default function SaveButton({ gigId, className = "", withText = false }: { gigId: number; className?: string; withText?: boolean }) {
+  const [saved, setSaved] = useState(false)
+  useEffect(() => {
+    isSaved(gigId).then(setSaved)
+  }, [gigId])
+  const onClick = async () => {
+    const s = await toggleSave(gigId)
+    setSaved(s)
+  }
+  return (
+    <button onClick={onClick} className={className} aria-label={saved ? "Unsave gig" : "Save gig"}>
+      {saved ? "⭐" : "☆"}
+      {withText && <span className="ml-1">{saved ? "Unsave" : "Save"}</span>}
+    </button>
+  )
+}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -17,6 +17,7 @@ export default function TopNav() {
           <Link href="/find-work">Find Work</Link>
           {loggedIn && <Link href="/dashboard/gigs">My Gigs</Link>}
           {loggedIn && <Link href="/applications">Applications</Link>}
+          {loggedIn && <Link href="/saved">Saved</Link>}
           {loggedIn && <NotificationsBell />}
           <Link href="/post-job" className="rounded px-3 py-1 bg-yellow-400 text-black font-medium">
             Post Job

--- a/docs/DEPLOYMENT_WIRING.md
+++ b/docs/DEPLOYMENT_WIRING.md
@@ -42,6 +42,11 @@
 
 - Run migration: `supabase/migrations/2025-08-22_notifications.sql`
 
+## Saved gigs & alerts
+
+- Run migration: `supabase/migrations/2025-08-22_saved_gigs_alerts.sql`
+- (Optional) Cron: `curl -sS https://app.quickgig.ph/api/alert-scan`
+
 ## Supabase health check
 
 - Endpoint: `/api/health` (Pages API)

--- a/lib/alerts.ts
+++ b/lib/alerts.ts
@@ -1,0 +1,11 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function listAlerts() {
+  return supabase.from('gig_alerts').select('*').order('created_at', { ascending: false })
+}
+export async function createAlert(keyword: string, city?: string) {
+  return supabase.from('gig_alerts').insert({ keyword, city })
+}
+export async function deleteAlert(id: number) {
+  return supabase.from('gig_alerts').delete().eq('id', id)
+}

--- a/lib/saved.ts
+++ b/lib/saved.ts
@@ -1,0 +1,28 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function isSaved(gigId: number) {
+  const { data } = await supabase
+    .from('saved_gigs')
+    .select('gig_id')
+    .eq('gig_id', gigId)
+    .maybeSingle()
+  return !!data
+}
+
+export async function toggleSave(gigId: number) {
+  if (await isSaved(gigId)) {
+    await supabase.from('saved_gigs').delete().eq('gig_id', gigId)
+    return false
+  } else {
+    await supabase.from('saved_gigs').insert({ gig_id: gigId })
+    return true
+  }
+}
+
+export async function mySaved(limit = 20, from = 0) {
+  return supabase
+    .from('saved_gigs')
+    .select('gig_id, created_at, gigs ( title, city, budget )')
+    .order('created_at', { ascending: false })
+    .range(from, from + limit - 1)
+}

--- a/pages/alerts.tsx
+++ b/pages/alerts.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react"
+import Shell from "@/components/Shell"
+import { listAlerts, createAlert, deleteAlert } from "@/lib/alerts"
+
+export default function AlertsPage() {
+  const [items, setItems] = useState<any[]>([])
+  const [keyword, setKeyword] = useState("")
+  const [city, setCity] = useState("")
+
+  const load = async () => {
+    const { data } = await listAlerts()
+    setItems(data ?? [])
+  }
+  useEffect(() => { load() }, [])
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await createAlert(keyword, city || undefined)
+    setKeyword("")
+    setCity("")
+    load()
+  }
+
+  const onDelete = async (id: number) => {
+    await deleteAlert(id)
+    load()
+  }
+
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Gig Alerts</h1>
+      <form onSubmit={onSubmit} className="mb-4 flex flex-wrap gap-2">
+        <input
+          required
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="Keyword"
+          className="flex-1 rounded bg-slate-900 border border-slate-700 px-3 py-2"
+        />
+        <input
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          placeholder="City (optional)"
+          className="rounded bg-slate-900 border border-slate-700 px-3 py-2"
+        />
+        <button type="submit" className="rounded bg-yellow-400 text-black px-3 py-2">
+          Add
+        </button>
+      </form>
+      <ul>
+        {items.map((a) => (
+          <li key={a.id} className="flex items-center justify-between border-b border-slate-800 py-2">
+            <span>
+              {a.keyword}
+              {a.city ? ` - ${a.city}` : ""}
+            </span>
+            <button onClick={() => onDelete(a.id)} className="underline text-sm">
+              Delete
+            </button>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="py-4 text-center opacity-70">No alerts.</li>
+        )}
+      </ul>
+    </Shell>
+  )
+}

--- a/pages/api/alert-scan.ts
+++ b/pages/api/alert-scan.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { createClient } from "@supabase/supabase-js"
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const { data: alerts } = await supabase.from("gig_alerts").select("*")
+  const now = new Date().toISOString()
+  for (const a of alerts ?? []) {
+    const since = a.last_notified_at ?? new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    let q = supabase
+      .from("gigs")
+      .select("id,title,city")
+      .gt("created_at", since)
+      .or(`title.ilike.%${a.keyword}%,description.ilike.%${a.keyword}%`)
+    if (a.city) q = q.eq("city", a.city)
+    const { data: gigs } = await q
+    if (gigs && gigs.length) {
+      await supabase.from("notifications").insert(
+        gigs.map((g: any) => ({
+          user_id: a.user_id,
+          kind: "alert_match",
+          payload: { gig_id: g.id, title: g.title },
+        }))
+      )
+      if (process.env.RESEND_API_KEY && process.env.NOTIFY_FROM) {
+        const { data: { user } } = await supabase.auth.admin.getUserById(a.user_id)
+        if (user?.email) {
+          const body = gigs
+            .map((g: any) => `<div>${g.title} - ${g.city ?? ""}</div>`)
+            .join("")
+          await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              from: process.env.NOTIFY_FROM,
+              to: [user.email],
+              subject: "New gigs match your alert",
+              html: `<div>${body}</div>`
+            }),
+          }).catch(() => {})
+        }
+      }
+      await supabase.from("gig_alerts").update({ last_notified_at: now }).eq("id", a.id)
+    }
+  }
+  res.status(200).json({ ok: true })
+}

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import Shell from "@/components/Shell";
 import Link from "next/link";
+import SaveButton from "@/components/SaveButton";
 
 const PAGE_SIZE = 12;
 
@@ -70,7 +71,10 @@ export default function FindWorkPage() {
       <ul className="grid sm:grid-cols-2 gap-4">
         {data.map((g: any) => (
           <li key={g.id} className="rounded border border-slate-800 p-4 bg-slate-900">
-            <h3 className="font-semibold text-lg">{g.title}</h3>
+            <div className="flex items-start justify-between">
+              <h3 className="font-semibold text-lg">{g.title}</h3>
+              <SaveButton gigId={g.id} />
+            </div>
             <p className="text-sm opacity-80 line-clamp-2">{g.description}</p>
             <div className="mt-2 flex items-center justify-between text-sm">
               <span>{g.city ?? "—"}</span>

--- a/pages/gigs/[id]/index.tsx
+++ b/pages/gigs/[id]/index.tsx
@@ -3,6 +3,7 @@ import Shell from "@/components/Shell";
 import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import SaveButton from "@/components/SaveButton";
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const id = ctx.params?.id as string;
@@ -20,7 +21,10 @@ export default function GigPage({ gig }: { gig: any }) {
 
   return (
     <Shell>
-      <h1 className="text-3xl font-bold mb-2">{gig.title}</h1>
+      <div className="mb-2 flex items-center justify-between">
+        <h1 className="text-3xl font-bold">{gig.title}</h1>
+        <SaveButton gigId={gig.id} withText />
+      </div>
       {user?.id !== gig.owner ? (
         <Link
           href={`/gigs/${gig.id}/apply`}

--- a/pages/saved.tsx
+++ b/pages/saved.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react"
+import Shell from "@/components/Shell"
+import Link from "next/link"
+import { mySaved, toggleSave } from "@/lib/saved"
+
+export default function SavedPage() {
+  const [items, setItems] = useState<any[]>([])
+  useEffect(() => {
+    mySaved(100, 0).then(({ data }) => setItems(data ?? []))
+  }, [])
+  const remove = async (gigId: number) => {
+    await toggleSave(gigId)
+    setItems((prev) => prev.filter((i) => i.gig_id !== gigId))
+  }
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Saved Gigs</h1>
+      <Link href="/alerts" className="underline text-sm">Manage Alerts</Link>
+      <table className="mt-4 w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-800">
+            <th className="py-2">Title</th>
+            <th className="py-2">City</th>
+            <th className="py-2">Budget</th>
+            <th className="py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((r) => (
+            <tr key={r.gig_id} className="border-b border-slate-800">
+              <td className="py-2"><Link href={`/gigs/${r.gig_id}`} className="underline">{r.gigs?.title}</Link></td>
+              <td className="py-2">{r.gigs?.city ?? "—"}</td>
+              <td className="py-2">{r.gigs?.budget ?? "—"}</td>
+              <td className="py-2 text-right"><button onClick={() => remove(r.gig_id)} className="underline">Unsave</button></td>
+            </tr>
+          ))}
+          {items.length === 0 && (
+            <tr>
+              <td colSpan={4} className="py-4 text-center opacity-70">No saved gigs.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </Shell>
+  )
+}

--- a/supabase/migrations/2025-08-22_saved_gigs_alerts.sql
+++ b/supabase/migrations/2025-08-22_saved_gigs_alerts.sql
@@ -1,0 +1,55 @@
+-- Saved gigs
+create table if not exists public.saved_gigs (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  gig_id  bigint not null references public.gigs(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (user_id, gig_id)
+);
+alter table public.saved_gigs enable row level security;
+
+-- RLS
+create policy if not exists "owner can manage their saved list"
+on public.saved_gigs for all to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+-- Simple alerts (keyword + city)
+create table if not exists public.gig_alerts (
+  id bigserial primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  keyword text,              -- e.g., "plumber"
+  city text,                 -- nullable
+  created_at timestamptz not null default now(),
+  last_notified_at timestamptz
+);
+alter table public.gig_alerts enable row level security;
+
+create policy if not exists "owner manages their alerts"
+on public.gig_alerts for all to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+-- Reuse notifications for pings
+-- on new application → notify owners who saved that gig (kind: 'saved_gig_activity')
+create type if not exists public.notification_type as enum ('message','offer','hired','saved_gig_activity','alert_match');
+
+create or replace function public.notify_saved_gig_activity()
+returns trigger language plpgsql security definer as $$
+begin
+  insert into public.notifications (user_id, app_id, kind, payload)
+  select sg.user_id, NEW.app_id, 'saved_gig_activity',
+         jsonb_build_object('gig_id', a.gig_id, 'event', 'new_application')
+  from public.applications a
+  join public.saved_gigs sg on sg.gig_id = a.gig_id
+  where a.id = NEW.app_id;
+  return NEW;
+end$$;
+
+drop trigger if exists trg_notify_saved_gig_activity on public.applications;
+create trigger trg_notify_saved_gig_activity
+after insert on public.applications
+for each row execute function public.notify_saved_gig_activity();
+
+-- Enable realtime on saved tables
+alter publication supabase_realtime add table public.saved_gigs;
+alter publication supabase_realtime add table public.gig_alerts;


### PR DESCRIPTION
## Summary
- add saved_gigs and gig_alerts tables with notifications trigger and realtime
- star toggle for saving gigs, saved list and keyword alerts pages
- alert scan API and dropdown handling for new notification kinds

## Testing
- `npm test` (fails: Missing script "test")
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a79b3967448327b36ecf3cbc198e9c