### PR TITLE
feat(e2e): complete job lifecycle (post → apply → message → hire)

### DIFF
--- a/pages/api/qa/cleanup/jobs.ts
+++ b/pages/api/qa/cleanup/jobs.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+function assertQA(req: NextApiRequest) {
+  if (process.env.QA_TEST_MODE !== 'true') throw new Error('QA disabled');
+  const ok = req.headers['x-qa-secret'] === process.env.QA_TEST_SECRET;
+  if (!ok) throw new Error('Unauthorized');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    assertQA(req);
+    const { titlePrefix } = req.body || {};
+    if (!titlePrefix) return res.status(400).json({ error: 'titlePrefix required' });
+    const supa = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    await supa.from('gigs').delete().ilike('title', `${titlePrefix}%`);
+    res.status(200).json({ ok: true });
+  } catch (e: any) {
+    res.status(401).json({ ok: false, error: e?.message || 'error' });
+  }
+}
+

--- a/pages/api/qa/tickets/get.ts
+++ b/pages/api/qa/tickets/get.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+function assertQA(req: NextApiRequest) {
+  if (process.env.QA_TEST_MODE !== 'true') throw new Error('QA disabled');
+  const ok = req.headers['x-qa-secret'] === process.env.QA_TEST_SECRET;
+  if (!ok) throw new Error('Unauthorized');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    assertQA(req);
+    const email = (req.query.email as string) || '';
+    if (!email) return res.status(400).json({ error: 'email required' });
+    const supa = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const { data: profile } = await supa.from('profiles').select('id').eq('email', email).single();
+    if (!profile?.id) return res.status(404).json({ error: 'not found' });
+    const { data: bal } = await supa
+      .from('ticket_balances')
+      .select('balance')
+      .eq('user_id', profile.id)
+      .single();
+    res.status(200).json({ balance: bal?.balance ?? 0 });
+  } catch (e: any) {
+    res.status(401).json({ ok: false, error: e?.message || 'error' });
+  }
+}
+

--- a/pages/api/qa/tickets/grant.ts
+++ b/pages/api/qa/tickets/grant.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+function assertQA(req: NextApiRequest) {
+  if (process.env.QA_TEST_MODE !== 'true') throw new Error('QA disabled');
+  const ok = req.headers['x-qa-secret'] === process.env.QA_TEST_SECRET;
+  if (!ok) throw new Error('Unauthorized');
+}
+
+async function findUserId(supa: any, email: string): Promise<string> {
+  const { data } = await supa.from('profiles').select('id').eq('email', email).single();
+  if (data?.id) return data.id;
+  let page = 1;
+  const perPage = 200;
+  while (true) {
+    const { data: list, error } = await supa.auth.admin.listUsers({ page, perPage });
+    if (error) throw error;
+    const match = list.users.find((u: any) => (u.email || '').toLowerCase() === email.toLowerCase());
+    if (match) return match.id;
+    if (list.users.length < perPage) break;
+    page += 1;
+  }
+  throw new Error(`User not found: ${email}`);
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    assertQA(req);
+    const { email, amount } = req.body || {};
+    if (!email || typeof amount !== 'number') return res.status(400).json({ error: 'email and amount required' });
+    const supa = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const id = await findUserId(supa, email);
+    await supa.rpc('credit_tickets_admin', {
+      p_user: id,
+      p_tickets: amount,
+      p_reason: 'qa_grant',
+      p_ref: null,
+    });
+    const { data: bal } = await supa
+      .from('ticket_balances')
+      .select('balance')
+      .eq('user_id', id)
+      .single();
+    res.status(200).json({ balance: bal?.balance ?? 0 });
+  } catch (e: any) {
+    res.status(401).json({ ok: false, error: e?.message || 'error' });
+  }
+}
+

