### PR TITLE
perf(core-web-vitals): faster LCP, zero-jank CLS, caching & lazy-load

### DIFF
--- a/components/AdminPayments.tsx
+++ b/components/AdminPayments.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { approvePayment, rejectPayment } from '@/lib/actions/adminPayments';
+import { notifyPaymentApproved, notifyPaymentRejected } from '@/lib/notifyPayments';
+
+export type PendingPayment = {
+  id: string;
+  user_id: string;
+  amount_php: number;
+  expected_tickets: number;
+  gcash_reference: string;
+  created_at: string;
+};
+
+export default function AdminPayments({ initial = [] }: { initial: PendingPayment[] }) {
+  const [rows, setRows] = useState(initial);
+
+  const handleApprove = async (id: string) => {
+    await approvePayment(id);
+    await notifyPaymentApproved(id);
+    setRows((r) => r.filter((x) => x.id !== id));
+    alert('Tickets credited.');
+  };
+
+  const handleReject = async (id: string) => {
+    const reason = prompt('Reason for rejection?') || 'N/A';
+    await rejectPayment(id, reason);
+    await notifyPaymentRejected(id, reason);
+    setRows((r) => r.filter((x) => x.id !== id));
+    alert('Payment rejected.');
+  };
+
+  return (
+    <main className="max-w-3xl mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Pending payments</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th>ID</th>
+            <th>User</th>
+            <th>Amount</th>
+            <th>Tickets</th>
+            <th>GCash Ref</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((p) => (
+            <tr key={p.id} className="border-t">
+              <td>{p.id}</td>
+              <td>{p.user_id}</td>
+              <td>{p.amount_php}</td>
+              <td>{p.expected_tickets}</td>
+              <td>{p.gcash_reference}</td>
+              <td className="space-x-2">
+                <button
+                  onClick={() => handleApprove(p.id)}
+                  data-testid="approve-payment"
+                  aria-label="Approve payment"
+                  className="px-2 py-1 bg-green-600 text-white rounded"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => handleReject(p.id)}
+                  data-testid="reject-payment"
+                  aria-label="Reject payment"
+                  className="px-2 py-1 bg-red-600 text-white rounded"
+                >
+                  Reject
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/components/AppLogo.tsx
+++ b/components/AppLogo.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 export default function AppLogo({ size=28, className="" }: { size?: number; className?: string }) {
   return (
     <span className={`inline-flex items-center gap-2 ${className}`}>
-      <Image src="/brand/quickgig-badge.png" alt="QuickGig" width={size} height={size} priority />
+      <Image src="/brand/quickgig-badge.png" alt="QuickGig" width={size} height={size} />
       <span className="hidden sm:inline font-semibold tracking-wide text-white">QuickGig.ph</span>
     </span>
   );

--- a/components/nav/AppHeader.tsx
+++ b/components/nav/AppHeader.tsx
@@ -22,8 +22,8 @@ export default function AppHeader(){
   const highlight = balance === 0 && balance !== null
 
     return (
-      <header className="qg-header">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+      <header className="qg-header h-14">
+        <div className="max-w-6xl mx-auto px-4 h-full flex items-center justify-between">
           <Link href="/" className="flex items-center">
             <AppLogo size={32} />
           </Link>

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,10 @@
+import localFont from 'next/font/local';
+
+export const qgSans = localFont({
+  src: [
+    { path: '../public/legacy/fonts/LegacySans-Regular.woff2', weight: '400', style: 'normal' },
+    { path: '../public/legacy/fonts/LegacySans-Medium.woff2', weight: '500', style: 'normal' },
+  ],
+  display: 'swap',
+  preload: true,
+});

--- a/lib/vitals.ts
+++ b/lib/vitals.ts
@@ -1,0 +1,6 @@
+export function reportWebVitals(metric: any){
+  // Only log in preview/dev; production can be wired to analytics later
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[Vitals]', metric.name, metric.value);
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,33 @@
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
+
 const redirects = async () => ([
   { source: '/post', destination: '/', permanent: false },
   { source: '/find', destination: '/', permanent: false }, // TEMP until cache settles
   { source: '/jobs', destination: '/', permanent: false }, // just in case
 ]);
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+module.exports = withBundleAnalyzer({
   reactStrictMode: true,
+  images: { formats: ['image/avif', 'image/webp'] },
   eslint: { ignoreDuringBuilds: true }, // prevent CI failing on eslint/parser fetch
+  async headers() {
+    return [
+      {
+        source: '/(.*)\\.(?:js|css|woff2|png|jpg|jpeg|gif|svg|webp|avif)$',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
+      {
+        source: '/favicon-:size.png',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
+    ];
+  },
   async redirects() {
     const base = await redirects();
     return [
@@ -16,6 +36,4 @@ const nextConfig = {
       { source: '/signup', destination: '/', permanent: true },
     ];
   },
-};
-
-module.exports = nextConfig;
+});

--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,8 @@ module.exports = withBundleAnalyzer({
   async headers() {
     return [
       {
-        source: '/(.*)\\.(?:js|css|woff2|png|jpg|jpeg|gif|svg|webp|avif)$',
+        source:
+          '/:path*{.js,.css,.woff2,.png,.jpg,.jpeg,.gif,.svg,.webp,.avif}',
         headers: [
           { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
         ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "qa:report": "playwright show-report",
     "build:prod": "next build",
     "start:prod": "next start -p 3000",
+    "analyze": "ANALYZE=true next build",
+    "build:profile": "NODE_OPTIONS='--trace-deopt --trace_gc' next build",
     "seed": "node scripts/seed.mjs",
     "postinstall": "node -e \"process.env.NODE_ENV==='production'?process.exit(0):0\" || npx playwright install --with-deps || true"
   },
@@ -47,7 +49,8 @@
     "fast-glob": "^3.3.2",
     "start-server-and-test": "^2.0.0",
     "@supabase/supabase-js": "^2.45.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
+    "@next/bundle-analyzer": "^15.0.0"
   },
   "engines": {
     "node": ">=18.17"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import AppFooter from "@/components/nav/AppFooter";
 import Container from "@/components/Container";
 import { useEffect } from "react";
 import { setupErrlog } from "@/lib/errlog";
+import { qgSans } from "@/lib/fonts";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -30,7 +31,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           content="Find work or hire quickly with simple, ticket-based matches."
         />
       </Head>
-      <div className="min-h-screen bg-surface text-text flex flex-col">
+      <div className={`${qgSans.className} min-h-screen bg-surface text-text flex flex-col`}>
         {!isError && <AppHeader />}
         <main className="flex-1 py-6 bg-surface">
           <Container>
@@ -43,9 +44,4 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   );
 }
 
-// (Next.js feature) export web-vitals to console for now
-export function reportWebVitals(metric: any) {
-  // CLS, LCP, FID, FCP, TTFB, INP
-  // eslint-disable-next-line no-console
-  console.log('[web-vitals]', metric);
-}
+export { reportWebVitals } from "@/lib/vitals";

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,10 @@ export default function Document() {
     <Html lang="en">
       <Head>
         {preconnectHref && (
-          <link rel="preconnect" href={preconnectHref} crossOrigin="" />
+          <>
+            <link rel="preconnect" href={preconnectHref} crossOrigin="" />
+            <link rel="dns-prefetch" href={preconnectHref} />
+          </>
         )}
         <meta name="theme-color" content="#000000" />
         <meta name="color-scheme" content="light only" />

--- a/pages/admin/payments.tsx
+++ b/pages/admin/payments.tsx
@@ -1,21 +1,13 @@
 import { GetServerSideProps } from 'next';
-import { useState } from 'react';
+import dynamic from 'next/dynamic';
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { requireAdmin } from '@/lib/auth/requireAdmin';
-import { approvePayment, rejectPayment } from '@/lib/actions/adminPayments';
-import {
-  notifyPaymentApproved,
-  notifyPaymentRejected,
-} from '@/lib/notifyPayments';
+import type { PendingPayment } from '@/components/AdminPayments';
 
-type PendingPayment = {
-  id: string;
-  user_id: string;
-  amount_php: number;
-  expected_tickets: number;
-  gcash_reference: string;
-  created_at: string;
-};
+const AdminPayments = dynamic(() => import('@/components/AdminPayments'), {
+  ssr: false,
+  loading: () => <div className="h-16" />,
+});
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const guard = await requireAdmin(ctx);
@@ -32,69 +24,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   return { props: { initial: data || [] } };
 };
 
-export default function AdminPayments({ initial = [] }: { initial: PendingPayment[] }) {
-  const [rows, setRows] = useState(initial);
-
-  const handleApprove = async (id: string) => {
-    await approvePayment(id);
-    await notifyPaymentApproved(id);
-    setRows((r) => r.filter((x) => x.id !== id));
-    alert('Tickets credited.');
-  };
-
-  const handleReject = async (id: string) => {
-    const reason = prompt('Reason for rejection?') || 'N/A';
-    await rejectPayment(id, reason);
-    await notifyPaymentRejected(id, reason);
-    setRows((r) => r.filter((x) => x.id !== id));
-    alert('Payment rejected.');
-  };
-
-  return (
-    <main className="max-w-3xl mx-auto p-6">
-      <h1 className="text-2xl font-semibold mb-4">Pending payments</h1>
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="text-left">
-            <th>ID</th>
-            <th>User</th>
-            <th>Amount</th>
-            <th>Tickets</th>
-            <th>GCash Ref</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((p) => (
-            <tr key={p.id} className="border-t">
-              <td>{p.id}</td>
-              <td>{p.user_id}</td>
-              <td>{p.amount_php}</td>
-              <td>{p.expected_tickets}</td>
-              <td>{p.gcash_reference}</td>
-              <td className="space-x-2">
-                <button
-                  onClick={() => handleApprove(p.id)}
-                  data-testid="approve-payment"
-                  aria-label="Approve payment"
-                  className="px-2 py-1 bg-green-600 text-white rounded"
-                >
-                  Approve
-                </button>
-                <button
-                  onClick={() => handleReject(p.id)}
-                  data-testid="reject-payment"
-                  aria-label="Reject payment"
-                  className="px-2 py-1 bg-red-600 text-white rounded"
-                >
-                  Reject
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </main>
-  );
+export default function AdminPaymentsPage(props: { initial: PendingPayment[] }) {
+  return <AdminPayments {...props} />;
 }
 

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Shell from '@/components/Shell';
+import Image from 'next/image';
 import {
   TICKET_PRICE_PHP,
   FREE_TICKETS_ON_SIGNUP,
@@ -48,10 +49,13 @@ export default function CheckoutPage() {
           <span> {GCASH_NOTES}</span>
         )}
       </p>
-      <img
+      <Image
         src={GCASH_QR_URL}
         alt="GCash QR"
-        loading="lazy"
+        width={200}
+        height={200}
+        placeholder="blur"
+        blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8dOnSfwAIhwNqCMJy1AAAAABJRU5ErkJggg=="
         className="max-w-xs mb-4"
       />
       {!order ? (

--- a/pages/find-work.tsx
+++ b/pages/find-work.tsx
@@ -78,7 +78,7 @@ export default function FindWorkPage() {
             <p className="text-sm text-brand-subtle line-clamp-2">{g.description}</p>
             <div className="mt-2 flex items-center justify-between text-sm">
               <span>{g.city ?? "—"}</span>
-              <Link className="underline" href={`/gigs/${g.id}`}>View</Link>
+              <Link className="underline" href={`/gigs/${g.id}`} prefetch>View</Link>
             </div>
           </li>
         ))}
@@ -91,4 +91,8 @@ export default function FindWorkPage() {
       </div>
     </Shell>
   );
+}
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,3 +44,7 @@ export default function Home() {
     </Card>
   );
 }
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}


### PR DESCRIPTION
## Summary
- add bundle analyzer and long-term cache headers
- wire up dev web-vitals logger and local font loading
- lazy-load admin payments table, prefetch job detail links, and optimize images

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68aaf731a00c8327ab76ac09868d811b