### PR TITLE
ci: give e2e job artifacts unique names

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-smoke
           path: |
             test-results/**
             playwright-report/**
@@ -59,7 +59,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-full-e2e
           path: |
             test-results/**
             playwright-report/**


### PR DESCRIPTION
## Summary
- give smoke and full e2e jobs unique artifact names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac11ae38832789432ef061ac9654