### PR TITLE
PR — Polish theme: white page background, dark header with white text, logo in header only

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -4,9 +4,9 @@ import Footer from './Footer';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col bg-surface-base text-brand-foreground">
+    <div className="min-h-screen bg-surface text-text flex flex-col">
       <Header />
-      <main className="flex-1">{children}</main>
+      <main className="container flex-1 py-6 bg-surface">{children}</main>
       <Footer />
     </div>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
-    <footer className="border-t border-brand-border text-center py-6 text-sm text-brand-muted">
-      © {new Date().getFullYear()} QuickGig.ph
+    <footer className="border-t border-gray-200/60 bg-surface text-sm text-gray-600">
+      <div className="container py-6">© 2025 QuickGig.ph</div>
     </footer>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import LinkSafe from './LinkSafe';
 import { supabase } from '@/utils/supabaseClient';
 import { copy } from '@/copy';
@@ -32,17 +33,20 @@ export default function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-20 bg-brand-foreground text-white shadow-soft">
-      <div className="max-w-6xl mx-auto flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16">
-        <LinkSafe href="/" className="font-semibold">QuickGig.ph</LinkSafe>
-        <nav className="hidden md:flex items-center gap-6 text-sm">
+    <header className="sticky top-0 z-40 bg-header-bg text-header-text border-b border-white/10">
+      <div className="container flex h-14 items-center justify-between">
+        <LinkSafe href="/" className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="QuickGig.ph" width={28} height={28} priority />
+          <span className="font-semibold">QuickGig.ph</span>
+        </LinkSafe>
+        <nav className="hidden md:flex items-center gap-4 text-sm">
           {links.map((l) => {
             const active = isActive(l.href);
             return (
               <LinkSafe
                 key={l.href}
                 href={l.href}
-                className={active ? 'underline underline-offset-4' : undefined}
+                className={`${active ? 'underline underline-offset-4' : ''} hover:text-white/90`}
               >
                 {l.label}
               </LinkSafe>
@@ -51,15 +55,15 @@ export default function Header() {
         </nav>
         <div className="flex items-center gap-4">
           {user ? (
-            <LinkSafe href="/profile" className="text-sm">
+            <LinkSafe href="/profile" className="text-sm hover:text-white/90">
               {copy.nav.auth}
             </LinkSafe>
           ) : (
             <>
-              <LinkSafe href="/auth" className="text-sm">
+              <LinkSafe href="/auth" className="text-sm hover:text-white/90">
                 Mag-login
               </LinkSafe>
-              <LinkSafe href="/auth" className="text-sm font-semibold">
+              <LinkSafe href="/auth" className="text-sm font-semibold hover:text-white/90">
                 Gumawa ng account
               </LinkSafe>
             </>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start:prod": "next start -p 3000",
     "qa:ci": "start-server-and-test start:prod http://localhost:3000 \"PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run qa:smoke\"",
     "qa:nav": "start-server-and-test start:prod http://localhost:3000 \"PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test tests/nav.audit.spec.ts --config=tests/playwright.config.ts\"",
-    "qa:ui": "playwright test tests/e2e/ui.spec.ts",
+    "qa:ui": "playwright test tests/ui/header.spec.ts --config=tests/playwright.config.ts",
     "qa:admin": "playwright test tests/admin.guard.spec.ts",
     "seed": "node scripts/seed.mjs",
     "postinstall": "node -e \"process.env.NODE_ENV==='production'?process.exit(0):0\" || npx playwright install --with-deps || true"

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,12 +2,9 @@ import LinkSafe from '@/components/LinkSafe';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-hero text-white text-center p-4">
-      <h1 className="text-4xl font-bold mb-4">Hindi makita ang page</h1>
-      <LinkSafe
-        href="/gigs"
-        className="underline text-xl"
-      >
+    <div className="py-20 text-center space-y-4">
+      <h1 className="text-3xl font-extrabold">Hindi makita ang page</h1>
+      <LinkSafe href="/find" className="text-link underline">
         Bumalik sa Hanap Trabaho
       </LinkSafe>
     </div>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -2,9 +2,9 @@ import LinkSafe from '@/components/LinkSafe';
 
 export default function FiveHundred() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-hero text-white text-center p-4">
-      <h1 className="text-4xl font-bold mb-4">May problema sa server</h1>
-      <LinkSafe href="/gigs" className="underline text-xl">
+    <div className="py-20 text-center space-y-4">
+      <h1 className="text-3xl font-extrabold">May problema sa server</h1>
+      <LinkSafe href="/find" className="text-link underline">
         Bumalik sa Hanap Trabaho
       </LinkSafe>
     </div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from "next/app";
+import "../styles/theme.css";
 import "../styles/globals.css";
 import "../styles/accessibility.css";
 import AppShell from "@/components/AppShell";

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <circle cx="16" cy="16" r="16" fill="#0b2a3a"/>
+  <text x="16" y="21" font-size="20" text-anchor="middle" fill="#fff">Q</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,12 +13,12 @@
     --hero-from: #0ea5a3;
     --hero-to: #065f46;
   }
-  html, body { @apply bg-surface-base text-brand-foreground; }
+  html, body { @apply bg-surface text-text; }
   h1 { @apply text-3xl font-bold tracking-tight; }
   h2 { @apply text-2xl font-semibold; }
   h3 { @apply text-xl font-semibold; }
-  p  { @apply text-[15px] leading-6 text-brand-foreground; }
-  a  { @apply text-brand-primary hover:text-brand-accent; }
+  p  { @apply text-[15px] leading-6 text-text; }
+  a  { @apply text-link hover:opacity-80; }
 }
 
 @layer components {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,8 @@
+:root{
+  --surface:#ffffff;
+  --surface-muted:#f6f7f9;
+  --text:#0b1220;
+  --header-bg:#0b2a3a;
+  --header-text:#ffffff;
+  --link:#0b5fff;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,9 +30,17 @@ const config: Config = {
           foreground: '#0f172a',
         },
         surface: {
+          DEFAULT: 'var(--surface)',
+          muted: 'var(--surface-muted)',
           base: '#ffffff',
           raised: '#f9fafb',
         },
+        text: 'var(--text)',
+        header: {
+          bg: 'var(--header-bg)',
+          text: 'var(--header-text)',
+        },
+        link: 'var(--link)',
       },
       boxShadow: {
         card: '0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06)',

--- a/tests/ui/header.spec.ts
+++ b/tests/ui/header.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('header is dark with white text, surface is white', async ({ page }) => {
+  await page.goto('/find');
+  const header = page.locator('header');
+  const main = page.locator('main');
+  await expect(header).toHaveCSS('color', 'rgb(255, 255, 255)');
+  await expect(main).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await expect(page.getByRole('link', { name: /QuickGig\.ph/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add theme tokens and Tailwind mappings for white surfaces and dark brand header
- update global layout with dark header, logo, and white page background
- simplify error pages and add header color Playwright test

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build:prod` *(fails: next not found)*
- `npm run qa:ui` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94831ff8483279722f69ef285b620