### PR TITLE
fix: add Next.js ESLint config and skip lint in builds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "root": true,
+  "extends": ["next/core-web-vitals"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": { "jsx": true }
+  },
+  "ignorePatterns": ["landing_public_html/**", "public_html/**", "node_modules/**"]
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  eslint: { ignoreDuringBuilds: true }
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "lint": "next lint",
     "start": "next start",
     "smoke": "node scripts/smoke.mjs",
     "smoke:local": "node scripts/smoke.mjs",
@@ -25,7 +26,10 @@
     "@types/react-dom": "^18",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "@typescript-eslint/parser": "^6.21.0"
   },
   "engines": {
     "node": ">=18 <22"


### PR DESCRIPTION
## Summary
- add minimal Next.js + TypeScript ESLint config
- allow `next build` to skip linting
- wire up lint/build/dev scripts and dev deps

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build` *(fails: Could not find a declaration file for module 'stripe')*


------
https://chatgpt.com/codex/tasks/task_e_68a7d7c051b083278eacf0b76ba9b304