### PR TITLE
feat: add job location and online filters

### DIFF
--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -1,0 +1,16 @@
+import { supabase } from '@/lib/supabaseClient';
+
+export type NewJob = {
+  title: string;
+  company?: string;
+  is_online: boolean;
+  location_region: string | null;
+  location_city: string | null;
+  location_address: string | null;
+};
+
+export async function createJob(job: NewJob) {
+  const { data, error } = await supabase.from('jobs').insert(job).select().single();
+  if (error) throw error;
+  return data;
+}

--- a/lib/locationsPH.ts
+++ b/lib/locationsPH.ts
@@ -1,0 +1,21 @@
+export const REGIONS_PH = [
+  "Metro Manila",
+  "CALABARZON",
+  "Central Luzon",
+  "Central Visayas",
+  "Western Visayas",
+  "Davao Region",
+  "Northern Mindanao",
+  "Bicol Region",
+] as const;
+
+export const CITIES_BY_REGION: Record<string, string[]> = {
+  "Metro Manila": ["Makati", "Taguig", "Quezon City", "Manila", "Pasig", "Mandaluyong"],
+  "CALABARZON": ["Antipolo", "San Pedro", "Dasmariñas", "Bacoor"],
+  "Central Luzon": ["Angeles", "San Fernando", "Olongapo"],
+  "Central Visayas": ["Cebu City", "Mandaue", "Lapu-Lapu"],
+  "Western Visayas": ["Iloilo City", "Bacolod"],
+  "Davao Region": ["Davao City", "Tagum"],
+  "Northern Mindanao": ["Cagayan de Oro", "Iligan"],
+  "Bicol Region": ["Legazpi", "Naga"],
+};

