### PR TITLE
fix landing page routes, add terms/privacy, unify logo

### DIFF
--- a/components/nav/AppFooter.tsx
+++ b/components/nav/AppFooter.tsx
@@ -1,10 +1,26 @@
-export default function AppFooter(){
+import Link from "next/link";
+
+export default function AppFooter() {
   return (
     <footer className="border-t mt-10" aria-label="Footer">
-      <div className="max-w-6xl mx-auto px-4 py-6 text-sm text-gray-500">
-        © {new Date().getFullYear()} QuickGig •{' '}
-        <a href="https://quickgig.ph" className="underline">Visit website</a>
+      <div className="max-w-6xl mx-auto px-4 py-6 text-sm text-gray-500 flex flex-col sm:flex-row items-center justify-between gap-4">
+        <span>© {new Date().getFullYear()} QuickGig</span>
+        <nav className="flex gap-4">
+          <Link href="/terms" className="underline" data-testid="footer-terms">
+            Terms
+          </Link>
+          <Link href="/privacy" className="underline" data-testid="footer-privacy">
+            Privacy
+          </Link>
+          <a
+            href="https://quickgig.ph"
+            className="underline"
+            data-testid="footer-website"
+          >
+            Visit website
+          </a>
+        </nav>
       </div>
     </footer>
-  )
+  );
 }

--- a/components/nav/AppHeader.tsx
+++ b/components/nav/AppHeader.tsx
@@ -23,9 +23,14 @@ export default function AppHeader(){
   return (
     <header className="bg-black text-white">
       <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="QuickGig logo" width={24} height={24} priority />
-          <span className="font-semibold">QuickGig</span>
+        <Link href="/" className="flex items-center">
+          <Image
+            src="/logo-horizontal.png"
+            alt="QuickGig.ph"
+            width={140}
+            height={32}
+            priority
+          />
         </Link>
         <nav aria-label="Primary" className="hidden md:flex items-center gap-6">
           <Link href="/gigs">Find work</Link>

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,62 @@
+import Shell from "@/components/Shell";
+
+export default function PrivacyPage() {
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+      <p className="mb-4">Effective Date: August 23, 2025</p>
+      <div className="space-y-6 text-sm">
+        <section>
+          <h2 className="font-semibold text-lg mb-2">1. Information We Collect</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li><strong>Account Information</strong>: name, email, password.</li>
+            <li><strong>Profile Information</strong>: skills, resume, job preferences.</li>
+            <li><strong>Usage Data</strong>: pages visited, actions taken on the platform.</li>
+            <li><strong>Communications</strong>: messages between Clients and Workers.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">2. How We Use Information</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>To operate and improve QuickGig.</li>
+            <li>To facilitate job postings and matches.</li>
+            <li>To communicate important updates.</li>
+            <li>To comply with legal obligations.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">3. Sharing of Information</h2>
+          <p>We do not sell personal data. We may share limited information with:</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Service providers (e.g. hosting, payment processors).</li>
+            <li>Legal authorities, if required by law.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">4. Data Security</h2>
+          <p>We use industry-standard security to protect your data. However, no method is 100% secure.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">5. Your Rights</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Access and update your information via your account.</li>
+            <li>Request deletion of your account by contacting support.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">6. Cookies</h2>
+          <p>QuickGig uses cookies for login sessions and analytics.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">7. Children’s Privacy</h2>
+          <p>QuickGig is not intended for individuals under 18.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">8. Contact</h2>
+          <p>If you have privacy concerns, email us at <a href="mailto:privacy@quickgig.ph" className="underline">privacy@quickgig.ph</a>.</p>
+        </section>
+      </div>
+    </Shell>
+  );
+}
+

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,0 +1,64 @@
+import Shell from "@/components/Shell";
+
+export default function TermsPage() {
+  return (
+    <Shell>
+      <h1 className="text-2xl font-bold mb-4">Terms of Service</h1>
+      <p className="mb-4">Effective Date: August 23, 2025</p>
+      <div className="space-y-6 text-sm">
+        <section>
+          <h2 className="font-semibold text-lg mb-2">1. Eligibility</h2>
+          <p>You must be at least 18 years old to use QuickGig. By signing up, you confirm you are legally able to enter into binding agreements.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">2. Account Responsibilities</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>You are responsible for maintaining the confidentiality of your account.</li>
+            <li>You agree to provide accurate information and not impersonate others.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">3. Services</h2>
+          <p>QuickGig is a platform that connects employers posting jobs ("Clients") with freelancers ("Workers"). QuickGig does not become a party to any contract between Clients and Workers.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">4. Tickets &amp; Payments</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Clients purchase tickets to post jobs.</li>
+            <li>The first ticket may be free as part of promotional onboarding.</li>
+            <li>Tickets are consumed only after a job is successfully agreed between Client and Worker.</li>
+            <li>Workers do not pay to use the platform.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">5. Prohibited Activities</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Post unlawful or fraudulent jobs.</li>
+            <li>Misuse the platform for spam, harassment, or illegal activity.</li>
+            <li>Circumvent payments or ticket usage outside QuickGig.</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">6. Disclaimers</h2>
+          <p>QuickGig is provided "as is" without warranties of any kind. QuickGig does not guarantee job quality, Worker performance, or Client payment reliability.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">7. Limitation of Liability</h2>
+          <p>QuickGig shall not be liable for indirect, incidental, or consequential damages arising from use of the platform.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">8. Termination</h2>
+          <p>We may suspend or terminate accounts that violate these Terms.</p>
+        </section>
+        <section>
+          <h2 className="font-semibold text-lg mb-2">9. Governing Law</h2>
+          <p>These Terms are governed by the laws of the Philippines.</p>
+        </section>
+        <section>
+          <p>If you have questions, contact us at <a href="mailto:support@quickgig.ph" className="underline">support@quickgig.ph</a>.</p>
+        </section>
+      </div>
+    </Shell>
+  );
+}
+


### PR DESCRIPTION
## Summary
- unify header branding with landing page logo
- add Terms of Service and Privacy Policy pages
- expose terms and privacy links in footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf37e664832794682cba03fe2497