### PR TITLE
feat: add basic notification helper and profile polish

### DIFF
--- a/pages/api/admin/payment-proofs/set-status.ts
+++ b/pages/api/admin/payment-proofs/set-status.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
-import { emitNotification } from '@/lib/notifications'
+import { sendNotification } from '@/lib/notifications'
 
 export default async function handler(req:NextApiRequest,res:NextApiResponse){
   if (req.method!=='POST') return res.status(405).end()
@@ -19,23 +19,19 @@ export default async function handler(req:NextApiRequest,res:NextApiResponse){
   const qty = Number(process.env.NEXT_PUBLIC_TICKETS_PER_PROOF || '0')
   if (employerId) {
     if (status === 'approved') {
-      await emitNotification({
-        userId: employerId,
-        type: 'gcash_approved',
-        title: 'GCash top-up approved',
-        body: `We added ${qty} ticket(s) to your balance. Salamat!`,
-        link: `${process.env.NEXT_PUBLIC_APP_URL}/account/wallet`,
-        uniq: `gcash_approved:${id}`,
+      await sendNotification({
+        type: 'payment_approved',
+        actorUserId: user.id,
+        targetUserId: employerId,
+        ticketsAdded: qty,
       })
     }
     if (status === 'flagged') {
-      await emitNotification({
-        userId: employerId,
-        type: 'gcash_rejected',
-        title: 'GCash top-up rejected',
-        body: `We couldn’t verify your GCash payment. Reason: ${reason || 'N/A'}. You can resubmit from your wallet.`,
-        link: `${process.env.NEXT_PUBLIC_APP_URL}/account/wallet`,
-        uniq: `gcash_rejected:${id}`,
+      await sendNotification({
+        type: 'payment_rejected',
+        actorUserId: user.id,
+        targetUserId: employerId,
+        reason,
       })
     }
   }

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -1,9 +1,40 @@
 import ProfileForm from '@/components/forms/ProfileForm'
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import { supabase } from '@/utils/supabaseClient'
 
 export default function ProfilePage() {
+  const [avatar, setAvatar] = useState<string | null>(null)
+  const [bio, setBio] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase
+      .from('profiles')
+      .select('avatar_url,bio')
+      .single()
+      .then(({ data }) => {
+        setAvatar(data?.avatar_url || null)
+        setBio(data?.bio || null)
+      })
+  }, [])
+
   return (
     <main className="max-w-xl mx-auto p-6">
-      <h1 className="text-2xl font-semibold mb-4">Complete your profile</h1>
+      <div className="flex items-center gap-4 mb-4">
+        {avatar && (
+          <Image
+            src={avatar}
+            alt="Profile avatar"
+            width={64}
+            height={64}
+            className="rounded-full"
+          />
+        )}
+        <div>
+          <h1 className="text-2xl font-semibold">Complete your profile</h1>
+          {bio && <p className="text-sm text-gray-600 max-w-md">{bio}</p>}
+        </div>
+      </div>
       <ProfileForm />
     </main>
   )

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { stubSignIn } from './utils/session';
 
 const APP_URL =
   process.env.APP_URL ??
@@ -60,4 +61,10 @@ test('landing → app header visible', async ({ page }) => {
       logoBtn.click(),
     ]);
   }
+});
+
+test('app notifications bell visible after login', async ({ page }) => {
+  await stubSignIn(page);
+  await page.goto(APP_URL + '/');
+  await expect(page.locator('a[aria-label="Notifications"]')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add `sendNotification` helper for job and payment events
- expose avatar and bio in profile page header
- include signed-in bell check in smoke test

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run qa:smoke` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaafb4d9e883278c934c976da7d126