--- a/pages/find.tsx
+++ b/pages/find.tsx
@@ -1,0 +1,73 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { REGIONS_PH, CITIES_BY_REGION } from '@/lib/locationsPH';
+
+export default function FindJobs() {
+  const r = useRouter();
+  const [region, setRegion] = useState((r.query.region as string) || '');
+  const [city, setCity] = useState((r.query.city as string) || '');
+  const [isOnline, setIsOnline] = useState(r.query.online === 'true');
+  const [jobs, setJobs] = useState<any[]>([]);
+
+  async function load() {
+    let q = supabase
+      .from('jobs')
+      .select('id,title,company,is_online,location_region,location_city,location_address,created_at')
+      .order('created_at', { ascending: false });
+    if (region) q = q.ilike('location_region', `%${region}%`);
+    if (city) q = q.ilike('location_city', `%${city}%`);
+    if (isOnline) q = q.eq('is_online', true);
+    const { data } = await q;
+    setJobs(data ?? []);
+  }
+  useEffect(() => {
+    load();
+  }, [region, city, isOnline]);
+
+  return (
+    <main className="max-w-6xl mx-auto p-4">
+      <form onSubmit={e => e.preventDefault()} className="mb-4 grid grid-cols-1 sm:grid-cols-4 gap-2">
+        <select className="border rounded p-2" value={region} onChange={e => setRegion(e.target.value)}>
+          <option value="">All regions</option>
+          {REGIONS_PH.map(r => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border rounded p-2"
+          value={city}
+          onChange={e => setCity(e.target.value)}
+          disabled={!region}
+        >
+          <option value="">{region ? 'All cities' : 'Select region first'}</option>
+          {(CITIES_BY_REGION[region] ?? []).map(c => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <label className="inline-flex items-center gap-2 border rounded p-2">
+          <input type="checkbox" checked={isOnline} onChange={e => setIsOnline(e.target.checked)} />
+          Online Jobs only
+        </label>
+      </form>
+
+      <ul className="space-y-2">
+        {jobs.map(j => (
+          <li key={j.id} className="border rounded p-3">
+            <div className="font-semibold">{j.title}</div>
+            <div className="text-sm text-gray-600">
+              {j.is_online
+                ? 'Online Job'
+                : [j.location_city, j.location_region].filter(Boolean).join(', ') +
+                  (j.location_address ? ` — ${j.location_address}` : '')}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -1,0 +1,110 @@
+import { useState, useMemo } from 'react';
+import { REGIONS_PH, CITIES_BY_REGION } from '@/lib/locationsPH';
+import { createJob } from '@/lib/jobs';
+
+export default function PostJobPage() {
+  const [title, setTitle] = useState('');
+  const [company, setCompany] = useState('');
+  const [isOnline, setIsOnline] = useState(false);
+  const [region, setRegion] = useState('');
+  const [city, setCity] = useState('');
+  const [address, setAddress] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const cities = useMemo(() => (region ? CITIES_BY_REGION[region] ?? [] : []), [region]);
+  const locationDisabled = isOnline;
+
+  async function onSubmit(e: any) {
+    e.preventDefault();
+    setBusy(true);
+    try {
+      await createJob({
+        title: title.trim(),
+        company: company.trim() || undefined,
+        is_online: isOnline,
+        location_region: locationDisabled ? null : region || null,
+        location_city: locationDisabled ? null : city || null,
+        location_address: locationDisabled ? null : address.trim() || null,
+      });
+      window.location.href = '/find';
+    } catch (err: any) {
+      console.error(err);
+      alert('Could not post job');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Post a Job</h1>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          className="w-full border rounded p-2"
+          placeholder="Job title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border rounded p-2"
+          placeholder="Company (optional)"
+          value={company}
+          onChange={e => setCompany(e.target.value)}
+        />
+
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={isOnline} onChange={e => setIsOnline(e.target.checked)} />
+          Online Job
+        </label>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <select
+            className="border rounded p-2"
+            value={region}
+            onChange={e => {
+              setRegion(e.target.value);
+              setCity('');
+            }}
+            disabled={locationDisabled}
+            required={!isOnline}
+          >
+            <option value="">Select Region</option>
+            {REGIONS_PH.map(r => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="border rounded p-2"
+            value={city}
+            onChange={e => setCity(e.target.value)}
+            disabled={locationDisabled || !region}
+            required={!isOnline}
+          >
+            <option value="">{region ? 'Select City' : 'Select Region first'}</option>
+            {cities.map(c => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+
+          <input
+            className="border rounded p-2"
+            placeholder="Address (optional)"
+            value={address}
+            onChange={e => setAddress(e.target.value)}
+            disabled={locationDisabled}
+          />
+        </div>
+
+        <button className="qg-btn qg-btn--primary px-4 py-2" disabled={busy}>
+          {busy ? 'Posting...' : 'Post Job'}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/supabase/migrations/20250825001500_jobs_location_online.sql
+++ b/supabase/migrations/20250825001500_jobs_location_online.sql
@@ -1,0 +1,23 @@
+-- Rename is_remote → is_online, or add if not present
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='jobs' and column_name='is_remote'
+  ) then
+    alter table public.jobs rename column is_remote to is_online;
+  else
+    alter table public.jobs add column if not exists is_online boolean not null default false;
+  end if;
+end $$;
+
+-- Ensure structured location fields exist
+alter table public.jobs
+  add column if not exists location_region text,
+  add column if not exists location_city text,
+  add column if not exists location_address text;
+
+-- Indexes
+create index if not exists jobs_city_lower_idx on public.jobs (lower(location_city));
+create index if not exists jobs_region_lower_idx on public.jobs (lower(location_region));
+create index if not exists jobs_online_idx on public.jobs (is_online);


### PR DESCRIPTION
## Summary
- support `is_online` and structured location fields for jobs
- add posting form with Online Job toggle and region/city/address inputs
- add find page with filters for region, city, and online jobs

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: 403 Forbidden for @next/bundle-analyzer)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab024e7ab48327bb145d9af502b644