### PR TITLE
feat: add guarded admin dashboard

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,51 +1,37 @@
-'use client';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import { isAdmin, getAdminStats } from '@/utils/admin';
-import { copy } from '@/copy';
+import { GetServerSideProps } from 'next'
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { requireAdmin } from '@/lib/auth/requireAdmin'
 
-export default function AdminHome() {
-  const router = useRouter();
-  const [allowed, setAllowed] = useState<boolean|null>(null);
-  const [stats, setStats] = useState<any>({});
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const guard = await requireAdmin(ctx)
+  // @ts-ignore
+  if (guard.redirect) return guard
+  const supabase = createServerSupabaseClient(ctx)
+  const [{ count: users }, { count: gigs }, { count: apps }, { data: pending }] = await Promise.all([
+    supabase.from('profiles').select('id', { count:'exact', head:true }),
+    supabase.from('gigs').select('id', { count:'exact', head:true }),
+    supabase.from('applications').select('id', { count:'exact', head:true }),
+    supabase.from('payment_proofs').select('id').eq('status','pending')
+  ])
+  return { props: { users: users||0, gigs: gigs||0, apps: apps||0, pending: pending?.length||0 } }
+}
 
-  useEffect(() => {
-    (async () => {
-      const ok = await isAdmin();
-      setAllowed(ok);
-      if (ok) setStats(await getAdminStats());
-      else router.replace('/');
-    })();
-  }, [router]);
-
-  if (allowed === null) return null; // loading
-
-  const Card = ({ title, total, last7, href, testId }:{
-    title:string; total:any; last7:any; href:string; testId:string;
-  }) => (
-    <a href={href} data-testid={testId}
-       className="rounded-2xl border p-5 shadow-sm hover:shadow-md transition bg-white">
+export default function AdminHome({ users=0, gigs=0, apps=0, pending=0 }){
+  const Card = ({title, value, href}:{title:string,value:number,href:string})=>(
+    <a href={href} className="border rounded-2xl p-4 hover:shadow">
       <div className="text-sm text-gray-500">{title}</div>
-      <div className="text-3xl font-semibold my-2">{total ?? '–'}</div>
-      <div className="text-xs text-gray-500">{copy.admin.last7d}: {last7 ?? '–'}</div>
-      <div className="mt-3 text-blue-600 underline">{copy.admin.view}</div>
+      <div className="text-3xl font-semibold">{value}</div>
     </a>
-  );
-
+  )
   return (
-    <main className="w-full px-4 py-8">
-      <div className="mx-auto w-full max-w-6xl">
-        <h1 className="text-2xl md:text-3xl font-semibold mb-6" data-testid="admin-home">
-          {copy.admin.title}
-        </h1>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
-          <Card title={copy.admin.orders}       total={stats?.orders?.total}       last7={stats?.orders?.last7}       href="/admin/orders"       testId="admin-card-orders" />
-          <Card title={copy.admin.users}        total={stats?.profiles?.total}     last7={stats?.profiles?.last7}     href="/admin/users"        testId="admin-card-users" />
-          <Card title={copy.admin.gigs}         total={stats?.gigs?.total}         last7={stats?.gigs?.last7}         href="/admin/gigs"         testId="admin-card-gigs" />
-          <Card title={copy.admin.applications} total={stats?.applications?.total} last7={stats?.applications?.last7} href="/admin/applications" testId="admin-card-apps" />
-        </div>
-        {/* Optional: recent activity table placeholder */}
+    <main className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Admin</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card title="Users" value={users} href="/admin/users"/>
+        <Card title="Gigs" value={gigs} href="/admin/gigs"/>
+        <Card title="Applications" value={apps} href="/admin/applications"/>
+        <Card title="Pending proofs" value={pending} href="/admin/payments"/>
       </div>
     </main>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- guard /admin with server-side check
- show admin KPI cards linking to management pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a99c133c1483279b79a6d819ceb808