--- a/pages/api/qa/users/upsert.ts
+++ b/pages/api/qa/users/upsert.ts
@@ -1,0 +1,76 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+function assertQA(req: NextApiRequest) {
+  if (process.env.QA_TEST_MODE !== 'true') throw new Error('QA disabled');
+  const ok = req.headers['x-qa-secret'] === process.env.QA_TEST_SECRET;
+  if (!ok) throw new Error('Unauthorized');
+}
+
+async function getOrCreateUser(supa: any, email: string): Promise<string> {
+  // Attempt to create user; if exists, fall back to search
+  const created = await supa.auth.admin.createUser({ email, email_confirm: true }).catch(() => null);
+  if (created?.data?.user?.id) {
+    const uid = created.data.user.id;
+    await supa.from('profiles').upsert({
+      id: uid,
+      email,
+      full_name: email.split('@')[0],
+      is_admin: false,
+    });
+    return uid;
+  }
+
+  // Search existing users via listUsers
+  let page = 1;
+  const perPage = 200;
+  while (true) {
+    const { data, error } = await supa.auth.admin.listUsers({ page, perPage });
+    if (error) throw error;
+    const match = data.users.find((u: any) => (u.email || '').toLowerCase() === email.toLowerCase());
+    if (match) {
+      const uid = match.id;
+      await supa.from('profiles').upsert({
+        id: uid,
+        email,
+        full_name: email.split('@')[0],
+        is_admin: false,
+      });
+      return uid;
+    }
+    if (data.users.length < perPage) break;
+    page += 1;
+  }
+  throw new Error(`Could not create or find user for ${email}`);
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    assertQA(req);
+    const { email, role, tickets } = req.body || {};
+    if (!email || !role) return res.status(400).json({ error: 'email and role required' });
+
+    const supa = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const id = await getOrCreateUser(supa, email);
+
+    if (typeof tickets === 'number' && tickets > 0) {
+      await supa.rpc('credit_tickets_admin', {
+        p_user: id,
+        p_tickets: tickets,
+        p_reason: 'qa_seed',
+        p_ref: null,
+      });
+    }
+
+    const { data: bal } = await supa
+      .from('ticket_balances')
+      .select('balance')
+      .eq('user_id', id)
+      .single();
+
+    res.status(200).json({ id, email, tickets: bal?.balance ?? 0 });
+  } catch (e: any) {
+    res.status(401).json({ ok: false, error: e?.message || 'error' });
+  }
+}
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   reporter: [['list'], ['html', { outputFolder: 'playwright-report' }]],
   projects: [
     { name: 'smoke', testMatch: /smoke\.spec\.ts$/ },
-    { name: 'full-e2e', testMatch: /\.e2e\.spec\.ts$/ }
+    { name: 'full-e2e', testMatch: /(?:\.e2e\.spec\.ts|full\.e2e.*\.spec\.ts)$/ }
   ]
 })

--- a/tests/full.e2e.job-lifecycle.spec.ts
+++ b/tests/full.e2e.job-lifecycle.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './utils/session';
+import { qaUpsertUser, qaGetTickets, qaCleanupJobs } from './utils/qa';
+
+const APP = process.env.PLAYWRIGHT_APP_URL || 'https://app.quickgig.ph';
+
+test('[full-e2e] job lifecycle: post → apply → message → hire', async ({ page, context }) => {
+  const title = `E2E Gig ${Date.now()}`;
+
+  const employer = { email: `employer+e2e${Date.now()}@example.com` };
+  const worker = { email: `worker+e2e${Date.now()}@example.com` };
+
+  await qaUpsertUser(employer.email, 'employer', { tickets: 2 });
+  await qaUpsertUser(worker.email, 'worker');
+  const before = await qaGetTickets(employer.email);
+
+  // Employer posts job
+  await loginAs(page, employer.email);
+  await page.goto(APP);
+  await page.getByRole('link', { name: /post job/i }).click();
+  await page.getByLabel(/title/i).fill(title);
+  await page.getByLabel(/description/i).fill('Automated E2E gig');
+  const price = page.getByLabel(/price/i);
+  if (await price.isVisible().catch(() => false)) await price.fill('123');
+  await page.getByRole('button', { name: /save|create|publish/i }).click();
+  await expect(page.getByRole('heading', { name: new RegExp(title, 'i') })).toBeVisible({ timeout: 15000 });
+
+  // Worker applies
+  const workerPage = await context.newPage();
+  await loginAs(workerPage, worker.email);
+  await workerPage.goto(APP);
+  await workerPage
+    .getByRole('link', { name: /find work|browse jobs|maghanap ng trabaho/i })
+    .click();
+  await workerPage.getByRole('link', { name: new RegExp(title, 'i') }).click();
+  const applyBtn = workerPage.getByRole('button', { name: /apply|send application|submit/i }).first();
+  await expect(applyBtn).toBeVisible();
+  await applyBtn.click();
+  const notes = workerPage.getByLabel(/note|message|cover/i);
+  if (await notes.isVisible().catch(() => false)) await notes.fill('Interested! (E2E)');
+  const submitApp = workerPage.getByRole('button', { name: /submit|send/i }).first();
+  if (await submitApp.isVisible().catch(() => false)) await submitApp.click();
+  await expect(
+    workerPage.getByText(/applied|application sent|pending/i)
+  ).toBeVisible({ timeout: 15000 });
+
+  // Messaging (worker → employer)
+  const msgInputW = workerPage.getByRole('textbox', { name: /message/i }).first();
+  if (await msgInputW.isVisible().catch(() => false)) {
+    await msgInputW.fill('Hello from worker (E2E)');
+    await workerPage.getByRole('button', { name: /send/i }).click();
+    await expect(workerPage.getByText(/hello from worker \(e2e\)/i)).toBeVisible();
+  }
+
+  // Employer replies and hires
+  await page.bringToFront();
+  await page.goto(APP);
+  await page.getByRole('link', { name: new RegExp(title, 'i') }).first().click();
+  const msgInputE = page.getByRole('textbox', { name: /message/i }).first();
+  if (await msgInputE.isVisible().catch(() => false)) {
+    await msgInputE.fill('Hello from employer (E2E)');
+    await page.getByRole('button', { name: /send/i }).click();
+    await expect(page.getByText(/hello from employer \(e2e\)/i)).toBeVisible();
+  }
+  const hireBtn = page.getByRole('button', { name: /hire|accept|mark as hired/i });
+  await expect(hireBtn).toBeVisible();
+  await hireBtn.click();
+  await expect(page.getByText(/hired|accepted/i)).toBeVisible({ timeout: 15000 });
+
+  const after = await qaGetTickets(employer.email);
+  expect(after).toBeLessThanOrEqual(before);
+  if (after === before) console.warn('[e2e] ticket did not change – consumption may occur earlier in flow');
+
+  await qaCleanupJobs({ titlePrefix: 'E2E Gig ' });
+});

