### PR TITLE
feat: a11y and perf basics

### DIFF
--- a/components/GigForm.tsx
+++ b/components/GigForm.tsx
@@ -99,7 +99,14 @@ export default function GigForm({ initialGig, onSubmit, onFileUpload, submitLabe
         {onFileUpload && (
           <div>
             <input type="file" accept="image/*" onChange={handleFileChange} />
-            {gig.image_url && <img src={gig.image_url ?? ''} alt="Gig" className="mt-2 max-w-xs" />}
+            {gig.image_url && (
+              <img
+                src={gig.image_url ?? ''}
+                alt="Gig"
+                loading="lazy"
+                className="mt-2 max-w-xs"
+              />
+            )}
           </div>
         )}
         <Button type="submit">{submitLabel}</Button>

--- a/components/nav/AppFooter.tsx
+++ b/components/nav/AppFooter.tsx
@@ -1,9 +1,9 @@
-import { LANDING_URL } from '@lib/config'
 export default function AppFooter(){
   return (
-    <footer className="border-t mt-10">
+    <footer className="border-t mt-10" aria-label="Footer">
       <div className="max-w-6xl mx-auto px-4 py-6 text-sm text-gray-500">
-        © {new Date().getFullYear()} QuickGig • <a href={LANDING_URL} className="underline">Website</a>
+        © {new Date().getFullYear()} QuickGig •{' '}
+        <a href="https://quickgig.ph" className="underline">Visit website</a>
       </div>
     </footer>
   )

--- a/components/nav/AppHeader.tsx
+++ b/components/nav/AppHeader.tsx
@@ -1,19 +1,20 @@
 import Link from 'next/link'
+import Image from 'next/image'
 export default function AppHeader(){
   return (
     <header className="bg-black text-white">
       <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-2">
-          <img src="/logo.svg" alt="QuickGig" className="h-6 w-6" />
+          <Image src="/logo.svg" alt="QuickGig logo" width={24} height={24} priority />
           <span className="font-semibold">QuickGig</span>
         </Link>
-        <nav className="hidden md:flex items-center gap-6">
-          <Link href="/gigs" className="focus:outline-none focus-visible:ring-2 ring-white">Find work</Link>
-          <Link href="/gigs/new" className="focus:outline-none focus-visible:ring-2 ring-white">Post job</Link>
+        <nav aria-label="Primary" className="hidden md:flex items-center gap-6">
+          <Link href="/gigs">Find work</Link>
+          <Link href="/gigs/new">Post job</Link>
           <Link href="/pay" className="px-3 py-1 rounded bg-white text-black">Pay</Link>
         </nav>
         <details className="md:hidden">
-          <summary className="cursor-pointer">Menu</summary>
+          <summary aria-label="Open menu" className="cursor-pointer">Menu</summary>
           <div className="mt-2 flex flex-col">
             <Link href="/gigs" className="py-2">Find work</Link>
             <Link href="/gigs/new" className="py-2">Post job</Link>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from "next/app";
+import Head from "next/head";
 import "../styles/theme.css";
 import "../styles/globals.css";
 import "../styles/accessibility.css";
@@ -11,14 +12,28 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isError = router.pathname === '/404' || router.pathname === '/500';
   return (
-    <div className="min-h-screen bg-surface text-text flex flex-col">
-      {!isError && <AppHeader />}
-      <main className="flex-1 py-6 bg-surface">
-        <Container>
-          <Component {...pageProps} />
-        </Container>
-      </main>
-      {!isError && <AppFooter />}
-    </div>
+    <>
+      <Head>
+        <meta
+          name="description"
+          content="QuickGig — find or post quick gigs fast."
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta property="og:title" content="QuickGig" />
+        <meta
+          property="og:description"
+          content="Find work or hire quickly with simple, ticket-based matches."
+        />
+      </Head>
+      <div className="min-h-screen bg-surface text-text flex flex-col">
+        {!isError && <AppHeader />}
+        <main className="flex-1 py-6 bg-surface">
+          <Container>
+            <Component {...pageProps} />
+          </Container>
+        </main>
+        {!isError && <AppFooter />}
+      </div>
+    </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,22 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+  let preconnectHref: string | null = null
+  try { if (supabaseUrl) preconnectHref = new URL(supabaseUrl).origin } catch {}
+  return (
+    <Html lang="en">
+      <Head>
+        {preconnectHref && (
+          <link rel="preconnect" href={preconnectHref} crossOrigin="" />
+        )}
+        <meta name="theme-color" content="#000000" />
+        <meta name="color-scheme" content="light only" />
+      </Head>
+      <body className="antialiased">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -31,7 +31,12 @@ export default function CheckoutPage() {
     <Shell>
       <h1 className="text-2xl font-bold mb-4">Buy Ticket</h1>
       <p className="mb-4">Send ₱{TICKET_PRICE_PHP} via GCash then upload the proof.</p>
-      <img src={process.env.GCASH_QR_URL || '/assets/gcash-qr.png'} alt="GCash QR" className="max-w-xs mb-4" />
+      <img
+        src={process.env.GCASH_QR_URL || '/assets/gcash-qr.png'}
+        alt="GCash QR"
+        loading="lazy"
+        className="max-w-xs mb-4"
+      />
       {!order ? (
         <button onClick={createOrder} className="btn-primary">Create Order</button>
       ) : (

--- a/pages/post-job.tsx
+++ b/pages/post-job.tsx
@@ -90,7 +90,14 @@ export default function PostJobPage() {
         <input className="input"
                placeholder="City (optional)" value={city} onChange={(e)=>setCity(e.target.value)} />
         <div className="space-y-2">
-          {imageUrl && <img src={imageUrl} className="rounded max-h-48 object-cover" />}
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt="Gig image preview"
+              loading="lazy"
+              className="rounded max-h-48 object-cover"
+            />
+          )}
           <input type="file" accept="image/*" onChange={onFile} />
         </div>
         <button className="btn-primary">Publish</button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,3 +68,8 @@ html, body { background: var(--surface, #fff); }
 @layer base {
   input[type="email"] { font-size: 16px; }
 }
+
+:where(a, button, [role="button"], input, select, textarea):focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- improve head defaults and preconnect to Supabase
- label navigation, add alt text and focus-visible styling
- use next/image for logo and lazy-load remaining images

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)
- `npm run typecheck` (fails: Cannot find type definition file for 'node')

------
https://chatgpt.com/codex/tasks/task_e_68a9b9a278e883279321237dc825edcf