### PR TITLE
PR14 — Taglish copy, full-width forms, and profile photo upload (no more “Avatar URL”)

### DIFF
--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { supabase } from '@/utils/supabaseClient'
+import { copy } from '@/copy'
 
 export default function AuthForm({ mode }: { mode: 'login' | 'signup' }) {
   const [email, setEmail] = useState('')
@@ -37,11 +38,11 @@ export default function AuthForm({ mode }: { mode: 'login' | 'signup' }) {
   return (
     <form onSubmit={onSubmit} className="max-w-sm space-y-3">
       {mode==='signup' && (
-        <input required className="input" placeholder="Full name" value={fullName} onChange={e=>setFullName(e.target.value)} />
+        <input required className="input" placeholder={copy.profile.fullName} value={fullName} onChange={e=>setFullName(e.target.value)} />
       )}
-      <input required type="email" className="input" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} />
-      <input required type="password" className="input" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} />
-      <button disabled={loading} className="btn-primary w-full">{loading?'Please wait…': mode==='signup'?'Create account':'Login'}</button>
+      <input required type="email" className="input" placeholder={copy.auth.email} value={email} onChange={e=>setEmail(e.target.value)} />
+      <input required type="password" className="input" placeholder={copy.auth.password} value={password} onChange={e=>setPassword(e.target.value)} />
+      <button disabled={loading} className="btn-primary w-full">{loading?'Please wait…': mode==='signup'?copy.auth.signup:copy.auth.login}</button>
       {msg && <p className="text-sm text-brand-danger">{msg}</p>}
     </form>
   )

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState } from 'react';
 import Banner from '@/components/ui/Banner';
 import NotificationsBell from './NotificationsBell';
 import { supabase } from '@/utils/supabaseClient';
