### PR TITLE
Sync app theme with landing palette

### DIFF
--- a/components/ApplicationThread.tsx
+++ b/components/ApplicationThread.tsx
@@ -69,7 +69,7 @@ export default function ApplicationThread({ threadId }: Props) {
         const isMe = uid && m.sender === uid
         return (
           <div key={m.id} className="flex flex-col">
-            <div className={`text-xs mb-1 ${isMe ? 'text-right' : ''}`}>
+            <div className={`text-xs mb-1 text-brand-subtle ${isMe ? 'text-right' : ''}`}>
               {(isMe ? 'You' : m.profiles?.full_name ?? m.sender) +
                 ' • ' +
                 timeAgo(m.created_at || new Date().toISOString())}
@@ -77,8 +77,8 @@ export default function ApplicationThread({ threadId }: Props) {
             <div
               className={
                 isMe
-                  ? 'bg-black text-white rounded-2xl px-3 py-2 ml-auto max-w-[80%]'
-                  : 'bg-gray-100 text-gray-900 rounded-2xl px-3 py-2 mr-auto max-w-[80%]'
+                  ? 'bg-brand-accent text-white rounded-2xl px-3 py-2 ml-auto max-w-[80%]'
+                  : 'bg-brand-surface text-brand rounded-2xl px-3 py-2 mr-auto max-w-[80%]'
               }
             >
               {m.body}

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -37,12 +37,12 @@ export default function AuthForm({ mode }: { mode: 'login' | 'signup' }) {
   return (
     <form onSubmit={onSubmit} className="max-w-sm space-y-3">
       {mode==='signup' && (
-        <input required className="w-full border p-2 rounded" placeholder="Full name" value={fullName} onChange={e=>setFullName(e.target.value)} />
+        <input required className="input" placeholder="Full name" value={fullName} onChange={e=>setFullName(e.target.value)} />
       )}
-      <input required type="email" className="w-full border p-2 rounded" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} />
-      <input required type="password" className="w-full border p-2 rounded" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} />
-      <button disabled={loading} className="w-full bg-yellow-400 font-bold rounded p-2">{loading?'Please wait…': mode==='signup'?'Create account':'Login'}</button>
-      {msg && <p className="text-sm text-red-600">{msg}</p>}
+      <input required type="email" className="input" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} />
+      <input required type="password" className="input" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} />
+      <button disabled={loading} className="btn-primary w-full">{loading?'Please wait…': mode==='signup'?'Create account':'Login'}</button>
+      {msg && <p className="text-sm text-brand-danger">{msg}</p>}
     </form>
   )
 }

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -1,7 +1,9 @@
 export default function Banner({ kind='info', children }:{kind?:'success'|'error'|'info', children:React.ReactNode}) {
-  const base = 'mb-4 rounded-md px-4 py-2 text-sm';
-  const map = {success:'bg-green-50 border border-green-200 text-green-800',
-               error:'bg-red-50 border border-red-200 text-red-800',
-               info:'bg-gray-50 border border-gray-200 text-gray-800'} as const;
+  const base = 'mb-4 rounded-md px-4 py-2 text-sm border';
+  const map = {
+    success: 'bg-brand-success/10 border-brand-success text-brand-success',
+    error: 'bg-brand-danger/10 border-brand-danger text-brand-danger',
+    info: 'bg-brand-info/10 border-brand-info text-brand-info',
+  } as const;
   return <div className={`${base} ${map[kind]}`}>{children}</div>;
 }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -44,8 +44,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-brand-bg text-black">
-      <header className="sticky top-0 z-10 border-b border-brand-border bg-brand-card">
+    <div className="min-h-screen flex flex-col bg-brand-bg text-brand">
+      <header className="sticky top-0 z-10 border-b border-brand-border bg-brand-surface">
         <div className="max-w-4xl mx-auto flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16">
           <Link href="/" className="text-lg font-semibold">QuickGig.ph</Link>
           <button

