### PR TITLE
Skip smoke notification test without demo creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 - `npm run build` - build for production
 - `npm start` - run production build
 
+## Testing
+
+```bash
+# Optional: provide demo emails for smoke specs
+export DEMO_USER_EMAIL="qa-user@example.com"
+export DEMO_ADMIN_EMAIL="qa-admin@example.com"
+```
+
 ## Smoke tests
 
 ```

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { stubSignIn } from './utils/session';
+import { getDemoEmail, stubSignIn } from './utils/session';
 
 const APP_URL =
   process.env.APP_URL ??
@@ -63,8 +63,20 @@ test('landing → app header visible', async ({ page }) => {
   }
 });
 
-test('app notifications bell visible after login', async ({ page }) => {
-  await stubSignIn(page);
-  await page.goto(APP_URL + '/');
-  await expect(page.locator('a[aria-label="Notifications"]')).toBeVisible();
-});
+test(
+  'app notifications bell visible after login (skips if no demo creds)',
+  async ({ page }) => {
+    const email = getDemoEmail('user');
+    test.skip(
+      !email,
+      'No demo user email available via env or optional fixture',
+    );
+
+    await stubSignIn(page, email!);
+    await page.goto(APP_URL + '/');
+
+    // Use your actual selector for the notifications bell:
+    const bell = page.getByRole('button', { name: /notifications/i }).first();
+    await expect(bell).toBeVisible();
+  },
+);


### PR DESCRIPTION
## Summary
- load demo emails from env or optional fixture
- skip notification smoke test when demo creds are unavailable
- document demo email env vars for local smoke runs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npx playwright test tests/smoke.spec.ts --project=smoke -g "app notifications bell"` *(fails: 403 fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68aab395a4488327a5995f603a4008fc