### PR TITLE
PR15 — Add Playwright nav audit: click all key links/buttons and assert routes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,12 @@
 name: E2E Smoke
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,4 +21,5 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      - run: npm run qa:nav
       - run: npm run qa:ci

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,11 +7,11 @@ import { supabase } from '@/utils/supabaseClient';
 import { copy } from '@/copy';
 
 const links = [
-  { href: '/gigs', label: copy.nav.findWork },
-  { href: '/gigs?mine=1', label: copy.nav.myGigs },
-  { href: '/applications', label: copy.nav.applications },
-  { href: '/saved', label: copy.nav.saved },
-  { href: '/gigs/new', label: copy.nav.postJob },
+  { href: '/gigs', label: copy.nav.findWork, id: 'nav-find' },
+  { href: '/gigs?mine=1', label: copy.nav.myGigs, id: 'nav-my-gigs' },
+  { href: '/applications', label: copy.nav.applications, id: 'nav-applications' },
+  { href: '/saved', label: copy.nav.saved, id: 'nav-saved' },
+  { href: '/gigs/new', label: copy.nav.postJob, id: 'nav-post' },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -66,6 +66,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                   href={l.href}
                   className={active ? 'font-semibold underline' : undefined}
                   aria-current={active ? 'page' : undefined}
+                  data-testid={l.id}
                 >
                   {l.label}
                 </Link>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:prod": "next build",
     "start:prod": "next start -p 3000",
     "qa:ci": "start-server-and-test start:prod http://localhost:3000 \"PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run qa:smoke\"",
+    "qa:nav": "start-server-and-test start:prod http://localhost:3000 \"PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test tests/nav.audit.spec.ts --config=tests/playwright.config.ts\"",
     "seed": "node scripts/seed.mjs",
     "postinstall": "node -e \"process.env.NODE_ENV==='production'?process.exit(0):0\" || npx playwright install --with-deps || true"
   },

--- a/pages/applications/index.tsx
+++ b/pages/applications/index.tsx
@@ -37,7 +37,7 @@ export default function ApplicationsList() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">My Applications</h1>
       {loading && <p>Loading…</p>}
-      <ul className="space-y-3">
+      <ul className="space-y-3" data-testid="applications-list">
         {rows.map((r) => (
           <li key={r.id} className="card">
             <Link

--- a/pages/gigs/index.tsx
+++ b/pages/gigs/index.tsx
@@ -56,7 +56,10 @@ export default function GigsList() {
   };
 
   return (
-    <div className="space-y-4">
+    <div
+      className="space-y-4"
+      data-testid={router.query.mine === '1' ? 'my-gigs' : 'gigs-list'}
+    >
       {redirecting && <p data-testid="paywall-redirect">Redirecting...</p>}
       <div className="text-right">
         <button onClick={handlePostJob} className="btn-primary">Post Job</button>

--- a/pages/gigs/new.tsx
+++ b/pages/gigs/new.tsx
@@ -60,7 +60,7 @@ export default function NewGig() {
   if (!allowed) return <p data-testid="paywall-redirect">Redirecting...</p>;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-testid="gig-editor">
       <p className="text-sm text-brand-subtle">Gigs / Post job</p>
       <h1>Post a Job</h1>
       {rlsDenied && <Banner kind="error">Only job posters can post</Banner>}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,9 +16,21 @@ export default function Home() {
       <h1>QuickGig.ph</h1>
       <p>Connect with opportunities — find work or hire talent quickly.</p>
       <div className="flex justify-center gap-4">
-        <Link href="/gigs" className="btn-primary">{copy.nav.findWork}</Link>
+        <Link
+          href="/gigs"
+          className="btn-primary cta-find"
+          data-testid="cta-find"
+        >
+          {copy.nav.findWork}
+        </Link>
         {canPost && (
-          <Link href="/gigs/new" className="btn-secondary">{copy.nav.postJob}</Link>
+          <Link
+            href="/gigs/new"
+            className="btn-secondary cta-post"
+            data-testid="cta-post"
+          >
+            {copy.nav.postJob}
+          </Link>
         )}
       </div>
     </Card>

--- a/pages/saved.tsx
+++ b/pages/saved.tsx
@@ -16,7 +16,7 @@ export default function SavedPage() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">Saved Gigs</h1>
       <Link href="/alerts" className="underline text-sm">Manage Alerts</Link>
-      <table className="mt-4 w-full text-left text-sm">
+      <table className="mt-4 w-full text-left text-sm" data-testid="saved-list">
         <thead>
           <tr className="border-b border-slate-800">
             <th className="py-2">Title</th>

--- a/tests/nav.audit.spec.ts
+++ b/tests/nav.audit.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+test('nav audit', async ({ page }) => {
+  const targets: { id: string; path: string | RegExp; marker: string | string[] }[] = [
+    { id: 'nav-find', path: '/gigs', marker: 'gigs-list' },
+    { id: 'nav-my-gigs', path: '/gigs?mine=1', marker: 'my-gigs' },
+    { id: 'nav-applications', path: '/applications', marker: 'applications-list' },
+    { id: 'nav-saved', path: '/saved', marker: 'saved-list' },
+    { id: 'nav-post', path: /\/(billing|gigs\/new)/, marker: ['paywall-redirect', 'gig-editor'] },
+    { id: 'nav-profile', path: '/profile', marker: 'profile-save' },
+  ];
+
+  const ctaMap: Record<string, { path: string | RegExp; marker: string | string[] }> = {
+    'cta-find': { path: '/gigs', marker: 'gigs-list' },
+    'cta-post': { path: /\/(billing|gigs\/new)/, marker: ['paywall-redirect', 'gig-editor'] },
+  };
+
+  await page.goto('/');
+
+  for (const id of Object.keys(ctaMap)) {
+    if (await page.getByTestId(id).count()) {
+      targets.push({ id, ...ctaMap[id] });
+    }
+  }
+
+  for (const t of targets) {
+    await page.getByTestId(t.id).click();
+    await page.waitForLoadState('networkidle');
+    expect(page.url()).toMatch(t.path);
+    const markers = Array.isArray(t.marker) ? t.marker : [t.marker];
+    let found = false;
+    for (const m of markers) {
+      if ((await page.getByTestId(m).count()) > 0) {
+        found = true;
+        break;
+      }
+      if ((await page.getByRole('heading', { name: m }).count()) > 0) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBeTruthy();
+    await page.goto('/');
+  }
+});


### PR DESCRIPTION
## Summary
- instrument top navigation links and home page CTAs with data-testid hooks
- add Playwright nav audit test and qa:nav script, wiring it into CI after build
- mark key pages with data-testids so the audit can assert correct routing

## Testing
- ❌ `npm ci` (403 Forbidden for @playwright/test)
- ❌ `npm run qa:nav` (start-server-and-test not found)


------
https://chatgpt.com/codex/tasks/task_e_68a91ede27c88327ba4c2b23e6e55821