### PR TITLE
test: stabilize full e2e flow

### DIFF
--- a/tests/full.e2e.spec.ts
+++ b/tests/full.e2e.spec.ts
@@ -3,31 +3,73 @@ import { APP_URL, TEST_EMAIL_ADMIN } from './helpers/env'
 import { loginViaMagicLink } from './helpers/auth'
 
 test('create gig → save → upload proof → admin approves', async ({ page, browser }) => {
+  // user A
   await page.goto(APP_URL)
   await loginViaMagicLink(page)
-  await page.goto(`${APP_URL}/gigs/new`)
-  await page.getByLabel(/title/i).fill('Playwright Test Gig')
-  await page.getByLabel(/description/i).fill('Automated E2E gig')
-  await page.getByLabel(/price/i).fill('123')
-  await page.getByRole('button', { name: /save|create/i }).click()
+  await page.waitForLoadState('networkidle')
+
+  // If first-run profile gate appears, complete it quickly
+  try {
+    const fullName = page.getByLabel(/full\s*name/i)
+    if (await fullName.isVisible({ timeout: 1000 })) {
+      await fullName.fill('QA Bot')
+      await page.getByRole('button', { name: /save|continue|update/i }).click()
+      await page.waitForLoadState('networkidle')
+    }
+  } catch {}
+
+  // Navigate to Create Gig via header (more reliable than deep-link)
+  const postJob = page.getByRole('link', { name: /post job/i })
+  if (await postJob.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await postJob.click()
+  } else {
+    await page.goto(`${APP_URL}/gigs/new`)
+  }
+  await page.waitForLoadState('domcontentloaded')
+
+  // Flexible selectors (label OR placeholder OR name OR data-testid)
+  const title = page
+    .locator(
+      'input[name="title"], input#title, [placeholder*="title" i], [data-testid="gig-title"]'
+    )
+    .first()
+  await title.waitFor({ state: 'visible', timeout: 10000 })
+  await title.fill('Playwright Test Gig')
+
+  const desc = page
+    .locator(
+      'textarea[name="description"], textarea#description, [placeholder*="description" i], [data-testid="gig-description"]'
+    )
+    .first()
+  await desc.fill('Automated E2E gig')
+
+  const price = page
+    .locator(
+      'input[name="price"], input#price, [placeholder*="price" i], [data-testid="gig-price"], input[type="number"]'
+    )
+    .first()
+  await price.fill('123')
+
+  await page.getByRole('button', { name: /save|create|publish/i }).click()
   await expect(page).toHaveURL(/\/gigs\/\d+$/)
   if (await page.getByRole('button', { name: /save/i }).isVisible()) {
     await page.getByRole('button', { name: /save/i }).click()
     await page.getByRole('button', { name: /unsave/i }).click()
   }
+  // upload payment proof
   await page.goto(`${APP_URL}/pay`)
-  await page.setInputFiles('input[type="file"]', {
-    name: 'proof.png',
-    mimeType: 'image/png',
-    buffer: Buffer.from('img'),
-  })
+  const file = Buffer.from('fakeimage', 'utf8')
+  const path = 'test.png'
+  await page.setInputFiles('input[type="file"]', { name: path, mimeType: 'image/png', buffer: file })
   await page.getByRole('button', { name: /submit/i }).click()
 
-  const ctx = await browser.newContext()
-  const admin = await ctx.newPage()
+  // admin review in a second context (still QA: use magic link + seeded admin)
+  const context2 = await browser.newContext()
+  const admin = await context2.newPage()
   await admin.goto(APP_URL)
   await loginViaMagicLink(admin, TEST_EMAIL_ADMIN)
   await admin.goto(`${APP_URL}/admin/payments`)
+  // approve the first
   const approve = admin.getByRole('button', { name: /approve/i }).first()
   if (await approve.isVisible()) await approve.click()
 })


### PR DESCRIPTION
## Summary
- handle optional profile gating in full E2E
- navigate to create gig via header, add resilient selectors
- tweak payment proof upload and admin context handling

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run qa:smoke` *(fails: playwright not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a9af611a348327b80b36bf3d341542