### PR TITLE
feat: Admin GCash review (approve/reject) + ticket edge-case E2E + QA route hardening + UX guardrails

### DIFF
--- a/lib/auth/requireAdmin.ts
+++ b/lib/auth/requireAdmin.ts
@@ -1,9 +1,18 @@
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
-export async function requireAdmin(ctx:any){
+
+export async function requireAdmin(ctx: any) {
   const supabase = createServerSupabaseClient(ctx)
   const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { redirect:{ destination:'/login', permanent:false } }
-  const { data: prof } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle()
-  if (!prof?.is_admin) return { redirect:{ destination:'/', permanent:false } }
-  return { props:{} }
+  if (!user) return { redirect: { destination: '/login', permanent: false } }
+
+  const allowed = (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean)
+
+  if (!allowed.includes((user.email || '').toLowerCase())) {
+    return { notFound: true }
+  }
+
+  return { props: {} }
 }

--- a/pages/api/admin/payment-proofs/set-status.ts
+++ b/pages/api/admin/payment-proofs/set-status.ts
@@ -7,6 +7,8 @@ export default async function handler(req:NextApiRequest,res:NextApiResponse){
   const supabase = createServerSupabaseClient({ req, res })
   const { data:{ user } } = await supabase.auth.getUser()
   if (!user) return res.status(401).end()
+  const allowed = (process.env.ADMIN_EMAILS||'').split(',').map(e=>e.trim().toLowerCase()).filter(Boolean)
+  if (!allowed.includes((user.email||'').toLowerCase())) return res.status(404).end('Not Found')
   const { id, status, reason } = req.body||{}
   if (!['approved','flagged'].includes(status)) return res.status(400).json({error:'invalid status'})
 

--- a/pages/api/qa/cleanup/jobs.ts
+++ b/pages/api/qa/cleanup/jobs.ts
@@ -8,6 +8,7 @@ function assertQA(req: NextApiRequest) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found');
   try {
     assertQA(req);
     const { titlePrefix } = req.body || {};

--- a/pages/api/qa/credit-tickets.ts
+++ b/pages/api/qa/credit-tickets.ts
@@ -6,6 +6,7 @@ function assertQA(req: NextApiRequest) {
   if (!ok) throw new Error('Unauthorized')
 }
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found')
   try {
     assertQA(req)
     const { userId, tickets = 5 } = req.body || {}

--- a/pages/api/qa/seed-hire-scenario.ts
+++ b/pages/api/qa/seed-hire-scenario.ts
@@ -8,6 +8,7 @@ function assertQA(req: NextApiRequest) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found')
   try {
     assertQA(req)
     const { employerEmail, workerEmail } = req.body || {}

--- a/pages/api/qa/tickets/get.ts
+++ b/pages/api/qa/tickets/get.ts
@@ -8,6 +8,7 @@ function assertQA(req: NextApiRequest) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found');
   try {
     assertQA(req);
     const email = (req.query.email as string) || '';

--- a/pages/api/qa/tickets/grant.ts
+++ b/pages/api/qa/tickets/grant.ts
@@ -24,6 +24,7 @@ async function findUserId(supa: any, email: string): Promise<string> {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found');
   try {
     assertQA(req);
     const { email, amount } = req.body || {};

--- a/pages/api/qa/users/upsert.ts
+++ b/pages/api/qa/users/upsert.ts
@@ -45,6 +45,7 @@ async function getOrCreateUser(supa: any, email: string): Promise<string> {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.QA_ENABLED !== 'true') return res.status(404).end('Not Found');
   try {
     assertQA(req);
     const { email, role, tickets } = req.body || {};

--- a/tests/qa-disabled.smoke.spec.ts
+++ b/tests/qa-disabled.smoke.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+import handler from '../pages/api/qa/tickets/get'
+
+test('QA route returns 404 when disabled', async () => {
+  process.env.QA_ENABLED = 'false'
+  const req: any = { method: 'GET', headers: {}, query: {} }
+  const res: any = {
+    statusCode: 0,
+    status(code:number){ this.statusCode = code; return this },
+    end(){ return this },
+    json(){ return this },
+  }
+  await handler(req, res)
+  expect(res.statusCode).toBe(404)
+})


### PR DESCRIPTION
## Summary
- restrict admin access via ADMIN_EMAILS
- harden QA API endpoints with QA_ENABLED env flag
- add smoke test ensuring QA routes return 404 when disabled

## Testing
- `npm run lint` *(fails: next not found)*
- `npx playwright test tests/qa-disabled.smoke.spec.ts` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6c121e88327a0ad281d6a46ed40