### PR TITLE
Stabilize smoke: set APP_URL in CI & allow CTA as link/button

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     env:
+      APP_URL: https://app.quickgig.ph
       PLAYWRIGHT_LANDING_URL: https://quickgig.ph
       PLAYWRIGHT_APP_URL: https://app.quickgig.ph
       QA_TEST_MODE: "true"
@@ -41,6 +42,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     env:
+      APP_URL: https://app.quickgig.ph
       PLAYWRIGHT_LANDING_URL: https://quickgig.ph
       PLAYWRIGHT_APP_URL: https://app.quickgig.ph
       QA_TEST_MODE: "true"

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -12,16 +12,61 @@ test('landing → app header visible', async ({ page }) => {
 
   // Accept English or Taglish copy for the main CTA.
   // Note: “Maghanap ng Trabaho” is the correct Taglish form.
-  const findWorkCta = page.getByRole('link', {
+  const findWorkLink = page.getByRole('link', {
     name: /find work|browse jobs|maghanap ng trabaho/i,
   });
-  await expect(findWorkCta).toHaveAttribute('href', appRootRe);
+  if (await findWorkLink.isVisible().catch(() => false)) {
+    try {
+      await expect(findWorkLink).toHaveAttribute('href', appRootRe);
+    } catch (err) {
+      console.log('CTA href:', await findWorkLink.getAttribute('href'));
+      throw err;
+    }
+  } else {
+    // fallback to button
+    const findWorkBtn = page.getByRole('button', {
+      name: /find work|browse jobs|maghanap ng trabaho/i,
+    });
+    await expect(findWorkBtn).toBeVisible();
+    await Promise.all([
+      page.waitForURL(appRootRe),
+      findWorkBtn.click(),
+    ]);
+  }
 
   // “Post job” should deep-link to the app root for now.
-  const postJobCta = page.getByRole('link', { name: /post job/i });
-  await expect(postJobCta).toHaveAttribute('href', appRootRe);
+  const postJobLink = page.getByRole('link', { name: /post job/i });
+  if (await postJobLink.isVisible().catch(() => false)) {
+    try {
+      await expect(postJobLink).toHaveAttribute('href', appRootRe);
+    } catch (err) {
+      console.log('CTA href:', await postJobLink.getAttribute('href'));
+      throw err;
+    }
+  } else {
+    const postJobBtn = page.getByRole('button', { name: /post job/i });
+    await expect(postJobBtn).toBeVisible();
+    await Promise.all([
+      page.waitForURL(appRootRe),
+      postJobBtn.click(),
+    ]);
+  }
 
   // Header logo link (landing’s logo linking to app root)
   const logoLink = page.getByRole('link', { name: /quickgig\.ph|quickgig/i });
-  await expect(logoLink).toHaveAttribute('href', appRootRe);
+  if (await logoLink.isVisible().catch(() => false)) {
+    try {
+      await expect(logoLink).toHaveAttribute('href', appRootRe);
+    } catch (err) {
+      console.log('CTA href:', await logoLink.getAttribute('href'));
+      throw err;
+    }
+  } else {
+    const logoBtn = page.getByRole('button', { name: /quickgig\.ph|quickgig/i });
+    await expect(logoBtn).toBeVisible();
+    await Promise.all([
+      page.waitForURL(appRootRe),
+      logoBtn.click(),
+    ]);
+  }
 });


### PR DESCRIPTION
## Summary
- define APP_URL for smoke and full E2E workflows
- allow smoke spec CTAs and header logo to be either link or button and assert accordingly

## Testing
- `npm install --legacy-peer-deps --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npx playwright test tests/smoke.spec.ts --project=smoke` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5e5c7c388327bbde5be8e9a34b72