### PR TITLE
PR9 — Stabilize E2E smoke in CI (Playwright install, cache, server startup)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+        with:
+          node-version: 20
+          cache: 'npm'
       - run: npm ci
       - run: npx playwright install --with-deps
-      - run: npm run build
-      - run: PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run qa:smoke || true
+      - run: npm run build:prod
+      - run: npm run qa:ci

--- a/docs/QA-E2E.md
+++ b/docs/QA-E2E.md
@@ -4,3 +4,4 @@
 3. Start app: npm run dev
 4. Run tests: npm run test:e2e
 Notes: Production builds (Vercel) exclude tests from typecheck via tsconfig.json.
+CI runs qa:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,14 @@
         "@types/react-dom": "^18",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "eslint": "^8.57.0",
+        "eslint-config-next": "^14.2.3",
+        "@typescript-eslint/parser": "^6.21.0",
+        "@playwright/test": "^1.48.0",
+        "ts-morph": "^24.0.0",
+        "fast-glob": "^3.3.2",
+        "start-server-and-test": "^2.0.0"
       },
       "engines": {
         "node": ">=18 <22"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "fix:href": "node scripts/href-codemod.mjs",
     "qa:smoke": "playwright test --config=tests/playwright.config.ts -g '@smoke'",
     "qa:all": "playwright test --config=tests/playwright.config.ts",
-    "postinstall": "if [ \"$NODE_ENV\" != \"production\" ]; then npx playwright install --with-deps || true; fi"
+    "build:prod": "next build",
+    "start:prod": "next start -p 3000",
+    "qa:ci": "start-server-and-test start:prod http://localhost:3000 \"PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run qa:smoke\"",
+    "postinstall": "node -e \"process.env.NODE_ENV==='production'?process.exit(0):0\" || npx playwright install --with-deps || true"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2",
@@ -37,7 +40,8 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@playwright/test": "^1.48.0",
     "ts-morph": "^24.0.0",
-    "fast-glob": "^3.3.2"
+    "fast-glob": "^3.3.2",
+    "start-server-and-test": "^2.0.0"
   },
   "engines": {
     "node": ">=18.17"


### PR DESCRIPTION
## Summary
- install Playwright-related dev dependencies and add server-start script
- run smoke suite in CI against a built Next server
- note in docs that CI runs `qa:ci`

## Testing
- `npm ci && npm run build:prod` *(fails: 403 Forbidden from npm registry)*
- `npm run qa:ci` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87becd7308327bdcdd3fd0dc22a52