### PR TITLE
PR QA+Autofix — E2E workflows, href safety guard, and codemod to fix /[id] links

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,27 @@
+name: E2E
+on: { pull_request: {} }
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - name: Compute base URL
+        run: |
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "PLAYWRIGHT_BASE_URL=https://${{ github.event.pull_request.head.repo.owner.login }}-quickgig-frontend-${{ github.event.number }}.${{ github.repository_owner }}-projects.vercel.app" >> $GITHUB_ENV || true
+          fi
+          echo "PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL:-http://localhost:3000}" >> $GITHUB_ENV
+      - name: href safety
+        run: npm run lint:href
+      - name: E2E
+        run: npm run test:e2e
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/components/ApplicationThread.tsx
+++ b/components/ApplicationThread.tsx
@@ -61,6 +61,7 @@ export default function ApplicationThread({ threadId }: Props) {
     <div
       ref={listRef}
       className="card p-3 h-[60vh] overflow-y-auto flex flex-col gap-2"
+      data-testid="thread-list"
     >
       {msgs.length === 0 && (
         <p className="text-sm text-center text-brand-subtle">No messages yet.</p>

--- a/components/MessageComposer.tsx
+++ b/components/MessageComposer.tsx
@@ -101,11 +101,13 @@ export default function MessageComposer({ threadId, onSent }: Props) {
           placeholder="Type a message..."
           disabled={sending}
           rows={2}
+          data-testid="composer-input"
         />
         <Button
           type="submit"
-          disabled={sending || !body.trim()}
+          disabled={sending || !body.trim()} 
           aria-busy={sending}
+          data-testid="composer-send"
         >
           Send
         </Button>

--- a/components/NotificationsBell.tsx
+++ b/components/NotificationsBell.tsx
@@ -69,9 +69,9 @@ export default function NotificationsBell() {
 
   return (
     <div className="relative">
-      <button onClick={toggle} className="relative">
+      <button onClick={toggle} className="relative" data-testid="nav-bell">
         🔔
-        {count > 0 && <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-brand-danger" />}
+        {count > 0 && <span data-testid="bell-badge" className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-brand-danger" />}
       </button>
       {open && (
         <div className="fixed right-0 top-0 z-50 h-full w-full max-w-sm overflow-y-auto border border-brand-border bg-brand-bg p-4 shadow-lg">
@@ -81,7 +81,7 @@ export default function NotificationsBell() {
                 ? `/applications/${n.payload.application_id}`
                 : undefined
             const content = (
-              <div key={n.id} className="mb-2 border-b border-brand-border pb-2 text-sm">
+              <div key={n.id} data-testid="notif-item" className="mb-2 border-b border-brand-border pb-2 text-sm">
                 {n.payload?.preview && <div>{n.payload.preview}</div>}
                 <div className="text-xs text-brand-subtle">{timeAgo(n.created_at)}</div>
               </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,10 +25,10 @@ export default function TopNav() {
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-4">
         <Link href="/" className="font-semibold">QuickGig.ph</Link>
         <div className="ml-auto flex items-center gap-4 text-sm">
-          <Link href="/find-work">Find Work</Link>
-          {loggedIn && <Link href="/dashboard/gigs">My Gigs</Link>}
-          {loggedIn && <Link href="/applications">Applications</Link>}
-          {loggedIn && <Link href="/saved">Saved</Link>}
+          <Link href="/find-work" data-testid="nav-find">Find Work</Link>
+          {loggedIn && <Link href="/dashboard/gigs" data-testid="nav-my-gigs">My Gigs</Link>}
+          {loggedIn && <Link href="/applications" data-testid="nav-apps">Applications</Link>}
+          {loggedIn && <Link href="/saved" data-testid="nav-saved">Saved</Link>}
           {loggedIn && <NotificationsBell />}
           {loggedIn && !eligible && (
             <Link href="/checkout" className="btn-primary">
@@ -37,12 +37,13 @@ export default function TopNav() {
           )}
           <Link
             href="/post-job"
+            data-testid="nav-post"
             className={`btn-primary ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
             title={loggedIn && !eligible ? 'Please buy a ticket (₱10)' : undefined}
           >
             Post Job
           </Link>
-          <Link href="/auth">Auth</Link>
+          <Link href="/auth" data-testid="nav-auth">Auth</Link>
         </div>
       </div>
     </nav>

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -1,0 +1,12 @@
+# QA
+
+## Running E2E locally
+
+```
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e
+```
+
+## href linter & codemod
+
+- `npm run lint:href` checks for dynamic route links like `/applications/[id]` without actual params.
+- `npm run fix:href` attempts a safe auto-fix. If it cannot determine the right variable, it leaves a `TODO` comment; replace the placeholder with real code and remove the comment.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint || true",
-    "smoke": "echo \"(placeholder)\""
+    "smoke": "echo \"(placeholder)\"",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "lint:href": "node scripts/lint-href.js",
+    "fix:href": "node scripts/fix-href.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2",
@@ -27,7 +31,9 @@
     "typescript": "^5",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
-    "@typescript-eslint/parser": "^6.21.0"
+    "@typescript-eslint/parser": "^6.21.0",
+    "@playwright/test": "^1.43.0",
+    "ts-morph": "^22.0.0"
   },
   "engines": {
     "node": ">=18.17"

--- a/pages/auth/index.tsx
+++ b/pages/auth/index.tsx
@@ -56,6 +56,7 @@ export default function AuthPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            data-testid={mode === 'login' ? 'login-email' : 'signup-email'}
           />
         </div>
         <div>
@@ -66,9 +67,15 @@ export default function AuthPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            data-testid={mode === 'login' ? 'login-password' : 'signup-password'}
           />
         </div>
-        <Button type="submit" disabled={loading} aria-busy={loading}>
+        <Button
+          type="submit"
+          disabled={loading}
+          aria-busy={loading}
+          data-testid={mode === 'login' ? 'login-submit' : 'signup-submit'}
+        >
           {loading ? 'Working…' : mode === 'login' ? 'Log in' : 'Sign up'}
         </Button>
       </form>

--- a/pages/gigs/[id]/index.tsx
+++ b/pages/gigs/[id]/index.tsx
@@ -98,7 +98,7 @@ export default function GigViewPage() {
       <div className="flex items-center justify-between">
         <h1>{gig.title}</h1>
         {isOwner && (
-          <Link href={`/gigs/${gig.id}/edit`} className="btn-secondary">Edit</Link>
+          <Link href={`/gigs/${gig.id}/edit`} className="btn-secondary" data-testid="edit-gig-btn">Edit</Link>
         )}
       </div>
       <Card className="p-4 space-y-2">
@@ -110,7 +110,7 @@ export default function GigViewPage() {
           appId ? (
             <Link href={`/applications/${appId}`} className="btn-secondary">View application</Link>
           ) : (
-            <Button onClick={apply}>Apply</Button>
+            <Button onClick={apply} data-testid="apply-btn">Apply</Button>
           )
         )}
       </Card>

--- a/pages/gigs/index.tsx
+++ b/pages/gigs/index.tsx
@@ -64,9 +64,9 @@ export default function GigsList() {
       ) : (
         <ul className="space-y-4">
           {gigs.map((gig) => (
-            <li key={gig.id}>
+            <li key={gig.id} data-testid="gig-card">
               <Card className="p-4">
-                <Link href={`/gigs/${gig.id}`} className="text-lg font-semibold">
+                <Link href={`/gigs/${gig.id}`} data-testid="gig-open" className="text-lg font-semibold">
                   {gig.title}
                 </Link>
                 <p className="text-sm text-brand-subtle">

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -82,6 +82,7 @@ export default function ProfilePage() {
               id="fullName"
               value={fullName}
               onChange={(e) => setFullName(e.target.value)}
+              data-testid="profile-name"
             />
           </div>
           <div>
@@ -92,7 +93,7 @@ export default function ProfilePage() {
               onChange={(e) => setAvatarUrl(e.target.value)}
             />
           </div>
-          <Button type="submit" disabled={saving} aria-busy={saving}>
+          <Button type="submit" disabled={saving} aria-busy={saving} data-testid="profile-save">
             {saving ? <Spinner /> : 'Save'}
           </Button>
         </form>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+const base = process.env.PLAYWRIGHT_BASE_URL ||
+             (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+
+export default defineConfig({
+  forbidOnly: true,
+  retries: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  expect: { timeout: 10000 },
+  use: {
+    baseURL: base,
+    trace: 'on-first-retry'
+  },
+});

--- a/scripts/fix-href.mjs
+++ b/scripts/fix-href.mjs
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import path from 'path';
+import { Project, SyntaxKind } from 'ts-morph';
+
+const SRC_DIRS = ['pages','components'];
+const project = new Project({ skipAddingFilesFromTsConfig: true });
+
+function addFiles(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir, name);
+    const st = fs.statSync(p);
+    if (st.isDirectory()) addFiles(p);
+    else if (/\.(t|j)sx?$/.test(name)) project.addSourceFileAtPath(p);
+  }
+}
+SRC_DIRS.filter(fs.existsSync).forEach(addFiles);
+
+let changed = 0;
+project.getSourceFiles().forEach(sf => {
+  let dirty = false;
+
+  // 1) <Link href="/applications/[id]"> → <Link href={`/applications/${id}`}> if "id" is in scope
+  sf.getDescendantsOfKind(SyntaxKind.JsxAttribute).forEach(attr => {
+    if (attr.getName() !== 'href') return;
+    const init = attr.getInitializer();
+    if (!init) return;
+    const text = init.getText().replaceAll(/^\{|\}$/g,'');
+    const m = text.match(/^["'`]\/applications\/\[id\]["'`]$/);
+    if (m) {
+      // Find a nearby "id" identifier in scope; if not found, annotate.
+      const idInScope = !!sf.getDescendantsOfKind(SyntaxKind.Identifier).find(i => i.getText() === 'id');
+      if (idInScope) {
+        attr.setInitializer('{`/applications/${id}`}');
+      } else {
+        attr.setInitializer('{/* TODO: supply real id */ `/applications/[id]`}');
+      }
+      dirty = true;
+      changed++;
+    }
+  });
+
+  // 2) router.push("/applications/[id]") → router.push(`/applications/${id}`)
+  sf.forEachDescendant(node => {
+    if (node.getKind() !== SyntaxKind.CallExpression) return;
+    const call = node;
+    const expr = call.getExpression().getText();
+    if (expr !== 'router.push') return;
+    const args = call.getArguments();
+    if (args.length === 1 && args[0].getKind() === SyntaxKind.StringLiteral) {
+      const val = args[0].getText().slice(1, -1);
+      if (val === '/applications/[id]') {
+        const idInScope = !!sf.getDescendantsOfKind(SyntaxKind.Identifier).find(i => i.getText() === 'id');
+        if (idInScope) {
+          args[0].replaceWithText('`/applications/${id}`');
+        } else {
+          args[0].replaceWithText('/* TODO: supply real id */ "/applications/[id]"');
+        }
+        dirty = true;
+        changed++;
+      }
+    }
+    // 3) router.push({ pathname:'/applications/[id]' }) → add missing query if absent
+    if (args.length === 1 && args[0].getKind() === SyntaxKind.ObjectLiteralExpression) {
+      const obj = args[0];
+      const pathnameProp = obj.getProperty('pathname');
+      if (pathnameProp && pathnameProp.getText().includes('/applications/[id]')) {
+        const queryProp = obj.getProperty('query');
+        if (!queryProp) {
+          obj.addPropertyAssignment({ name: 'query', initializer: '{ id }' });
+          dirty = true; changed++;
+        }
+      }
+    }
+  });
+
+  if (dirty) sf.saveSync();
+});
+
+console.log(`fix-href: updated ${changed} occurrence(s)`);

--- a/scripts/lint-href.js
+++ b/scripts/lint-href.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const SRC_DIRS = ['pages','components'];
+
+const offenders = [];
+function scan(file) {
+  const txt = fs.readFileSync(file, 'utf8');
+  // raw bracketed href in <Link> or string push()
+  const badLink = /<Link[^>]*href\s*=\s*["'`](?:[^"'`]*\/\[[^"'`]+\][^"'`]*)["'`]/g;
+  const badPush = /router\.push\(\s*["'`](?:[^"'`]*\/\[[^"'`]+\][^"'`]*)["'`]\s*\)/g;
+  if (badLink.test(txt) || badPush.test(txt)) offenders.push(file);
+
+  // object push with pathname but no query
+  const badObj = /router\.push\(\s*\{\s*pathname:\s*["'`](?:[^"'`]*\/\[[^"'`]+\][^"'`]*)["'`]\s*(?:,\s*query\s*:\s*\{[^}]*\})?\s*\}\s*\)/g;
+  const m = txt.match(badObj);
+  if (m?.some(s => !/query\s*:\s*\{[^}]*\}/.test(s))) offenders.push(file);
+}
+
+function walk(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir, name);
+    const st = fs.statSync(p);
+    if (st.isDirectory()) walk(p);
+    else if (/\.(t|j)sx?$/.test(name)) scan(p);
+  }
+}
+
+for (const d of SRC_DIRS) if (fs.existsSync(d)) walk(d);
+
+if (offenders.length) {
+  console.error('Dynamic-route href issues in:');
+  offenders.forEach(f => console.error(' -', f));
+  process.exit(1);
+}
+console.log('href-safety: OK');

--- a/tests/e2e/applications.messaging.spec.ts
+++ b/tests/e2e/applications.messaging.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { signUpOrLogin } from '../utils/auth';
+import '../utils/consoleFail';
+
+test('apply → thread → message → bell deep link', async ({ page }) => {
+  const email = `applicant+${Date.now()}@example.com`;
+  await signUpOrLogin(page, email, 'Password123!');
+  await page.goto('/gigs');
+  const anyGig = page.getByTestId('gig-open').first();
+  await anyGig.click();
+  if (await page.getByTestId('apply-btn').isVisible()) {
+    await page.getByTestId('apply-btn').click();
+  }
+  await expect(page).toHaveURL(/\/applications\/\d+|\/applications\/[0-9a-f-]{6,}$/);
+  await page.getByTestId('composer-input').fill('Hello!');
+  await page.getByTestId('composer-send').click();
+  await expect(page.getByText('Hello!')).toBeVisible();
+  await page.getByTestId('nav-bell').click();
+  const firstNotif = page.getByTestId('notif-item').first();
+  await firstNotif.click();
+  await expect(page).toHaveURL(/\/applications\/\d+|\/applications\/[0-9a-f-]{6,}$/);
+});

--- a/tests/e2e/auth.onboarding.spec.ts
+++ b/tests/e2e/auth.onboarding.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { signUpOrLogin } from '../utils/auth';
+import '../utils/consoleFail';
+
+test('signup → profile → gigs', async ({ page }) => {
+  const email = `user+${Date.now()}@example.com`;
+  await signUpOrLogin(page, email, 'Password123!');
+  if (page.url().includes('/profile')) {
+    await page.getByTestId('profile-name').fill('User A');
+    await page.getByTestId('profile-save').click();
+    await expect(page).toHaveURL(/\/gigs/);
+  }
+});

--- a/tests/e2e/gigs.crud.spec.ts
+++ b/tests/e2e/gigs.crud.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { signUpOrLogin } from '../utils/auth';
+import '../utils/consoleFail';
+
+test('create & view a gig (if posting is allowed)', async ({ page }) => {
+  const email = `owner+${Date.now()}@example.com`;
+  await signUpOrLogin(page, email, 'Password123!');
+  await page.getByTestId('nav-post').click();
+  if (page.url().includes('/billing')) test.skip(true, 'Posting gated by billing');
+  await page.getByLabel(/title/i).fill('Test Gig');
+  await page.getByLabel(/description/i).fill('Something to do');
+  await page.getByLabel(/budget/i).fill('5000');
+  await page.getByRole('button', { name: /create/i }).click();
+  await expect(page).toHaveURL(/\/gigs\/\d+/);
+  await expect(page.getByText('Test Gig')).toBeVisible();
+});

--- a/tests/e2e/notifications.guard.spec.ts
+++ b/tests/e2e/notifications.guard.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+import '../utils/consoleFail';
+
+test('unrelated user sees friendly access message on /applications/<id>', async ({ page }) => {
+  await page.goto('/applications/999999'); // harmless invalid id path
+  await expect(page.getByText(/not allowed|no access|not public/i)).toBeVisible();
+});

--- a/tests/e2e/smoke.navigation.spec.ts
+++ b/tests/e2e/smoke.navigation.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import '../utils/consoleFail';
+
+test('primary nav works without console errors', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByTestId('nav-find')).toBeVisible();
+  const taps = ['nav-find','nav-my-gigs','nav-apps','nav-saved','nav-auth'];
+  for (const id of taps) {
+    await page.getByTestId(id).click();
+    await expect(page).toHaveURL(/\/(gigs|applications|saved|auth)/);
+  }
+});

--- a/tests/utils/auth.ts
+++ b/tests/utils/auth.ts
@@ -1,0 +1,19 @@
+import { Page, expect } from '@playwright/test';
+
+export async function signUpOrLogin(page: Page, email: string, password: string) {
+  await page.goto('/auth');
+  // Prefer login; if not visible, sign up.
+  const loginEmail = page.getByPlaceholder('Email').first();
+  const loginPw = page.getByPlaceholder('Password').first();
+  if (await loginEmail.isVisible()) {
+    await loginEmail.fill(email);
+    await loginPw.fill(password);
+    await page.getByRole('button', { name: /log in/i }).click();
+  } else {
+    await page.getByPlaceholder('Email').fill(email);
+    await page.getByPlaceholder('Password').fill(password);
+    await page.getByRole('button', { name: /sign up/i }).click();
+  }
+  // Land on profile or gigs
+  await expect(page).toHaveURL(/\/(profile|gigs)/);
+}

--- a/tests/utils/consoleFail.ts
+++ b/tests/utils/consoleFail.ts
@@ -1,0 +1,10 @@
+import { test } from '@playwright/test';
+test.beforeEach(async ({ page }) => {
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      // Fail immediately on console errors
+      test.info().attachments.set('console-error', { body: msg.text(), contentType: 'text/plain' });
+      throw new Error(`Console error: ${msg.text()}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright config, console guard, and smoke tests for nav/auth/gigs/applications
- lint and codemod to prevent `/applications/[id]` links without params
- wire data-testid hooks across nav, gigs, auth, profile, messaging, and notifications

## Testing
- `npm run fix:href` *(fails: Cannot find package 'ts-morph')*
- `npm run lint:href`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ef3e71c8327bb0e0490098e9b65