+import { copy } from '@/copy';
 
 const links = [
-  { href: '/gigs', label: 'Find Work' },
-  { href: '/gigs?mine=1', label: 'My Gigs' },
-  { href: '/applications', label: 'Applications' },
-  { href: '/saved', label: 'Saved' },
-  { href: '/gigs/new', label: 'Post Job' },
+  { href: '/gigs', label: copy.nav.findWork },
+  { href: '/gigs?mine=1', label: copy.nav.myGigs },
+  { href: '/applications', label: copy.nav.applications },
+  { href: '/saved', label: copy.nav.saved },
+  { href: '/gigs/new', label: copy.nav.postJob },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -73,7 +74,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {user ? (
               <Link href="/profile" data-testid="nav-profile">Profile</Link>
             ) : (
-              <Link href="/auth" data-testid="nav-login">Auth</Link>
+              <Link href="/auth" data-testid="nav-login">{copy.nav.auth}</Link>
             )}
           </nav>
           {user && <NotificationsBell />}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { supabase } from '@/utils/supabaseClient'
 import type { Session } from '@supabase/supabase-js'
+import { copy } from '@/copy'
 
 export default function Nav() {
   const [session, setSession] = useState<Session | null>(null)
@@ -22,12 +23,12 @@ export default function Nav() {
   return (
     <nav className="p-4 border-b mb-4 flex gap-4">
       <Link href="/">Home</Link>
-      <Link href="/find-work">Find Work</Link>
-      <Link href="/post-job">Post Job</Link>
+      <Link href="/find-work">{copy.nav.findWork}</Link>
+      <Link href="/post-job">{copy.nav.postJob}</Link>
       {session ? (
         <button onClick={logout}>Logout</button>
       ) : (
-        <Link href="/auth">Auth</Link>
+        <Link href="/auth">{copy.nav.auth}</Link>
       )}
     </nav>
   )

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { supabase } from "@/utils/supabaseClient";
 import NotificationsBell from "@/components/NotificationsBell";
+import { copy } from "@/copy";
 
 export default function TopNav() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -25,10 +26,10 @@ export default function TopNav() {
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-4">
         <Link href="/" className="font-semibold">QuickGig.ph</Link>
         <div className="ml-auto flex items-center gap-4 text-sm">
-          <Link href="/find-work">Find Work</Link>
-          {loggedIn && <Link href="/dashboard/gigs">My Gigs</Link>}
-          {loggedIn && <Link href="/applications">Applications</Link>}
-          {loggedIn && <Link href="/saved">Saved</Link>}
+          <Link href="/find-work">{copy.nav.findWork}</Link>
+          {loggedIn && <Link href="/dashboard/gigs">{copy.nav.myGigs}</Link>}
+          {loggedIn && <Link href="/applications">{copy.nav.applications}</Link>}
+          {loggedIn && <Link href="/saved">{copy.nav.saved}</Link>}
           {loggedIn && <NotificationsBell />}
           {loggedIn && !eligible && (
             <Link href="/checkout" className="btn-primary">
@@ -40,9 +41,9 @@ export default function TopNav() {
             className={`btn-primary ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
             title={loggedIn && !eligible ? 'Please buy a ticket (₱10)' : undefined}
           >
-            Post Job
+            {copy.nav.postJob}
           </Link>
-          <Link href="/auth">Auth</Link>
+          <Link href="/auth">{copy.nav.auth}</Link>
         </div>
       </div>
     </nav>

--- a/pages/auth/index.tsx
+++ b/pages/auth/index.tsx
@@ -3,10 +3,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { supabase } from '@/utils/supabaseClient';
 import Banner from '@/components/ui/Banner';
-import Button from '@/components/ui/Button';
-import Input from '@/components/ui/Input';
-import Card from '@/components/ui/Card';
 import { getProfile } from '@/utils/session';
+import { copy } from '@/copy';
 
 export default function AuthPage() {
   const [mode, setMode] = useState<'login' | 'signup'>('login');
@@ -43,41 +41,45 @@ export default function AuthPage() {
   }
 
   return (
-    <Card className="max-w-md mx-auto p-6">
-      <h1>{mode === 'login' ? 'Log in' : 'Sign up'}</h1>
+    <main className="max-w-xl w-full mx-auto px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-4">
+        {mode === 'login' ? copy.auth.loginTitle : copy.auth.signupTitle}
+      </h1>
       {msg && <Banner kind="success">{msg}</Banner>}
       {err && <Banner kind="error">{err}</Banner>}
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="label">Email</label>
-          <Input
+          <label htmlFor="email" className="block text-sm font-medium">{copy.auth.email}</label>
+          <input
             id="email"
             type="email"
+            className="w-full"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
           />
         </div>
         <div>
-          <label htmlFor="password" className="label">Password</label>
-          <Input
+          <label htmlFor="password" className="block text-sm font-medium">{copy.auth.password}</label>
+          <input
             id="password"
             type="password"
+            className="w-full"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
           />
         </div>
-        <Button type="submit" disabled={loading} aria-busy={loading}>
-          {loading ? 'Working…' : mode === 'login' ? 'Log in' : 'Sign up'}
-        </Button>
+        <button type="submit" disabled={loading} aria-busy={loading} className="btn-primary px-4 py-2 rounded">
+          {loading ? '...' : mode === 'login' ? copy.auth.login : copy.auth.signup}
+        </button>
       </form>
       <p className="mt-4 text-sm">
         {mode === 'login' ? 'No account?' : 'Have an account?'}{' '}
         <button className="underline" onClick={() => setMode(mode === 'login' ? 'signup' : 'login')}>
-          {mode === 'login' ? 'Sign up' : 'Log in'}
+          {mode === 'login' ? copy.auth.signup : copy.auth.login}
         </button>
       </p>
-    </Card>
+    </main>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Card from '@/components/ui/Card';
 import { getProfile } from '@/utils/session';
+import { copy } from '@/copy';
 
 export default function Home() {
   const [canPost, setCanPost] = useState(false);
@@ -15,9 +16,9 @@ export default function Home() {
       <h1>QuickGig.ph</h1>
       <p>Connect with opportunities — find work or hire talent quickly.</p>
       <div className="flex justify-center gap-4">
-        <Link href="/gigs" className="btn-primary">Find Work</Link>
+        <Link href="/gigs" className="btn-primary">{copy.nav.findWork}</Link>
         {canPost && (
-          <Link href="/gigs/new" className="btn-secondary">Post a Job</Link>
+          <Link href="/gigs/new" className="btn-secondary">{copy.nav.postJob}</Link>
         )}
       </div>
     </Card>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { supabase } from "@/utils/supabaseClient";
 import Shell from "@/components/Shell";
 import { useRouter } from "next/router";
+import { copy } from "@/copy";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -19,7 +20,7 @@ export default function LoginPage() {
 
   return (
     <Shell>
-      <h1 className="text-2xl font-bold mb-4">Login / Sign up</h1>
+      <h1 className="text-2xl font-bold mb-4">{copy.auth.loginTitle} / {copy.auth.signup}</h1>
       {sent ? (
         <p className="text-brand-success">Magic link sent! Check your email.</p>
       ) : (
@@ -27,12 +28,12 @@ export default function LoginPage() {
           <input
             type="email"
             required
-            placeholder="you@email.com"
+            placeholder={copy.auth.email}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="input"
           />
-          <button className="btn-primary">Send Magic Link</button>
+          <button className="btn-primary">{copy.auth.login}</button>
           {error && <p className="text-brand-danger">{error}</p>}
         </form>
       )}

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -4,30 +4,40 @@ import { useRouter } from 'next/router';
 import { supabase } from '@/utils/supabaseClient';
 import Banner from '@/components/ui/Banner';
 import Spinner from '@/components/ui/Spinner';
-import Input from '@/components/ui/Input';
-import Button from '@/components/ui/Button';
-import Card from '@/components/ui/Card';
-import { getProfile, getUserId } from '@/utils/session';
+import { copy } from '@/copy';
+import { uploadImage } from '@/utils/uploadImage';
 import { isAccessDenied } from '@/utils/errors';
 
 export default function ProfilePage() {
   const router = useRouter();
   const onboarding = router.query.onboarding === '1';
   const [fullName, setFullName] = useState('');
-  const [avatarUrl, setAvatarUrl] = useState('');
+  const [avatar, setAvatar] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string>();
   const [canPostJob, setCanPostJob] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [user, setUser] = useState<any>(null);
+  const [profile, setProfile] = useState<any>(null);
 
   useEffect(() => {
     (async () => {
-      const profile = await getProfile();
-      if (profile) {
-        setFullName(profile.full_name ?? '');
-        setAvatarUrl(profile.avatar_url ?? '');
-        setCanPostJob(profile.can_post_job ?? false);
+      const { data: u } = await supabase.auth.getUser();
+      setUser(u.user);
+      if (u.user) {
+        const { data: p } = await supabase
+          .from('profiles')
+          .select('*')
+          .eq('id', u.user.id)
+          .single();
+        setProfile(p);
+        if (p) {
+          setFullName(p.full_name ?? '');
+          setPreview(p.avatar_url ?? undefined);
+          setCanPostJob(p.can_post_job ?? false);
+        }
       }
       setLoaded(true);
     })();
@@ -38,18 +48,29 @@ export default function ProfilePage() {
     setSaving(true);
     setStatus(null);
     setError(null);
-    const id = await getUserId();
-    if (!id) {
-      setError("You don't have access to this profile.");
+    const { data: u } = await supabase.auth.getUser();
+    const uid = u?.user?.id;
+    if (!uid) {
+      setError(copy.profile.noAccess);
       setSaving(false);
       return;
     }
-    const { error } = await supabase
-      .from('profiles')
-      .upsert({ id, full_name: fullName, avatar_url: avatarUrl });
-    if (error) {
-      if (isAccessDenied(error)) setError("You don't have access to this profile.");
-      else setError(error.message);
+    try {
+      if (avatar) {
+        const up = await uploadImage('avatars', uid, avatar);
+        await supabase.from('profiles').update({ avatar_url: up.publicUrl }).eq('id', uid);
+      }
+      const { error } = await supabase
+        .from('profiles')
+        .upsert({ id: uid, full_name: fullName });
+      if (error) {
+        if (isAccessDenied(error)) setError(copy.profile.noAccess);
+        else setError(error.message);
+        setSaving(false);
+        return;
+      }
+    } catch (err: any) {
+      setError(err.message);
       setSaving(false);
       return;
     }
@@ -67,36 +88,57 @@ export default function ProfilePage() {
 
   if (!loaded) return <p>Loading...</p>;
 
+  const noAccess = !!(user && profile && profile.id !== user.id);
+
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-brand-subtle">Profile</p>
-      {onboarding && <Banner kind="info">Step 1 of 2 — Complete your profile</Banner>}
+    <main className="max-w-xl w-full mx-auto px-4 py-8 space-y-4">
+      {onboarding && <p className="text-sm text-brand-subtle">{copy.profile.step}</p>}
+      {noAccess && (
+        <div className="text-red-600 text-sm border rounded px-3 py-2">
+          {copy.profile.noAccess}
+        </div>
+      )}
       {status && <Banner kind="success">{status}</Banner>}
       {error && <Banner kind="error">{error}</Banner>}
-      <Card className="max-w-md p-6">
-        <h1 className="mb-4">Your Profile</h1>
-        <form onSubmit={save} className="space-y-4">
-          <div>
-            <label htmlFor="fullName" className="label">Full name</label>
-            <Input
-              id="fullName"
-              value={fullName}
-              onChange={(e) => setFullName(e.target.value)}
-            />
-          </div>
-          <div>
-            <label htmlFor="avatar" className="label">Avatar URL</label>
-            <Input
-              id="avatar"
-              value={avatarUrl}
-              onChange={(e) => setAvatarUrl(e.target.value)}
-            />
-          </div>
-          <Button type="submit" disabled={saving} aria-busy={saving}>
-            {saving ? <Spinner /> : 'Save'}
-          </Button>
-        </form>
-      </Card>
-    </div>
+      <h1 className="text-2xl font-semibold mb-4">{copy.profile.heading}</h1>
+      <form onSubmit={save} className="space-y-4">
+        <div>
+          <label htmlFor="fullName" className="block text-sm font-medium">{copy.profile.fullName}</label>
+          <input
+            id="fullName"
+            type="text"
+            className="w-full"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">{copy.profile.photoLabel}</label>
+          {preview && (
+            <img src={preview} alt="Preview" className="h-20 w-20 rounded-full border" />
+          )}
+          <input
+            data-testid="profile-avatar-upload"
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const f = e.target.files?.[0] || null;
+              setAvatar(f);
+              setPreview(f ? URL.createObjectURL(f) : preview);
+            }}
+          />
+          <p className="text-xs text-gray-500">{copy.profile.photoHelp}</p>
+        </div>
+        <button
+          data-testid="profile-save"
+          type="submit"
+          disabled={saving}
+          aria-busy={saving}
+          className="btn-primary px-4 py-2 rounded"
+        >
+          {saving ? <Spinner /> : copy.profile.save}
+        </button>
+      </form>
+    </main>
   );
 }

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -1,0 +1,32 @@
+export const copy = {
+  nav: {
+    findWork: 'Hanap Trabaho',
+    myGigs: 'My Gigs',
+    applications: 'Applications',
+    saved: 'Saved',
+    postJob: 'Mag-post ng Gig',
+    auth: 'Account',
+    admin: 'Admin',
+  },
+  auth: {
+    signupTitle: 'Gumawa ng account',
+    loginTitle: 'Mag-login',
+    email: 'Email address',
+    password: 'Password',
+    signup: 'Sign up',
+    login: 'Login',
+  },
+  profile: {
+    step: 'Step 1 of 2 — Kumpletuhin ang profile',
+    heading: 'Iyong Profile',
+    fullName: 'Buong pangalan',
+    photoLabel: 'Profile picture (larawan)',
+    photoHelp: 'PNG/JPG hanggang ~2MB',
+    uploadBtn: 'I-upload ang larawan',
+    save: 'I-save',
+    noAccess: 'Di puwedeng i-edit ang profile ng ibang tao.',
+  },
+  billing: {
+    paywallMsg: 'Para makapag-post ng gig, mag-upload muna ng GCash resibo. Ire-review ng admin.',
+  },
+};

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,0 +1,11 @@
+import { supabase } from '@/utils/supabaseClient';
+export async function uploadImage(bucket: string, userId: string, file: File) {
+  const ext = file.name.split('.').pop() || 'jpg';
+  const path = `${userId}/${crypto.randomUUID()}.${ext}`;
+  const { data, error } = await supabase.storage.from(bucket).upload(path, file, {
+    upsert: false, contentType: file.type || 'application/octet-stream'
+  });
+  if (error) throw error;
+  const { data: pub } = supabase.storage.from(bucket).getPublicUrl(data.path);
+  return { path: data.path, publicUrl: pub.publicUrl };
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,3 +26,12 @@
   .banner-error { @apply banner bg-brand-danger/10 border-brand-danger text-brand-danger; }
   .section { @apply space-y-6; }
 }
+@layer base {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="url"],
+  textarea, select {
+    @apply w-full text-base md:text-lg leading-6 px-3 py-2 border rounded-lg;
+  }
+}

--- a/supabase/migrations/20250823_avatars_bucket.sql
+++ b/supabase/migrations/20250823_avatars_bucket.sql
@@ -1,0 +1,3 @@
+insert into storage.buckets (id, name, public)
+values ('avatars','avatars', true)
+on conflict (id) do update set public = excluded.public;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["*"],
+      "@/*": ["*", "src/*"],
       "@lib/*": ["lib/*"],
       "@utils/*": ["utils/*"],
       "@components/*": ["components/*"]


### PR DESCRIPTION
## Summary
- add central Taglish copy helper and use for nav/auth labels
- widen auth/profile forms and apply global input styles
- replace avatar URL with image upload + preview and add avatars bucket migration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

## Checklist
- [x] Inputs are full-width; long emails are readable
- [x] “Avatar URL” removed → Upload photo + preview
- [x] Taglish copy for nav/auth/profile
- [x] Access error only shown when applicable
- [x] Avatars bucket migration added

------
https://chatgpt.com/codex/tasks/task_e_68a919f0f270832790a6c1685ad38806