### PR TITLE
feat: align app theme with landing styles

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
+import { useRouter } from 'next/router';
 import Header from './Header';
 import Footer from './Footer';
 import Container from './Container';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const isError = router.pathname === '/404' || router.pathname === '/500';
   return (
     <div className="min-h-screen bg-surface text-text flex flex-col">
-      <Header />
+      {!isError && <Header />}
       <main className="flex-1 py-6 bg-surface">
         <Container>{children}</Container>
       </main>
-      <Footer />
+      {!isError && <Footer />}
     </div>
   );
 }

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -2,7 +2,7 @@ import { cn } from '@utils/cn';
 import React from 'react';
 
 export const Container = ({ className, ...p }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div {...p} className={cn('mx-auto w-full max-w-[1100px] px-4 sm:px-6 md:px-8', className)} />
+  <div {...p} className={cn('mx-auto w-full max-w-[1200px] px-6', className)} />
 );
 
 export default Container;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import Container from './Container';
 
 export default function Footer() {
   return (
-    <footer className="border-t border-gray-200/60 bg-surface text-sm text-gray-600">
+    <footer className="border-t border-brand-border bg-surface text-sm text-brand-muted">
       <Container className="py-6">© 2025 QuickGig.ph</Container>
     </footer>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -55,19 +55,18 @@ export default function Header() {
       data-app-header
       className="sticky top-0 z-40 bg-header-bg text-header-text border-b border-white/10"
     >
-      <Container className="flex h-14 items-center justify-between">
-        <LinkSafe href="/" className="flex items-center gap-2 h-11 min-h-[44px]">
-          <Image src="/logo.svg" alt="QuickGig.ph" width={28} height={28} priority />
-          <span className="font-semibold">QuickGig.ph</span>
+      <Container className="flex h-16 items-center justify-between">
+        <LinkSafe href="/" className="flex items-center h-11 min-h-[44px]">
+          <Image src="/logo-horizontal.png" alt="QuickGig.ph" width={140} height={32} priority />
         </LinkSafe>
-        <nav className="hidden md:flex items-center gap-4 text-sm">
+        <nav className="hidden md:flex items-center gap-6 text-sm">
           {links.map((l) => {
             const active = isActive(l.href);
             return (
               <LinkSafe
                 key={l.href}
                 href={l.href}
-                className={`${active ? 'underline underline-offset-4' : ''} h-11 min-h-[44px] inline-flex items-center hover:text-white/90`}
+                className={`${active ? 'opacity-100 underline underline-offset-4' : 'opacity-90 hover:opacity-100'} h-11 min-h-[44px] inline-flex items-center`}
               >
                 {l.label}
               </LinkSafe>
@@ -77,7 +76,7 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <button
             data-testid="menu-toggle"
-            className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-brand-fg"
+            className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-lg text-white"
             aria-label="Open menu"
             aria-expanded={open}
             onClick={() => setOpen((v) => !v)}
@@ -87,23 +86,31 @@ export default function Header() {
           {user ? (
             <LinkSafe
               href="/profile"
-              className="hidden md:inline-flex h-11 min-h-[44px] items-center text-sm hover:text-white/90"
+              className="hidden md:inline-flex h-11 min-h-[44px] items-center text-sm opacity-90 hover:opacity-100"
             >
               {copy.nav.auth}
             </LinkSafe>
           ) : (
-            <LinkSafe
-              href="/auth"
-              className="hidden md:inline-flex h-11 min-h-[44px] items-center text-sm hover:text-white/90"
-            >
-              Mag-login
-            </LinkSafe>
+            <>
+              <LinkSafe
+                href="/auth"
+                className="hidden md:inline-flex h-11 min-h-[44px] items-center text-sm opacity-90 hover:opacity-100"
+              >
+                Mag-login
+              </LinkSafe>
+              <LinkSafe
+                href="/signup"
+                className="hidden md:inline-flex btn-primary h-11 min-h-[44px]"
+              >
+                Sign Up
+              </LinkSafe>
+            </>
           )}
         </div>
       </Container>
       {open && (
-        <div className="md:hidden border-t border-white/10 bg-brand-bg text-brand-fg">
-          <nav className="grid gap-1 p-3">
+        <div className="md:hidden fixed inset-0 z-30 bg-header-bg text-white pt-16">
+          <nav className="grid gap-1 p-6">
             {links.map((l) => (
               <LinkSafe
                 key={l.href}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -6,9 +6,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 export default function Button({ variant = 'primary', className = '', ...props }: ButtonProps) {
   const base =
-    'inline-flex h-11 min-h-[44px] w-full sm:w-auto items-center justify-center rounded-xl px-4 text-base md:text-lg font-medium focus:outline-none focus:ring-2 focus:ring-brand-primary';
+    'inline-flex h-11 min-h-[44px] w-full sm:w-auto items-center justify-center rounded-xl px-4 text-base md:text-lg font-medium focus:outline-none focus:ring-2 focus:ring-brand-accent';
   const styles: Record<NonNullable<ButtonProps['variant']>, string> = {
-    primary: 'bg-brand-primary text-white hover:bg-brand-primary/90 shadow-soft',
+    primary:
+      'bg-brand-accent text-brand-foreground hover:bg-brand-accent/90 shadow-[0_6px_20px_rgba(250,204,21,0.35)]',
     outline:
       'border border-brand-border text-brand-foreground bg-surface-base hover:bg-surface-raised',
     subtle: 'bg-surface-raised text-brand-foreground hover:bg-surface-base',

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,14 +1,13 @@
 import LinkSafe from '@/components/LinkSafe';
-import Container from '@/components/Container';
 import { H1 } from '@/components/ui/Text';
 
 export default function NotFound() {
   return (
-    <Container className="py-20 text-center space-y-4">
+    <div className="py-20 text-center space-y-4">
       <H1>Hindi makita ang page</H1>
       <LinkSafe href="/find" className="text-link underline">
         Bumalik sa Hanap Trabaho
       </LinkSafe>
-    </Container>
+    </div>
   );
 }

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,14 +1,13 @@
 import LinkSafe from '@/components/LinkSafe';
-import Container from '@/components/Container';
 import { H1 } from '@/components/ui/Text';
 
 export default function FiveHundred() {
   return (
-    <Container className="py-20 text-center space-y-4">
+    <div className="py-20 text-center space-y-4">
       <H1>May problema sa server</H1>
       <LinkSafe href="/find" className="text-link underline">
         Bumalik sa Hanap Trabaho
       </LinkSafe>
-    </Container>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,7 +46,9 @@ html, body { background: var(--surface, #fff); }
     @apply w-full text-base md:text-lg leading-6 px-3 py-3 border rounded-lg;
   }
   label { @apply block text-sm font-medium mb-1; }
-  .btn-primary { @apply inline-flex items-center justify-center px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700; }
+  .btn-primary {
+    @apply inline-flex items-center justify-center px-4 py-2 rounded-xl bg-brand-accent text-brand-foreground shadow-[0_6px_20px_rgba(250,204,21,0.35)] hover:bg-brand-accent/90;
+  }
 }
 
 @layer utilities {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,8 +1,9 @@
 :root{
   --surface:#ffffff;
   --surface-muted:#f6f7f9;
-  --text:#0b1220;
-  --header-bg:#0b2a3a;
+  --text:#0f172a;
+  --brand-surface:#0b1d1f;
+  --header-bg:var(--brand-surface);
   --header-text:#ffffff;
   --link:#0b5fff;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,8 +14,8 @@ const config: Config = {
           DEFAULT: '#111827', // text
           bg: '#ffffff', // background
           surface: '#f9fafb', // cards
-          accent: '#2563eb', // CTA / primary
-          'accent-hover': '#1e40af',
+          accent: '#facc15', // CTA / primary
+          'accent-hover': '#eab308',
           border: '#e5e7eb',
           subtle: '#6b7280', // metadata/muted
           success: '#10b981',


### PR DESCRIPTION
## Summary
- match app navigation and buttons to landing page colors and spacing
- add horizontal QuickGig logo and sign up CTA in header
- simplify error pages and share layout tokens

## Testing
- `npm run lint` (fails: next: not found)
- `npm run typecheck` (fails: Cannot find type definition file for 'node')

------
https://chatgpt.com/codex/tasks/task_e_68a950a0d6a483278b64ddb6b5e8ae34