### PR TITLE
Admin Moderation + Reports (hide/unhide/ban) + RLS guard for hidden gigs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ NEXT_PUBLIC_STORAGE_BUCKET=assets
 RESEND_API_KEY=
 NOTIFY_FROM="QuickGig <notifications@quickgig.ph>"
 APP_URL=https://app.quickgig.ph
+
+# Admin allowlist (comma-separated emails)
+ADMIN_EMAILS=you@quickgig.ph,admin@quickgig.ph

--- a/components/MessageItem.tsx
+++ b/components/MessageItem.tsx
@@ -7,12 +7,25 @@ interface Message {
 }
 
 export default function MessageItem({ msg, self }: { msg: Message; self: string }) {
+  async function report() {
+    const reason = prompt("Why are you reporting this message?") || "";
+    try {
+      await fetch("/api/reports/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "message", target_id: msg.id, reason }),
+      });
+      alert("Reported");
+    } catch (_) {}
+  }
+
   return (
     <div className="mb-3">
       <div className="text-xs opacity-70">
         {msg.profiles?.full_name ?? msg.sender} • {new Date(msg.created_at).toLocaleString()}
       </div>
       <div className="whitespace-pre-wrap">{msg.body}</div>
+      <button onClick={report} className="text-xs underline">Report</button>
     </div>
   );
 }