--- a/components/NotificationsBell.tsx
+++ b/components/NotificationsBell.tsx
@@ -71,19 +71,19 @@ export default function NotificationsBell() {
     <div className="relative">
       <button onClick={toggle} className="relative">
         🔔
-        {count > 0 && <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500" />}
+        {count > 0 && <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-brand-danger" />}
       </button>
       {open && (
-        <div className="fixed right-0 top-0 z-50 h-full w-full max-w-sm overflow-y-auto border bg-white p-4 shadow-lg">
+        <div className="fixed right-0 top-0 z-50 h-full w-full max-w-sm overflow-y-auto border border-brand-border bg-brand-bg p-4 shadow-lg">
           {items.map(n => {
             const href =
               n.type === 'message' && n.payload?.application_id
                 ? `/applications/${n.payload.application_id}`
                 : undefined
             const content = (
-              <div key={n.id} className="mb-2 border-b pb-2 text-sm">
+              <div key={n.id} className="mb-2 border-b border-brand-border pb-2 text-sm">
                 {n.payload?.preview && <div>{n.payload.preview}</div>}
-                <div className="text-xs text-gray-500">{timeAgo(n.created_at)}</div>
+                <div className="text-xs text-brand-subtle">{timeAgo(n.created_at)}</div>
               </div>
             )
             return href ? (
@@ -94,7 +94,7 @@ export default function NotificationsBell() {
               content
             )
           })}
-          {items.length === 0 && <p className="text-sm text-gray-500">No notifications.</p>}
+          {items.length === 0 && <p className="text-sm text-brand-subtle">No notifications.</p>}
         </div>
       )}
     </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -21,7 +21,7 @@ export default function TopNav() {
   }, []);
 
   return (
-    <nav className="w-full sticky top-0 z-20 bg-slate-900/90 border-b border-slate-800 backdrop-blur text-white">
+    <nav className="w-full sticky top-0 z-20 border-b border-brand-border bg-brand-bg backdrop-blur text-brand">
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-4">
         <Link href="/" className="font-semibold">QuickGig.ph</Link>
         <div className="ml-auto flex items-center gap-4 text-sm">
@@ -31,13 +31,13 @@ export default function TopNav() {
           {loggedIn && <Link href="/saved">Saved</Link>}
           {loggedIn && <NotificationsBell />}
           {loggedIn && !eligible && (
-            <Link href="/checkout" className="rounded px-3 py-1 bg-blue-500 text-white font-medium">
+            <Link href="/checkout" className="btn-primary">
               Buy Ticket
             </Link>
           )}
           <Link
             href="/post-job"
-            className={`rounded px-3 py-1 bg-yellow-400 text-black font-medium ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
+            className={`btn-primary ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
             title={loggedIn && !eligible ? 'Please buy a ticket (₱10)' : undefined}
           >
             Post Job

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,13 +1,17 @@
 # Design Theme
 
 ## Color Tokens
-- `brand.DEFAULT` `#111111`
-- `brand.accent` `#16A34A`
-- `brand.subtle` `#6B7280`
-- `brand.bg` `#F9FAFB`
-- `brand.card` `#FFFFFF`
-- `brand.border` `#E5E7EB`
-- `brand.danger` `#DC2626`
+- `brand.DEFAULT` `#111827` – primary text
+- `brand.bg` `#ffffff` – app background
+- `brand.surface` `#f9fafb` – cards/surfaces
+- `brand.accent` `#2563eb` – primary action
+- `brand.accent-hover` `#1e40af`
+- `brand.border` `#e5e7eb` – dividers
+- `brand.subtle` `#6b7280` – muted text
+- `brand.success` `#10b981`
+- `brand.warning` `#f59e0b`
+- `brand.danger` `#ef4444`
+- `brand.info` `#3b82f6`
 
 ## Spacing
 Use `container-page` for page padding. Components and sections rely on Tailwind spacing utilities with multiples of `4`.
@@ -21,8 +25,8 @@ Use `container-page` for page padding. Components and sections rely on Tailwind 
 ## Component Primitives
 - **Button**: `.btn-*` variants (`primary`, `secondary`, `danger`)
 - **Input**: `.input` with optional `as="textarea"`
-- **Card**: `.card`
-- **Banner**: `banner-info`, `banner-success`, `banner-error`
+- **Card**: `.card` using `bg-brand-surface` and `border-brand-border`
+- **Banner**: `banner-info`, `banner-success`, `banner-error` map to feedback tokens
 - **Empty**: title + subtitle + action node
 - **Spinner**: simple inline spinner
 

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -39,14 +39,14 @@ export default function AdminOrders() {
         </thead>
         <tbody>
           {orders.map(o => (
-            <tr key={o.id} className="border-t border-slate-800">
+            <tr key={o.id} className="border-t border-brand-border">
               <td>{o.reference}</td>
               <td>{o.user?.email}</td>
               <td>{o.proof_url && <a href={o.proof_url} className="underline">Link</a>}</td>
               <td>{o.status}</td>
               <td className="space-x-2">
-                <button onClick={()=>decide(o.id,'paid')} className="text-green-400">Approve</button>
-                <button onClick={()=>decide(o.id,'rejected')} className="text-red-400">Reject</button>
+                <button onClick={()=>decide(o.id,'paid')} className="text-brand-success">Approve</button>
+                <button onClick={()=>decide(o.id,'rejected')} className="text-brand-danger">Reject</button>
               </td>
             </tr>
           ))}

--- a/pages/alerts.tsx
+++ b/pages/alerts.tsx
@@ -35,21 +35,21 @@ export default function AlertsPage() {
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           placeholder="Keyword"
-          className="flex-1 rounded bg-slate-900 border border-slate-700 px-3 py-2"
+          className="input flex-1"
         />
         <input
           value={city}
           onChange={(e) => setCity(e.target.value)}
           placeholder="City (optional)"
-          className="rounded bg-slate-900 border border-slate-700 px-3 py-2"
+          className="input"
         />
-        <button type="submit" className="rounded bg-yellow-400 text-black px-3 py-2">
+        <button type="submit" className="btn-primary">
           Add
         </button>
       </form>
       <ul>
         {items.map((a) => (
-          <li key={a.id} className="flex items-center justify-between border-b border-slate-800 py-2">
+          <li key={a.id} className="flex items-center justify-between border-b border-brand-border py-2">
             <span>
               {a.keyword}
               {a.city ? ` - ${a.city}` : ""}
@@ -60,7 +60,7 @@ export default function AlertsPage() {
           </li>
         ))}
         {items.length === 0 && (
-          <li className="py-4 text-center opacity-70">No alerts.</li>
+          <li className="py-4 text-center text-brand-subtle">No alerts.</li>
         )}
       </ul>
     </Shell>

--- a/pages/applications/index.tsx
+++ b/pages/applications/index.tsx
@@ -39,15 +39,15 @@ export default function ApplicationsList() {
       {loading && <p>Loading…</p>}
       <ul className="space-y-3">
         {rows.map((r) => (
-            <li key={r.id} className="rounded border border-slate-800 bg-slate-900">
-              <Link href={`/applications/${r.id}`} className="flex justify-between p-4">
-                <div>
-                  <div className="font-semibold">{r.gigs?.title ?? "Gig"}</div>
-                  <div className="text-sm opacity-80">{r.gigs?.city ?? "—"} • status: {r.status}</div>
-                </div>
-                {r.unread > 0 && <span className="w-2 h-2 rounded-full bg-yellow-400 self-center" />}
-              </Link>
-            </li>
+          <li key={r.id} className="card">
+            <Link href={`/applications/${r.id}`} className="flex justify-between p-4">
+              <div>
+                <div className="font-semibold">{r.gigs?.title ?? 'Gig'}</div>
+                <div className="text-sm text-brand-subtle">{r.gigs?.city ?? '—'} • status: {r.status}</div>
+              </div>
+              {r.unread > 0 && <span className="w-2 h-2 rounded-full bg-brand-warning self-center" />}
+            </Link>
+          </li>
         ))}
         {!loading && rows.length === 0 && <p>No applications.</p>}
       </ul>

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -33,12 +33,12 @@ export default function CheckoutPage() {
       <p className="mb-4">Send ₱{TICKET_PRICE_PHP} via GCash then upload the proof.</p>
       <img src={process.env.GCASH_QR_URL || '/assets/gcash-qr.png'} alt="GCash QR" className="max-w-xs mb-4" />
       {!order ? (
-        <button onClick={createOrder} className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Create Order</button>
+        <button onClick={createOrder} className="btn-primary">Create Order</button>
       ) : (
         <form onSubmit={submitProof} className="space-y-3 max-w-md">
           <p>Reference: <span className="font-mono">{order.reference}</span></p>
-          <input className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2" placeholder="Proof image URL" value={proofUrl} onChange={e=>setProofUrl(e.target.value)} />
-          <button className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Submit</button>
+          <input className="input" placeholder="Proof image URL" value={proofUrl} onChange={e=>setProofUrl(e.target.value)} />
+          <button className="btn-primary">Submit</button>
         </form>
       )}
       {msg && <p className="mt-3">{msg}</p>}

--- a/pages/dashboard/gigs.tsx
+++ b/pages/dashboard/gigs.tsx
@@ -40,19 +40,19 @@ export default function MyGigs() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">My Gigs</h1>
       {loading && <p>Loading…</p>}
-      {error && <p className="text-red-400">{error.message}</p>}
+      {error && <p className="text-brand-danger">{error.message}</p>}
       <ul className="space-y-3">
         {data.map((g: any) => (
-          <li key={g.id} className="rounded border border-slate-800 p-4 bg-slate-900">
+          <li key={g.id} className="card p-4">
             <div className="flex items-center justify-between">
               <div>
                 <div className="font-semibold">{g.title}</div>
-                <div className="text-sm opacity-80">{g.city ?? "—"} • #{g.id}</div>
+                <div className="text-sm text-brand-subtle">{g.city ?? '—'} • #{g.id}</div>
               </div>
               <div className="flex gap-3">
                 <Link className="underline" href={`/gigs/${g.id}`}>View</Link>
                 <Link className="underline" href={`/gigs/${g.id}/edit`}>Edit</Link>
-                <button onClick={() => del(g.id)} className="underline text-red-300">Delete</button>
+                <button onClick={() => del(g.id)} className="underline text-brand-danger">Delete</button>
               </div>
             </div>
           </li>

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -56,26 +56,26 @@ export default function FindWorkPage() {
 
       <div className="mb-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         <input value={q} onChange={(e)=>setQ(e.target.value)} placeholder="Search title/description"
-               className="rounded bg-slate-900 border border-slate-700 px-3 py-2" />
+               className="input" />
         <input value={city} onChange={(e)=>setCity(e.target.value)} placeholder="City"
-               className="rounded bg-slate-900 border border-slate-700 px-3 py-2" />
+               className="input" />
         <input value={minBudget} onChange={(e)=>setMinBudget(e.target.value)} placeholder="Min budget"
-               className="rounded bg-slate-900 border border-slate-700 px-3 py-2" />
+               className="input" />
         <input value={maxBudget} onChange={(e)=>setMaxBudget(e.target.value)} placeholder="Max budget"
-               className="rounded bg-slate-900 border border-slate-700 px-3 py-2" />
+               className="input" />
       </div>
 
       {loading && <p>Loading…</p>}
-      {error && <p className="text-red-400">{error.message}</p>}
+      {error && <p className="text-brand-danger">{error.message}</p>}
 
       <ul className="grid sm:grid-cols-2 gap-4">
         {data.map((g: any) => (
-          <li key={g.id} className="rounded border border-slate-800 p-4 bg-slate-900">
+          <li key={g.id} className="card p-4">
             <div className="flex items-start justify-between">
               <h3 className="font-semibold text-lg">{g.title}</h3>
               <SaveButton gigId={g.id} />
             </div>
-            <p className="text-sm opacity-80 line-clamp-2">{g.description}</p>
+            <p className="text-sm text-brand-subtle line-clamp-2">{g.description}</p>
             <div className="mt-2 flex items-center justify-between text-sm">
               <span>{g.city ?? "—"}</span>
               <Link className="underline" href={`/gigs/${g.id}`}>View</Link>
@@ -85,9 +85,9 @@ export default function FindWorkPage() {
       </ul>
 
       <div className="mt-6 flex items-center gap-3">
-        <button disabled={page<=1} onClick={()=>setPage(p=>Math.max(1,p-1))} className="px-3 py-1 rounded border border-slate-800 disabled:opacity-50">Prev</button>
-        <span className="text-sm opacity-80">Page {page} / {pages}</span>
-        <button disabled={page>=pages} onClick={()=>setPage(p=>Math.min(pages,p+1))} className="px-3 py-1 rounded border border-slate-800 disabled:opacity-50">Next</button>
+        <button disabled={page<=1} onClick={()=>setPage(p=>Math.max(1,p-1))} className="px-3 py-1 rounded border border-brand-border disabled:opacity-50">Prev</button>
+        <span className="text-sm text-brand-subtle">Page {page} / {pages}</span>
+        <button disabled={page>=pages} onClick={()=>setPage(p=>Math.min(pages,p+1))} className="px-3 py-1 rounded border border-brand-border disabled:opacity-50">Next</button>
       </div>
     </Shell>
   );

--- a/pages/gigs/[id]/applicants.tsx
+++ b/pages/gigs/[id]/applicants.tsx
@@ -47,23 +47,21 @@ export default function Applicants() {
           const last = typeof window !== "undefined" ? localStorage.getItem(`app:lastSeen:${a.id}`) : null;
           const unread = a.latest_message && (!last || new Date(a.latest_message).getTime() > Number(last));
           return (
-            <li key={a.id} className="rounded border border-slate-800 p-4 bg-slate-900">
+            <li key={a.id} className="card p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="font-semibold">{a.profiles?.full_name ?? "Applicant"}</div>
-                  <div className="text-sm opacity-80">status: {a.status}</div>
-                  {a.cover_letter && <p className="mt-2 opacity-90 whitespace-pre-wrap">{a.cover_letter}</p>}
+                  <div className="font-semibold">{a.profiles?.full_name ?? 'Applicant'}</div>
+                  <div className="text-sm text-brand-subtle">status: {a.status}</div>
+                  {a.cover_letter && <p className="mt-2 whitespace-pre-wrap">{a.cover_letter}</p>}
                 </div>
                 <div className="flex gap-2 items-center">
-                  {unread && <span className="w-2 h-2 rounded-full bg-yellow-400" />}
-                  <Link href={`/applications/${a.id}`} className="rounded bg-slate-700 px-3 py-1">Open Thread</Link>
-                  {a.status !== "accepted" && (
-                    <button onClick={()=>setStatus(a.id,"accepted")}
-                            className="rounded bg-green-500 text-black px-3 py-1">Accept</button>
+                  {unread && <span className="w-2 h-2 rounded-full bg-brand-warning" />}
+                  <Link href={`/applications/${a.id}`} className="btn-secondary">Open Thread</Link>
+                  {a.status !== 'accepted' && (
+                    <button onClick={() => setStatus(a.id, 'accepted')} className="btn bg-brand-success text-white">Accept</button>
                   )}
-                  {a.status !== "rejected" && (
-                    <button onClick={()=>setStatus(a.id,"rejected")}
-                            className="rounded bg-slate-700 px-3 py-1">Reject</button>
+                  {a.status !== 'rejected' && (
+                    <button onClick={() => setStatus(a.id, 'rejected')} className="btn-danger">Reject</button>
                   )}
                 </div>
               </div>

--- a/pages/gigs/[id]/apply.tsx
+++ b/pages/gigs/[id]/apply.tsx
@@ -49,17 +49,17 @@ export default function ApplyGig() {
           placeholder="Short cover letter (optional)"
           value={cover}
           onChange={(e) => setCover(e.target.value)}
-          className="w-full border rounded-md px-3 py-2"
+          className="input"
         />
         <button
-          className="inline-flex items-center rounded-md bg-black text-white px-4 py-2 hover:opacity-90"
+          className="btn-primary"
           disabled={saving}
         >
           {saving ? <Spinner /> : 'Send Application'}
         </button>
       </form>
       {msg && <p className="mt-3">{msg}</p>}
-      <p className="mt-4 text-sm opacity-80"><Link className="underline" href={`/gigs/${gig.id}`}>Back to gig</Link></p>
+      <p className="mt-4 text-sm text-brand-subtle"><Link className="underline" href={`/gigs/${gig.id}`}>Back to gig</Link></p>
     </div>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">Login / Sign up</h1>
       {sent ? (
-        <p className="text-green-400">Magic link sent! Check your email.</p>
+        <p className="text-brand-success">Magic link sent! Check your email.</p>
       ) : (
         <form onSubmit={signIn} className="max-w-md space-y-3">
           <input
@@ -30,10 +30,10 @@ export default function LoginPage() {
             placeholder="you@email.com"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2"
+            className="input"
           />
-          <button className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Send Magic Link</button>
-          {error && <p className="text-red-400">{error}</p>}
+          <button className="btn-primary">Send Magic Link</button>
+          {error && <p className="text-brand-danger">{error}</p>}
         </form>
       )}
       <button

--- a/pages/post-job.tsx
+++ b/pages/post-job.tsx
@@ -55,19 +55,19 @@ export default function PostJobPage() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">Post a Job</h1>
       <form onSubmit={submit} className="max-w-xl space-y-3">
-        <input className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2" required
+        <input className="input" required
                placeholder="Title" value={title} onChange={(e)=>setTitle(e.target.value)} />
-        <textarea className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2" rows={5}
+        <textarea className="input" rows={5}
                placeholder="Description" value={description} onChange={(e)=>setDesc(e.target.value)} />
-        <input className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2"
+        <input className="input"
                placeholder="Budget (optional)" value={budget} onChange={(e)=>setBudget(e.target.value as any)} />
-        <input className="w-full rounded bg-slate-900 border border-slate-700 px-3 py-2"
+        <input className="input"
                placeholder="City (optional)" value={city} onChange={(e)=>setCity(e.target.value)} />
         <div className="space-y-2">
           {imageUrl && <img src={imageUrl} className="rounded max-h-48 object-cover" />}
           <input type="file" accept="image/*" onChange={onFile} />
         </div>
-        <button className="rounded bg-yellow-400 text-black font-medium px-4 py-2">Publish</button>
+        <button className="btn-primary">Publish</button>
       </form>
       {msg && <p className="mt-3">{msg}</p>}
     </Shell>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -37,15 +37,15 @@ export default function Signup() {
       <h1 className="mb-4 text-xl">Sign Up</h1>
       <form onSubmit={onSubmit} className="space-y-3">
         <input
-          className="w-full border p-2"
+          className="input"
           type="email"
           required
           placeholder="you@example.com"
           value={email}
           onChange={e => setEmail(e.target.value)}
         />
-        <button className="w-full bg-green-600 text-white p-2" type="submit">Send Magic Link</button>
-        {msg && <p className="text-sm">{msg}</p>}
+        <button className="btn-primary w-full" type="submit">Send Magic Link</button>
+        {msg && <p className="text-sm text-brand-subtle">{msg}</p>}
       </form>
     </div>
   )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,26 +3,26 @@
 @tailwind utilities;
 
 @layer base {
-  html, body { @apply bg-brand-bg text-black; }
+  html, body { @apply bg-brand-bg text-brand; }
   h1 { @apply text-3xl font-bold tracking-tight; }
   h2 { @apply text-2xl font-semibold; }
   h3 { @apply text-xl font-semibold; }
-  p  { @apply text-[15px] leading-6 text-gray-800; }
-  a  { @apply text-black hover:opacity-80; }
+  p  { @apply text-[15px] leading-6 text-brand; }
+  a  { @apply text-brand hover:text-brand-accent; }
 }
 
 @layer components {
   .container-page { @apply max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8; }
-  .card { @apply bg-brand-card shadow-card rounded-xl2 border border-brand-border; }
+  .card { @apply bg-brand-surface shadow-card rounded-xl2 border border-brand-border; }
   .btn { @apply inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition; }
-  .btn-primary { @apply btn bg-black text-white hover:opacity-90; }
-  .btn-secondary { @apply btn border border-brand-border bg-white hover:bg-gray-50; }
+  .btn-primary { @apply btn bg-brand-accent text-white hover:bg-brand-accent-hover; }
+  .btn-secondary { @apply btn border border-brand-border bg-brand-bg hover:bg-brand-surface; }
   .btn-danger { @apply btn bg-brand-danger text-white hover:opacity-90; }
-  .input { @apply w-full rounded-md border border-brand-border bg-white px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-black; }
-  .label { @apply block text-sm font-medium text-gray-700 mb-1; }
+  .input { @apply w-full rounded-md border border-brand-border bg-brand-bg px-3 py-2 text-sm text-brand placeholder-brand-subtle focus:outline-none focus:ring-2 focus:ring-brand-accent; }
+  .label { @apply block text-sm font-medium text-brand mb-1; }
   .banner { @apply mb-4 rounded-md border px-4 py-2 text-sm; }
-  .banner-info { @apply banner bg-gray-50 border-gray-200 text-gray-800; }
-  .banner-success { @apply banner bg-green-50 border-green-200 text-green-800; }
-  .banner-error { @apply banner bg-red-50 border-red-200 text-red-800; }
+  .banner-info { @apply banner bg-brand-info/10 border-brand-info text-brand-info; }
+  .banner-success { @apply banner bg-brand-success/10 border-brand-success text-brand-success; }
+  .banner-error { @apply banner bg-brand-danger/10 border-brand-danger text-brand-danger; }
   .section { @apply space-y-6; }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,13 +11,17 @@ const config: Config = {
     extend: {
       colors: {
         brand: {
-          DEFAULT: "#111111", // primary text/buttons (near-black)
-          accent: "#16A34A", // success/CTA accent (green-600)
-          subtle: "#6B7280", // gray-500 text
-          bg: "#F9FAFB", // page background
-          card: "#FFFFFF", // card background
-          border: "#E5E7EB", // gray-200
-          danger: "#DC2626", // red-600
+          DEFAULT: '#111827', // text
+          bg: '#ffffff', // background
+          surface: '#f9fafb', // cards
+          accent: '#2563eb', // CTA / primary
+          'accent-hover': '#1e40af',
+          border: '#e5e7eb',
+          subtle: '#6b7280', // metadata/muted
+          success: '#10b981',
+          warning: '#f59e0b',
+          danger: '#ef4444',
+          info: '#3b82f6',
         },
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- align Tailwind brand palette with landing page colors
- replace hardcoded colors with theme tokens across layout, components, and pages
- document palette mapping for contributors

## Testing
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*
- `npm run build` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a867e99d688327bdc981b3404e8486