### PR TITLE
PR 2-fix5 — add gigs.published + keep in sync with status

### DIFF
--- a/docs/db-setup.md
+++ b/docs/db-setup.md
@@ -27,3 +27,4 @@ Migrations are **idempotent**. Apply via CI or:
 * Service role bypasses RLS (server-only actions).
 * Trigger `on_auth_user_created` (see `20250822_profiles_bootstrap_audit.sql`) auto-inserts rows into `public.profiles` for new `auth.users` to satisfy FK and RLS requirements.
 
+- 20250822_add_published_to_gigs_audit.sql: adds `gigs.published` and a trigger to sync with `status`. Legacy code that queries `published` now works; new code should prefer `status` ('draft'|'published'|'closed').

--- a/supabase/migrations/20250822_add_published_to_gigs_audit.sql
+++ b/supabase/migrations/20250822_add_published_to_gigs_audit.sql
@@ -1,0 +1,50 @@
+-- Add gigs.published and keep it in sync with status
+begin;
+
+-- 1) Add column if missing
+alter table public.gigs
+  add column if not exists published boolean;
+
+-- 2) Backfill once: published = (status = 'published')
+update public.gigs
+set published = (status = 'published')
+where published is null;
+
+-- 3) Create sync trigger fn (updates whichever is stale)
+create or replace function public.gigs_status_published_sync()
+returns trigger
+language plpgsql
+as $$
+begin
+  -- If status changed, derive published
+  if tg_op in ('INSERT','UPDATE') and (NEW.status is distinct from OLD.status) then
+    NEW.published := (NEW.status = 'published');
+    return NEW;
+  end if;
+
+  -- If published changed (and status didn't), derive status
+  if tg_op = 'UPDATE' and (NEW.published is distinct from OLD.published)
+     and (NEW.status is not distinct from OLD.status) then
+    NEW.status := case when NEW.published then 'published' else 'draft' end;
+    return NEW;
+  end if;
+
+  -- On INSERT where both are provided or unchanged, ensure consistency
+  if tg_op = 'INSERT' then
+    if NEW.published is null then
+      NEW.published := (NEW.status = 'published');
+    elsif NEW.status is null then
+      NEW.status := case when NEW.published then 'published' else 'draft' end;
+    end if;
+  end if;
+
+  return NEW;
+end
+$$;
+
+drop trigger if exists tr_gigs_status_published_sync on public.gigs;
+create trigger tr_gigs_status_published_sync
+before insert or update on public.gigs
+for each row execute function public.gigs_status_published_sync();
+
+commit;


### PR DESCRIPTION
**PLAN**
Expose `gigs.published` for legacy queries and keep it consistent with `status`.

**Summary**

* Added migration to create `gigs.published` (if missing).
* Backfilled values from `status`.
* Added trigger to keep `status` ⇄ `published` in sync on insert/update.
* Updated docs.

**Testing**

1. Apply migration (`supabase db apply`) → no errors.
2. Insert a gig with `status='published'` → `published=true`.
3. Update `published=false` → `status` becomes `'draft'`.
4. Update `status='published'` → `published=true`.
5. `/gigs` page no longer throws “column gigs.published does not exist”.

**Smoke**
`/gigs`, `/gigs/[id]`, and `/gigs/[id]/edit` load without DB column errors.

**Notes**
Idempotent; RLS unchanged.


------
https://chatgpt.com/codex/tasks/task_e_68a830565814832783e3abbfd8b0ef73