--- a/docs/MODERATION.md
+++ b/docs/MODERATION.md
@@ -1,0 +1,24 @@
+# Moderation & Reports
+
+## Admin allowlist
+
+Set `ADMIN_EMAILS` in your environment (comma-separated emails) to allow admin access.
+
+```
+# .env
+ADMIN_EMAILS=you@quickgig.ph,admin@quickgig.ph
+```
+
+## Reporting content
+
+Users can report gigs, profiles, or messages. Each page shows a **Report** link that submits to `/api/reports/create`.
+
+## Admin dashboard
+
+Visit `/admin/moderation` with an allowlisted email to view recent reports and manage hidden gigs or profiles. Actions are sent to `/api/admin/moderation`.
+
+## Hidden & blocked
+
+- Hidden gigs or profiles are not shown in listings.
+- Blocked profiles indicate banned users.
+- A row-level security policy prevents new applications to hidden gigs.

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -1,0 +1,4 @@
+export function isAdminEmail(email?: string | null) {
+  const raw = (process.env.ADMIN_EMAILS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+  return !!email && raw.includes(email.toLowerCase());
+}

--- a/lib/saved.ts
+++ b/lib/saved.ts
@@ -23,6 +23,7 @@ export async function mySaved(limit = 20, from = 0) {
   return supabase
     .from('saved_gigs')
     .select('gig_id, created_at, gigs ( title, city, budget )')
+    .neq('gigs.hidden', true)
     .order('created_at', { ascending: false })
     .range(from, from + limit - 1)
 }

--- a/pages/admin/moderation.tsx
+++ b/pages/admin/moderation.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import Shell from '@/components/Shell';
+import { supabase } from '@/lib/supabaseClient';
+import { isAdminEmail } from '@/lib/authz';
+import Link from 'next/link';
+
+export default function ModerationPage() {
+  const [user, setUser] = useState<any>(null);
+  const [tab, setTab] = useState<'reports' | 'gigs' | 'profiles'>('reports');
+  const [reports, setReports] = useState<any[]>([]);
+  const [gigs, setGigs] = useState<any[]>([]);
+  const [profiles, setProfiles] = useState<any[]>([]);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+  }, []);
+
+  useEffect(() => {
+    if (!user || !isAdminEmail(user.email)) return;
+    if (tab === 'reports') {
+      supabase.from('reports').select('*').order('created_at', { ascending: false }).limit(50).then(({ data }) => setReports(data ?? []));
+    }
+    if (tab === 'gigs') {
+      supabase.from('gigs').select('*').eq('hidden', true).order('created_at', { ascending: false }).then(({ data }) => setGigs(data ?? []));
+    }
+    if (tab === 'profiles') {
+      supabase.from('profiles').select('*').or('hidden.eq.true,blocked.eq.true').order('created_at', { ascending: false }).then(({ data }) => setProfiles(data ?? []));
+    }
+  }, [tab, user]);
+
+  async function act(action: string, kind: 'gig' | 'profile', id: any) {
+    await fetch('/api/admin/moderation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, kind, id }),
+    });
+    setTab(tab); // reload
+  }
+
+  if (!user) return <Shell><p>Loading…</p></Shell>;
+  if (!isAdminEmail(user.email)) return <Shell><p>Not found</p></Shell>;
+
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Admin Moderation</h1>
+      <div className="flex gap-4 mb-4 text-sm">
+        <button onClick={() => setTab('reports')} className={tab === 'reports' ? 'font-semibold' : ''}>Reports</button>
+        <button onClick={() => setTab('gigs')} className={tab === 'gigs' ? 'font-semibold' : ''}>Gigs</button>
+        <button onClick={() => setTab('profiles')} className={tab === 'profiles' ? 'font-semibold' : ''}>Profiles</button>
+      </div>
+      {tab === 'reports' && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b border-slate-800"><th className="py-2">Kind</th><th>Target</th><th>Reporter</th><th>Reason</th><th>Time</th></tr>
+          </thead>
+          <tbody>
+            {reports.map(r => (
+              <tr key={r.id} className="border-b border-slate-800">
+                <td className="py-2">{r.kind}</td>
+                <td className="py-2">
+                  {r.kind === 'gig' && <Link className="underline" href={`/gigs/${r.target_id}`}>{r.target_id}</Link>}
+                  {r.kind === 'profile' && <span>{r.target_id}</span>}
+                  {r.kind === 'message' && <span>{r.target_id}</span>}
+                </td>
+                <td className="py-2">{r.reporter ?? ''}</td>
+                <td className="py-2">{r.reason ?? ''}</td>
+                <td className="py-2">{new Date(r.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {tab === 'gigs' && (
+        <ul className="space-y-2">
+          {gigs.map(g => (
+            <li key={g.id} className="border border-slate-800 p-2 rounded">
+              <div className="flex justify-between"><span>{g.title} (#{g.id})</span><button onClick={() => act('unhide','gig',g.id)} className="underline text-sm">Unhide</button></div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {tab === 'profiles' && (
+        <ul className="space-y-2">
+          {profiles.map(p => (
+            <li key={p.id} className="border border-slate-800 p-2 rounded">
+              <div className="flex justify-between text-sm">
+                <span>{p.full_name ?? p.id}</span>
+                <div className="space-x-2">
+                  {p.hidden && <button onClick={() => act('unhide','profile',p.id)} className="underline">Unhide</button>}
+                  {p.blocked && <button onClick={() => act('unban','profile',p.id)} className="underline">Unban</button>}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Shell>
+  );
+}

--- a/pages/api/admin/moderation.ts
+++ b/pages/api/admin/moderation.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabaseClient';
+import { isAdminEmail } from '@/lib/authz';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') { res.status(405).end(); return; }
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!isAdminEmail(user?.email)) { res.status(403).json({ error: 'forbidden' }); return; }
+
+  const { action, kind, id } = req.body || {};
+  if (!action || !kind || !id) { res.status(400).json({ error: 'missing fields' }); return; }
+
+  if (kind === 'gig') {
+    if (action === 'hide') await supabase.from('gigs').update({ hidden: true }).eq('id', id);
+    if (action === 'unhide') await supabase.from('gigs').update({ hidden: false }).eq('id', id);
+  }
+  if (kind === 'profile') {
+    if (action === 'hide') await supabase.from('profiles').update({ hidden: true }).eq('id', id);
+    if (action === 'unhide') await supabase.from('profiles').update({ hidden: false }).eq('id', id);
+    if (action === 'ban') await supabase.from('profiles').update({ blocked: true }).eq('id', id);
+    if (action === 'unban') await supabase.from('profiles').update({ blocked: false }).eq('id', id);
+  }
+  res.json({ ok: true });
+}

--- a/pages/api/alert-scan.ts
+++ b/pages/api/alert-scan.ts
@@ -16,6 +16,7 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       .select("id,title,city")
       .gt("created_at", since)
       .or(`title.ilike.%${a.keyword}%,description.ilike.%${a.keyword}%`)
+      .neq('hidden', true)
     if (a.city) q = q.eq("city", a.city)
     const { data: gigs } = await q
     if (gigs && gigs.length) {

--- a/pages/api/gigs/index.ts
+++ b/pages/api/gigs/index.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'GET') {
     const { q, city } = req.query as { q?: string, city?: string }
-    let query = supabase.from('gigs').select('*').order('created_at', { ascending: false })
+    let query = supabase.from('gigs').select('*').neq('hidden', true).order('created_at', { ascending: false })
     if (q) query = query.ilike('title', `%${q}%`)
     if (city) query = query.ilike('city', `%${city}%`)
     const { data, error } = await query

--- a/pages/api/reports/create.ts
+++ b/pages/api/reports/create.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabaseClient';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') { res.status(405).end(); return; }
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) { res.status(401).json({ error: 'unauthenticated' }); return; }
+
+  const { kind, target_id, reason } = req.body || {};
+  if (!kind || !target_id) { res.status(400).json({ error: 'missing fields' }); return; }
+
+  const { error } = await supabase.from('reports').insert({ kind, target_id, reason, reporter: user.id });
+  if (error) { res.status(400).json({ error: error.message }); return; }
+  res.json({ ok: true });
+}

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -21,7 +21,7 @@ export default function FindWorkPage() {
     let ignore = false;
     setLoading(true);
     (async () => {
-      let query = supabase.from("gigs").select("*", { count: "exact" });
+      let query = supabase.from("gigs").select("*", { count: "exact" }).neq('hidden', true);
 
       if (q.trim()) {
         query = query.ilike("title", `%${q}%`).or(`description.ilike.%${q}%`);

--- a/pages/gigs/[id]/apply.tsx
+++ b/pages/gigs/[id]/apply.tsx
@@ -35,6 +35,7 @@ export default function ApplyGig() {
   }
 
   if (!ready || !gig) return <Shell><p>Loading…</p></Shell>;
+  if (gig.hidden) return <Shell><p>This gig is unavailable.</p></Shell>;
 
   return (
     <Shell>

--- a/pages/gigs/[id]/index.tsx
+++ b/pages/gigs/[id]/index.tsx
@@ -13,17 +13,37 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 };
 
 export default function GigPage({ gig }: { gig: any }) {
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<any>(undefined);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setUser(data.user));
   }, []);
 
+  async function report() {
+    const reason = prompt("Why are you reporting this gig?") || "";
+    try {
+      await fetch("/api/reports/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "gig", target_id: gig.id, reason }),
+      });
+      alert("Reported");
+    } catch (_) {}
+  }
+
+  if (gig.hidden) {
+    if (user === undefined) return <Shell><p>Loading…</p></Shell>;
+    if (!user || user.id !== gig.owner) return <Shell><p>This gig is unavailable.</p></Shell>;
+  }
+
   return (
     <Shell>
       <div className="mb-2 flex items-center justify-between">
         <h1 className="text-3xl font-bold">{gig.title}</h1>
-        <SaveButton gigId={gig.id} withText />
+        <div className="flex items-center gap-2">
+          <SaveButton gigId={gig.id} withText />
+          <button onClick={report} className="text-sm underline">Report</button>
+        </div>
       </div>
       {user?.id !== gig.owner ? (
         <Link

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -11,11 +11,13 @@ export default function ProfilePage() {
   const [ratingAvg, setRatingAvg] = useState<number | null>(null);
   const [ratingCount, setRatingCount] = useState<number | null>(null);
   const [reviews, setReviews] = useState<any[]>([]);
+  const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { setLoading(false); return; }
+      setUserId(user.id);
 
       const { data } = await supabase
         .from("profiles")
@@ -48,6 +50,19 @@ export default function ProfilePage() {
     setStatus(error ? error.message : "Saved!");
   }
 
+  async function reportProfile() {
+    if (!userId) return;
+    const reason = prompt("Why are you reporting this profile?") || "";
+    try {
+      await fetch("/api/reports/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "profile", target_id: userId, reason }),
+      });
+      alert("Reported");
+    } catch (_) {}
+  }
+
   if (loading) return <Shell><p>Loading…</p></Shell>;
 
   return (
@@ -73,6 +88,11 @@ export default function ProfilePage() {
             </li>
           ))}
         </ul>
+      )}
+      {userId && (
+        <button onClick={reportProfile} className="mt-4 text-sm underline">
+          Report Profile
+        </button>
       )}
     </Shell>
   );

--- a/supabase/migrations/2025-08-22_admin_moderation.sql
+++ b/supabase/migrations/2025-08-22_admin_moderation.sql
@@ -1,0 +1,49 @@
+-- Profiles: moderation flags
+alter table if exists public.profiles
+  add column if not exists hidden boolean default false,
+  add column if not exists blocked boolean default false;
+
+-- Gigs: moderation flag
+alter table if exists public.gigs
+  add column if not exists hidden boolean default false;
+
+-- Reports table
+create table if not exists public.reports (
+  id bigserial primary key,
+  kind text not null check (kind in ('gig','profile','message')),
+  target_id text not null,
+  reason text,
+  reporter uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.reports enable row level security;
+
+do $$ begin
+  create policy if not exists "reports_insert_any_auth"
+  on public.reports for insert to authenticated
+  with check (true);
+exception when duplicate_object then null; end $$;
+
+-- Prevent applying to hidden gigs (apps table already exists)
+-- Add an extra WITH CHECK policy so hidden gigs cannot receive new applications.
+do $$ begin
+  create policy if not exists "apps_insert_disallow_hidden_gig"
+  on public.applications for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.gigs g
+      where g.id = public.applications.gig_id
+        and coalesce(g.hidden, false) = false
+    )
+  );
+exception when duplicate_object then null; end $$;
+
+-- (Optional) Make sure notifications enum has a value for moderation events
+do $$ begin
+  if not exists (select 1 from pg_type t join pg_namespace n on n.oid=t.typnamespace
+                 where t.typname='notification_type' and n.nspname='public') then
+    create type public.notification_type as enum ('message','offer','hired','saved_gig_activity','alert_match');
+  end if;
+  alter type public.notification_type add value if not exists 'content_hidden';
+end $$;


### PR DESCRIPTION
## Summary
- add admin allowlist env and moderation SQL migration with reports table and RLS guard against hidden gig applications
- expose helper `isAdminEmail`, report creation API and admin moderation API
- add report buttons on gigs, profiles, and messages; hide hidden gigs from listings and new `/admin/moderation` dashboard

## Testing
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' npm run build`
- `SMOKE_BASE=http://localhost:3000 npm run smoke`

## Manual Smoke Plan
1. As a normal user, report a gig with a short reason → expect 200.
2. As admin (email in `ADMIN_EMAILS`), open `/admin/moderation` → see the report.
3. Hide the gig → it disappears from **Find Work**; trying to apply returns RLS error (blocked).
4. Unhide → gig appears again.
5. Ban a profile → (optional) ensure UI shows limited actions for that account (future enhancement).


------
https://chatgpt.com/codex/tasks/task_e_68a7a4777df083278579902b2d0c5ee8