### PR TITLE
Force landing links to app root and tighten smoke checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ jobs:
       APP_URL: https://app.quickgig.ph
       PLAYWRIGHT_LANDING_URL: https://quickgig.ph
       PLAYWRIGHT_APP_URL: https://app.quickgig.ph
+      NEXT_PUBLIC_APP_URL: https://app.quickgig.ph
       QA_TEST_MODE: "true"
       QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
       QA_TEST_SECRET: ${{ secrets.QA_TEST_SECRET }}

--- a/components/nav/AppHeader.tsx
+++ b/components/nav/AppHeader.tsx
@@ -23,14 +23,15 @@ export default function AppHeader(){
   return (
     <header className="bg-black text-white">
       <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="flex items-center">
+        <Link href="/" className="flex items-center gap-2">
           <Image
-            src="/logo-horizontal.png"
+            src="/logo/quickgig.svg"
             alt="QuickGig.ph"
-            width={140}
-            height={32}
+            width={28}
+            height={28}
             priority
           />
+          <span className="font-semibold">QuickGig.ph</span>
         </Link>
         <nav aria-label="Primary" className="hidden md:flex items-center gap-6">
           <Link href="/gigs">Find work</Link>

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -18,7 +18,7 @@
   <body>
     <header class="header" data-theme-brand="quickgig">
         <div class="container row">
-        <a href="/" class="brand" data-testid="brand-link">
+        <a href="https://app.quickgig.ph/" class="brand" data-testid="brand-link">
           <img src="/logo/quickgig.svg" alt="QuickGig.ph" width="28" height="28" />
           <strong>QuickGig.ph</strong>
         </a>
@@ -31,7 +31,7 @@
             >Maghanap ng Trabaho</a
           >
           <a
-            href="https://app.quickgig.ph/gigs/new"
+            href="https://app.quickgig.ph/"
             data-testid="nav-post-job"
             aria-label="Post job on QuickGig app"
             >Post Job</a

--- a/lib/appUrl.ts
+++ b/lib/appUrl.ts
@@ -1,0 +1,14 @@
+export function getAppRoot(): string {
+  const raw = process.env.NEXT_PUBLIC_APP_URL?.trim() || '';
+  // Strip query/hash
+  const noFrag = raw.split('#')[0].split('?')[0];
+  // Remove any trailing slash
+  const trimmed = noFrag.replace(/\/+$/, '');
+  // Remove any accidental path (we want pure origin)
+  try {
+    const u = new URL(trimmed);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return 'https://app.quickgig.ph';
+  }
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,2 +1,3 @@
-export const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.quickgig.ph'
-export const LANDING_URL = process.env.NEXT_PUBLIC_LANDING_URL || 'https://quickgig.ph'
+import { getAppRoot } from './appUrl';
+export const APP_URL = getAppRoot();
+export const LANDING_URL = process.env.NEXT_PUBLIC_LANDING_URL || 'https://quickgig.ph';

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,13 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { getAppRoot } from '../lib/appUrl';
 
-const APP_URL = process.env.APP_URL ?? 'https://app.quickgig.ph';
-const appRootRe = new RegExp(`^${APP_URL.replace('.', '\.').replace('/', '\/')}\/?(?:[?#].*)?$`, 'i');
-const appRootOrFindRe = new RegExp(
-  `^${APP_URL.replace('.', '\.').replace('/', '\/')}(?:/(?:find)?/?)?(?:[?#].*)?$`,
-  'i',
-);
-const appPostRe = new RegExp(
-  `^${APP_URL.replace('.', '\.').replace('/', '\/')}/post\/?(?:[?#].*)?$`,
+process.env.NEXT_PUBLIC_APP_URL = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+const APP_ROOT = getAppRoot();
+const appRootRe = new RegExp(
+  `^${APP_ROOT.replace(/\./g, '\.').replace(/\//g, '\/')}\/?$`,
   'i',
 );
 
@@ -17,60 +14,33 @@ test.beforeEach(async ({ page }) => {
 
 test('landing → app header visible', async ({ page }) => {
   await page.goto('https://quickgig.ph');
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('networkidle');
 
   // ---- Find work CTA (accept: "Find work" | "Browse jobs" | "Maghanap ng Trabaho") ----
-  const ctaText = /find work|browse jobs|maghanap ng trabaho/i;
-  const findWorkLink = page.getByRole('link', { name: ctaText });
-  if (await findWorkLink.isVisible().catch(() => false)) {
-    await expect(findWorkLink).toBeVisible();
-    const href = await findWorkLink.getAttribute('href');
-    console.log('[smoke] Found CTA link:', href);
-    expect(href, 'href should exist').not.toBeNull();
-    expect(href!).toMatch(appRootOrFindRe);
-  } else {
-    const findWorkBtn = page.getByRole('button', { name: ctaText });
-    await expect(findWorkBtn).toBeVisible();
-    await Promise.all([
-      page.waitForURL(appRootOrFindRe),
-      findWorkBtn.click(),
-    ]);
-    await page.goBack({ waitUntil: 'load' }).catch(() => {});
-  }
+  const cta = page.getByRole('link', { name: /find work|browse jobs|maghanap ng trabaho/i }).first();
+  await expect(cta).toBeVisible();
+  const ctaText = await cta.innerText();
+  const ctaHref = await cta.getAttribute('href');
+  console.log('[smoke] CTA text:', ctaText, 'href:', ctaHref);
+  await expect(cta).toHaveAttribute('href', appRootRe);
 
   // ---- Post job CTA ----
-  const postJobLink = page.getByRole('link', { name: /post job/i });
-  if (await postJobLink.isVisible().catch(() => false)) {
-    await expect(postJobLink).toBeVisible();
-    const href = await postJobLink.getAttribute('href');
-    console.log('[smoke] Found CTA link:', href);
-    expect(href, 'href should exist').not.toBeNull();
-    expect(href!).toMatch(appPostRe);
-  } else {
-    const postJobBtn = page.getByRole('button', { name: /post job/i });
-    await expect(postJobBtn).toBeVisible();
-    await Promise.all([
-      page.waitForURL(appPostRe),
-      postJobBtn.click(),
-    ]);
-    await page.goBack({ waitUntil: 'load' }).catch(() => {});
+  const post = page.getByRole('link', { name: /post job/i }).first();
+  if (await post.isVisible().catch(() => false)) {
+    await expect(post).toBeVisible();
+    const text = await post.innerText();
+    const href = await post.getAttribute('href');
+    console.log('[smoke] Post job text:', text, 'href:', href);
+    await expect(post).toHaveAttribute('href', appRootRe);
   }
 
-  // ---- Header logo (prefer href, else click) ----
-  const logoLink = page
+  // ---- Header logo ----
+  const logo = page
     .locator('a[aria-label="QuickGig"], a[aria-label="QuickGig.ph"], header a:has(img)')
     .first();
-  if (await logoLink.isVisible().catch(() => false)) {
-    await expect(logoLink).toBeVisible();
-    const href = await logoLink.getAttribute('href');
-    console.log('[smoke] Found logo link:', href);
-    expect(href, 'href should exist').not.toBeNull();
-    expect(href!).toMatch(appRootRe);
-  } else {
-    const logoBtn = page.locator('header button:has(img)').first();
-    await expect(logoBtn).toBeVisible();
-    await Promise.all([
-      page.waitForURL(appRootRe),
-      logoBtn.click(),
-    ]);
-  }
+  await expect(logo).toBeVisible();
+  const logoHref = await logo.getAttribute('href');
+  console.log('[smoke] Logo href:', logoHref);
+  await expect(logo).toHaveAttribute('href', appRootRe);
 });


### PR DESCRIPTION
## Summary
- normalize APP_URL with new getAppRoot util and reuse in config
- point landing CTAs and logo to the app root and align app header logo
- harden smoke test and CI env to require root-only links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run qa:smoke` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6aa54d0c8327b442044d384e79d1