--- a/tests/job-lifecycle.e2e.spec.ts
+++ b/tests/job-lifecycle.e2e.spec.ts
@@ -1,8 +1,0 @@
-import { test } from '@playwright/test'
-
-// TODO: Implement full job lifecycle E2E scenario
-// Placeholder to satisfy migration until full test is written
-
-test('job lifecycle placeholder', async () => {
-  // This test will be implemented in future iterations.
-})

--- a/tests/utils/qa.ts
+++ b/tests/utils/qa.ts
@@ -1,0 +1,41 @@
+import { request } from '@playwright/test';
+import { APP_URL } from '../helpers/env';
+
+const QA_HEADER = process.env.QA_TEST_SECRET || '';
+
+async function ctx() {
+  return request.newContext({
+    baseURL: APP_URL,
+    extraHTTPHeaders: QA_HEADER ? { 'x-qa-secret': QA_HEADER } : {},
+  });
+}
+
+export async function qaUpsertUser(
+  email: string,
+  role: 'employer' | 'worker',
+  opts: { tickets?: number } = {}
+) {
+  const c = await ctx();
+  const r = await c.post('/api/qa/users/upsert', { data: { email, role, ...opts } });
+  const json = await r.json();
+  return json;
+}
+
+export async function qaGrantTickets(email: string, amount: number) {
+  const c = await ctx();
+  const r = await c.post('/api/qa/tickets/grant', { data: { email, amount } });
+  const json = await r.json();
+  return json.balance as number;
+}
+
+export async function qaGetTickets(email: string) {
+  const c = await ctx();
+  const r = await c.get(`/api/qa/tickets/get?email=${encodeURIComponent(email)}`);
+  const json = await r.json();
+  return json.balance as number;
+}
+
+export async function qaCleanupJobs(opts: { titlePrefix: string }) {
+  const c = await ctx();
+  await c.post('/api/qa/cleanup/jobs', { data: opts });
+}

--- a/tests/utils/session.ts
+++ b/tests/utils/session.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { loginViaMagicLink } from '../helpers/auth';
 
 type Kind = 'user' | 'admin';
 
@@ -40,4 +41,13 @@ export function getDemoEmail(kind: Kind = 'user'): string | null {
  */
 export async function stubSignIn(page: Page, email = getDemoEmail()) {
   await page.addInitScript(([e]) => localStorage.setItem('TEST_SESSION_EMAIL', e), [email]);
+}
+
+/** Log in using either QA stub or magic link helper */
+export async function loginAs(page: Page, email: string) {
+  if (process.env.QA_TEST_MODE === 'true') {
+    await stubSignIn(page, email);
+  } else {
+    await loginViaMagicLink(page, email);
+  }
 }


### PR DESCRIPTION
## Summary
- Add resilient full-e2e job lifecycle spec covering post → apply → message → hire
- Seed and inspect QA users/tickets through new helpers and endpoints
- Provide dev-only QA API routes for upsert, ticket grant/get, and gig cleanup

## Testing
- `npm run lint` (fails: next not found)
- `npm run typecheck` (fails: Cannot find type definition file for 'node')
- `npx playwright test tests/full.e2e.job-lifecycle.spec.ts --project=full-e2e` (fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)


------
https://chatgpt.com/codex/tasks/task_e_68aac31627fc8327891a1ed561ebc8e5