### PR TITLE
feat: finalize manual GCash soft-launch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ APP_URL=https://app.quickgig.ph
 # Admin allowlist (comma-separated emails)
 ADMIN_EMAILS=you@quickgig.ph,admin@quickgig.ph
 
+TICKET_PRICE_PHP=10
+GCASH_QR_URL=/assets/gcash-qr.png
+
 # Stripe
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 - `npm run dev` - start development server
 - `npm run build` - build for production
 - `npm start` - run production build
+
+## Smoke tests
+
+```
+curl -X POST https://app.quickgig.ph/api/orders
+curl -X POST -H "Content-Type: application/json" -d '{"proof_url":"https://.../receipt.jpg"}' https://app.quickgig.ph/api/orders/<id>/submit
+curl -X POST -H "Content-Type: application/json" -d '{"decision":"paid"}' https://app.quickgig.ph/api/orders/<id>/decide
+curl https://app.quickgig.ph/api/users/me/eligibility
+```

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -5,8 +5,19 @@ import NotificationsBell from "@/components/NotificationsBell";
 
 export default function TopNav() {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [eligible, setEligible] = useState(true);
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setLoggedIn(!!data.user));
+    supabase.auth.getUser().then(async ({ data }) => {
+      const user = data.user;
+      setLoggedIn(!!user);
+      if (user) {
+        const res = await fetch('/api/users/me/eligibility');
+        if (res.ok) {
+          const d = await res.json();
+          setEligible(d.canPost);
+        }
+      }
+    });
   }, []);
 
   return (
@@ -19,7 +30,16 @@ export default function TopNav() {
           {loggedIn && <Link href="/applications">Applications</Link>}
           {loggedIn && <Link href="/saved">Saved</Link>}
           {loggedIn && <NotificationsBell />}
-          <Link href="/post-job" className="rounded px-3 py-1 bg-yellow-400 text-black font-medium">
+          {loggedIn && !eligible && (
+            <Link href="/checkout" className="rounded px-3 py-1 bg-blue-500 text-white font-medium">
+              Buy Ticket
+            </Link>
+          )}
+          <Link
+            href="/post-job"
+            className={`rounded px-3 py-1 bg-yellow-400 text-black font-medium ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
+            title={loggedIn && !eligible ? 'Please buy a ticket (₱10)' : undefined}
+          >
             Post Job
           </Link>
           <Link href="/login">Login</Link>

--- a/docs/PAYMENTS_SOFTLAUNCH.md
+++ b/docs/PAYMENTS_SOFTLAUNCH.md
@@ -1,0 +1,15 @@
+# Manual GCash Soft-launch
+
+## QR Upload
+- Place the GCash QR at `public/assets/gcash-qr.png` or upload to Supabase storage and set the public URL in `GCASH_QR_URL`.
+
+## Environment
+Set in Vercel:
+- `TICKET_PRICE_PHP`
+- `ADMIN_EMAILS`
+- `NEXT_PUBLIC_SITE_URL`
+
+## Admin Review
+1. User creates order and submits payment proof.
+2. Admin visits `/admin/orders` to review.
+3. Approve to mark as `paid` or reject to ask for re-upload.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,6 @@
+export const isAdmin = (email?: string) =>
+  (process.env.ADMIN_EMAILS || '')
+    .toLowerCase()
+    .split(',')
+    .map(s => s.trim())
+    .includes((email || '').toLowerCase());

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,4 @@
+export const TICKET_PRICE_PHP = Number(process.env.TICKET_PRICE_PHP || 10);
+export const makeRef = () =>
+  'QG' + Date.now().toString(36) + Math.random().toString(36).slice(2,6).toUpperCase();
+export const canPostJob = (hasPaid: boolean) => hasPaid;

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import Shell from '@/components/Shell';
+import { supabase } from '@/lib/supabaseClient';
+import { isAdmin } from '@/lib/auth';
+
+export default function AdminOrders() {
+  const [orders, setOrders] = useState<any[]>([]);
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(async ({ data }) => {
+      if (isAdmin(data.user?.email)) {
+        setAllowed(true);
+        const res = await fetch('/api/orders');
+        const d = await res.json();
+        setOrders(d.orders || []);
+      } else {
+        setAllowed(false);
+      }
+    });
+  }, []);
+
+  async function decide(id: number, decision: 'paid' | 'rejected') {
+    await fetch(`/api/orders/${id}/decide`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ decision }) });
+    const res = await fetch('/api/orders');
+    const d = await res.json();
+    setOrders(d.orders || []);
+  }
+
+  if (allowed === null) return <Shell><p>Loading…</p></Shell>;
+  if (!allowed) return <Shell><p>Forbidden</p></Shell>;
+
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">All Orders</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr><th className="text-left">Ref</th><th>User</th><th>Proof</th><th>Status</th><th></th></tr>
+        </thead>
+        <tbody>
+          {orders.map(o => (
+            <tr key={o.id} className="border-t border-slate-800">
+              <td>{o.reference}</td>
+              <td>{o.user?.email}</td>
+              <td>{o.proof_url && <a href={o.proof_url} className="underline">Link</a>}</td>
+              <td>{o.status}</td>
+              <td className="space-x-2">
+                <button onClick={()=>decide(o.id,'paid')} className="text-green-400">Approve</button>
+                <button onClick={()=>decide(o.id,'rejected')} className="text-red-400">Reject</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Shell>
+  );
+}

--- a/pages/api/orders/[id]/decide.ts
+++ b/pages/api/orders/[id]/decide.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerClient } from '@/lib/supabaseClient';
+import { isAdmin } from '@/lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') { res.status(405).json({ error: 'method not allowed' }); return; }
+  const supabase = createServerClient();
+  await supabase.rpc('set_config', { setting_name: 'app.admin_emails', new_value: process.env.ADMIN_EMAILS ?? '', is_local: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !isAdmin(user.email)) { res.status(403).json({ error: 'forbidden' }); return; }
+
+  const { decision } = req.body || {};
+  if (decision !== 'paid' && decision !== 'rejected') { res.status(400).json({ error: 'bad decision' }); return; }
+
+  const { error } = await supabase.from('orders').update({ status: decision }).eq('id', req.query.id);
+  if (error) { res.status(400).json({ error: error.message }); return; }
+  res.json({ ok: true });
+}

--- a/pages/api/orders/[id]/submit.ts
+++ b/pages/api/orders/[id]/submit.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerClient } from '@/lib/supabaseClient';
+
+function validProof(urlStr: string) {
+  try {
+    const url = new URL(urlStr);
+    if (url.protocol !== 'https:') return false;
+    const allowed = [
+      new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://app.quickgig.ph').host,
+      new URL(process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://app.quickgig.ph').host,
+    ];
+    return allowed.some(h => url.host.endsWith(h));
+  } catch { return false; }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') { res.status(405).json({ error: 'method not allowed' }); return; }
+  const supabase = createServerClient();
+  await supabase.rpc('set_config', { setting_name: 'app.admin_emails', new_value: process.env.ADMIN_EMAILS ?? '', is_local: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) { res.status(401).json({ error: 'unauthorized' }); return; }
+
+  const { proof_url } = req.body || {};
+  if (!proof_url || !validProof(proof_url)) { res.status(400).json({ error: 'invalid proof_url' }); return; }
+
+  const { error } = await supabase.from('orders')
+    .update({ proof_url, status: 'submitted' })
+    .eq('id', req.query.id)
+    .eq('user_id', user.id);
+  if (error) { res.status(400).json({ error: error.message }); return; }
+  res.json({ ok: true });
+}

--- a/pages/api/orders/index.ts
+++ b/pages/api/orders/index.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerClient } from '@/lib/supabaseClient';
+import { TICKET_PRICE_PHP, makeRef } from '@/lib/payments';
+import { isAdmin } from '@/lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const supabase = createServerClient();
+  await supabase.rpc('set_config', { setting_name: 'app.admin_emails', new_value: process.env.ADMIN_EMAILS ?? '', is_local: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) { res.status(401).json({ error: 'unauthorized' }); return; }
+
+  if (req.method === 'POST') {
+    const { data, error } = await supabase.from('orders')
+      .insert({ user_id: user.id, amount: TICKET_PRICE_PHP, reference: makeRef(), status: 'pending' })
+      .select('id, reference').single();
+    if (error) { res.status(400).json({ error: error.message }); return; }
+    res.json({ id: data.id, reference: data.reference });
+    return;
+  }
+
+  if (req.method === 'GET') {
+    let query = supabase.from('orders').select('id, user_id, amount, reference, proof_url, status, created_at, user:auth.users(email)').order('created_at', { ascending: false });
+    if (!isAdmin(user.email)) query = query.eq('user_id', user.id);
+    const { data, error } = await query;
+    if (error) { res.status(400).json({ error: error.message }); return; }
+    res.json({ orders: data });
+    return;
+  }
+
+  res.status(405).json({ error: 'method not allowed' });
+}

--- a/pages/api/users/me/eligibility.ts
+++ b/pages/api/users/me/eligibility.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerClient } from '@/lib/supabaseClient';
+import { canPostJob } from '@/lib/payments';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') { res.status(405).json({ error: 'method not allowed' }); return; }
+  const supabase = createServerClient();
+  await supabase.rpc('set_config', { setting_name: 'app.admin_emails', new_value: process.env.ADMIN_EMAILS ?? '', is_local: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) { res.status(401).json({ error: 'unauthorized' }); return; }
+  const { count } = await supabase.from('orders').select('id', { count: 'exact', head: true }).eq('user_id', user.id).eq('status', 'paid');
+  res.json({ canPost: canPostJob((count ?? 0) > 0) });
+}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import Shell from '@/components/Shell';
+import { TICKET_PRICE_PHP } from '@/lib/payments';
+
+export default function CheckoutPage() {
+  const [order, setOrder] = useState<{id:number, reference:string} | null>(null);
+  const [proofUrl, setProofUrl] = useState('');
+  const [msg, setMsg] = useState<string | null>(null);
+
+  async function createOrder() {
+    const res = await fetch('/api/orders', { method: 'POST' });
+    const data = await res.json();
+    if (res.ok) setOrder(data);
+    else setMsg(data.error);
+  }
+
+  async function submitProof(e: React.FormEvent) {
+    e.preventDefault();
+    if (!order) return;
+    const res = await fetch(`/api/orders/${order.id}/submit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ proof_url: proofUrl })
+    });
+    const data = await res.json();
+    if (res.ok) setMsg('Submitted!');
+    else setMsg(data.error);
+  }
+
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Buy Ticket</h1>
+      <p className="mb-4">Send ₱{TICKET_PRICE_PHP} via GCash then upload the proof.</p>
+      <img src={process.env.GCASH_QR_URL || '/assets/gcash-qr.png'} alt="GCash QR" className="max-w-xs mb-4" />
+      {!order ? (
+        <button onClick={createOrder} className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Create Order</button>
+      ) : (
+        <form onSubmit={submitProof} className="space-y-3 max-w-md">
+          <p>Reference: <span className="font-mono">{order.reference}</span></p>
+          <input className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2" placeholder="Proof image URL" value={proofUrl} onChange={e=>setProofUrl(e.target.value)} />
+          <button className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Submit</button>
+        </form>
+      )}
+      {msg && <p className="mt-3">{msg}</p>}
+    </Shell>
+  );
+}

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import Shell from '@/components/Shell';
+
+export default function OrdersPage() {
+  const [orders, setOrders] = useState<any[]>([]);
+  useEffect(() => { fetch('/api/orders').then(r=>r.json()).then(d=>setOrders(d.orders || [])); }, []);
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">My Orders</h1>
+      <ul className="space-y-2">
+        {orders.map((o, i) => (
+          <li key={o.id} className={`border p-2 rounded ${i===0 ? 'border-yellow-400' : 'border-slate-700'}`}>
+            <div>Ref: {o.reference}</div>
+            <div>Status: {o.status}</div>
+            {o.proof_url && <a href={o.proof_url} className="text-sm underline">Proof</a>}
+          </li>
+        ))}
+      </ul>
+    </Shell>
+  );
+}

