### PR TITLE
Guard test magic-link endpoint with QA secret

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ jobs:
       PLAYWRIGHT_APP_URL: https://app.quickgig.ph
       QA_TEST_MODE: "true"
       QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
+      QA_TEST_SECRET: ${{ secrets.QA_TEST_SECRET }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,6 +44,7 @@ jobs:
       QA_TEST_MODE: "true"
       QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
       QA_TEST_EMAIL_ADMIN: ${{ secrets.QA_TEST_EMAIL_ADMIN || secrets.QA_TEST_EMAIL }}
+      QA_TEST_SECRET: ${{ secrets.QA_TEST_SECRET }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/pages/api/test/magic-link.ts
+++ b/pages/api/test/magic-link.ts
@@ -1,7 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (process.env.QA_TEST_MODE !== 'true') return res.status(404).end()
+  const enabled = process.env.QA_TEST_MODE === 'true'
+  const okHeader = req.headers['x-qa-secret'] === process.env.QA_TEST_SECRET
+  if (!enabled) return res.status(404).end()
+  if (!okHeader) return res.status(401).json({ error: 'unauthorized' })
   if (req.method !== 'POST') return res.status(405).end()
   const { email } = req.body || {}
   if (!email) return res.status(400).json({ error: 'email required' })

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,9 +1,14 @@
 import { request } from '@playwright/test'
 import { APP_URL, TEST_EMAIL } from './env'
 
+const QA_HEADER = process.env.QA_TEST_SECRET || ''
+
 export async function loginViaMagicLink(page, email = TEST_EMAIL) {
   const ctx = await request.newContext()
-  const r = await ctx.post(`${APP_URL}/api/test/magic-link`, { data: { email } })
+  const r = await ctx.post(`${APP_URL}/api/test/magic-link`, {
+    data: { email },
+    headers: QA_HEADER ? { 'x-qa-secret': QA_HEADER } : {},
+  })
   const body = await r.text()
   if (r.status() !== 200) {
     throw new Error(`[magic-link] ${r.status()} ${r.statusText()} — ${body.slice(0, 160)}`)


### PR DESCRIPTION
## Summary
- require `x-qa-secret` header for `/api/test/magic-link` when `QA_TEST_MODE` is enabled
- send header from Playwright helper and expose `QA_TEST_SECRET` to workflows
- allow safe `QA_TEST_MODE` usage in production

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a69a94f88327bc9a201b2a966d4f