--- a/pages/post-job.tsx
+++ b/pages/post-job.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import Shell from "@/components/Shell";
 import { useRouter } from "next/router";
@@ -14,6 +14,11 @@ export default function PostJobPage() {
   const [msg, setMsg] = useState<string | null>(null);
   const router = useRouter();
   const { ready, userId } = useRequireUser();
+  const [eligible, setEligible] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    fetch('/api/users/me/eligibility').then(r => r.json()).then(d => setEligible(d.canPost)).catch(()=>setEligible(false));
+  }, []);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -43,7 +48,8 @@ export default function PostJobPage() {
     }
   }
 
-  if (!ready) return <Shell><p>Loading…</p></Shell>;
+  if (!ready || eligible === null) return <Shell><p>Loading…</p></Shell>;
+  if (!eligible) return <Shell><p>Please buy a ticket first. <a className="underline" href="/checkout">Go to checkout</a>.</p></Shell>;
 
   return (
     <Shell>

--- a/public/assets/gcash-qr.png
+++ b/public/assets/gcash-qr.png
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#eee"/>
+  <text x="100" y="100" font-size="14" text-anchor="middle" fill="#888" dy="0.35em">
+    GCash QR Placeholder
+  </text>
+</svg>

--- a/supabase/migrations/2025-08-22_orders.sql
+++ b/supabase/migrations/2025-08-22_orders.sql
@@ -1,0 +1,30 @@
+create table if not exists public.orders (
+  id bigint generated always as identity primary key,
+  user_id uuid references auth.users on delete cascade,
+  amount integer not null,
+  reference text unique not null,
+  proof_url text,
+  status text not null default 'pending' check (status in ('pending','submitted','paid','rejected','expired')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists idx_orders_user on public.orders(user_id);
+alter table public.orders enable row level security;
+
+-- helper: admin check from allowlist
+create or replace function public.is_admin(email text)
+returns boolean language sql stable as $$
+  select coalesce(position(lower(email) in lower(current_setting('app.admin_emails', true))) > 0, false)
+$$;
+
+-- seed GUC for RLS (set at runtime from env)
+-- (handled in API by `set_config('app.admin_emails', process.env.ADMIN_EMAILS ?? '', true)`)
+
+-- RLS:
+drop policy if exists "orders owner crud" on public.orders;
+drop policy if exists "orders admin all" on public.orders;
+create policy "orders owner crud" on public.orders
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+create policy "orders admin all" on public.orders
+  using ( public.is_admin((select email from auth.users u where u.id = auth.uid())) );


### PR DESCRIPTION
## Summary
- add environment settings and payments helpers for manual GCash flow
- introduce orders API, admin review, and job posting gating
- provide docs and runbook for soft-launch payments

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon ADMIN_EMAILS=a@example.com TICKET_PRICE_PHP=10 GCASH_QR_URL=/assets/gcash-qr.png npm run build` *(fails: Module not found: Can't resolve 'stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68a7d999186c8327aad4460d23e47bcb