### PR TITLE
feat: add home dashboard and avatar uploads

### DIFF
--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,0 +1,22 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export async function uploadAvatar(file: File): Promise<string> {
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth?.user) throw new Error("Not authenticated");
+
+  const path = `${auth.user.id}/${Date.now()}-${file.name.replace(/\s+/g, "_")}`;
+  const { error: upErr } = await supabase.storage.from("avatars").upload(path, file, { upsert: true });
+  if (upErr) throw upErr;
+
+  const { data: pub } = supabase.storage.from("avatars").getPublicUrl(path);
+  const publicUrl = pub?.publicUrl;
+  if (!publicUrl) throw new Error("Could not resolve avatar URL");
+
+  const { error: upProfileErr } = await supabase
+    .from("profiles")
+    .update({ avatar_url: publicUrl })
+    .eq("id", auth.user.id);
+  if (upProfileErr) throw upProfileErr;
+
+  return publicUrl;
+}

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -22,7 +22,7 @@ export default function AuthCallback() {
       if (!user) { router.replace('/'); return }
       const { data: prof } = await supabase.from('profiles')
         .select('full_name').eq('id', user.id).maybeSingle()
-      router.replace(!prof?.full_name ? '/profile' : '/')
+      router.replace(!prof?.full_name ? '/profile' : '/home')
     }
     run()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/pages/auth/index.tsx
+++ b/pages/auth/index.tsx
@@ -26,7 +26,7 @@ export default function AuthPage() {
     setError(null);
     const intended = router.query?.next as string | undefined;
     try {
-      localStorage.setItem('postAuthRedirect', intended || '/profile');
+      localStorage.setItem('postAuthRedirect', intended || '/home');
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { supabase } from "@/lib/supabaseClient";
+import { uploadAvatar } from "@/lib/avatar";
+
+type TicketBalance = { balance: number };
+
+export default function Home() {
+  const [role, setRole] = useState<"seeker" | "employer" | "admin">("seeker");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [profileEmail, setProfileEmail] = useState<string | null>(null);
+  const [suspended, setSuspended] = useState(false);
+  const [deleted, setDeleted] = useState(false);
+  const [balance, setBalance] = useState<number>(0);
+
+  // seeker
+  const [apps, setApps] = useState<any[]>([]);
+  const [activeMatches, setActiveMatches] = useState<any[]>([]);
+  // employer
+  const [myJobs, setMyJobs] = useState<any[]>([]);
+  const [pendingCounts, setPendingCounts] = useState<Record<string, number>>({});
+
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: auth } = await supabase.auth.getUser();
+      if (!auth?.user) return;
+
+      const { data: prof } = await supabase
+        .from("profiles")
+        .select("role, avatar_url, email, suspended_at, deleted_at")
+        .eq("id", auth.user.id)
+        .maybeSingle();
+
+      setRole((prof?.role as any) ?? "seeker");
+      setAvatarUrl(prof?.avatar_url ?? null);
+      setProfileEmail(prof?.email ?? null);
+      setSuspended(!!prof?.suspended_at);
+      setDeleted(!!prof?.deleted_at);
+
+      const { data: bal } = await supabase
+        .from("v_ticket_balances")
+        .select("balance")
+        .eq("user_id", auth.user.id)
+        .maybeSingle();
+      setBalance(bal?.balance ?? 0);
+
+      // seeker widgets
+      const { data: seekerApps } = await supabase
+        .from("applications")
+        .select("id, job_id, status, updated_at, job:jobs(title)")
+        .order("updated_at", { ascending: false })
+        .limit(5);
+      setApps(seekerApps ?? []);
+
+      const { data: seekerMatches } = await supabase
+        .from("matches")
+        .select("id, status, job_id, updated_at, job:jobs(title)")
+        .in("status", ["agreed", "in_progress"])
+        .order("updated_at", { ascending: false })
+        .limit(5);
+      setActiveMatches(seekerMatches ?? []);
+
+      // employer widgets
+      const { data: jobs } = await supabase
+        .from("jobs")
+        .select("id, title, created_at, is_online, location_city, location_region")
+        .order("created_at", { ascending: false })
+        .limit(5);
+      setMyJobs(jobs ?? []);
+
+      const { data: pend, error: pendErr } = await supabase
+        .from("applications")
+        .select("job_id, status")
+        .eq("status", "pending");
+      if (!pendErr && pend) {
+        const m: Record<string, number> = {};
+        for (const a of pend as any[]) m[a.job_id] = (m[a.job_id] ?? 0) + 1;
+        setPendingCounts(m);
+      }
+    })();
+  }, []);
+
+  const roleLabel = useMemo(() => (role === "employer" ? "Employer" : role === "admin" ? "Admin" : "Seeker"), [role]);
+
+  async function onPickAvatar(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    try {
+      const url = await uploadAvatar(f);
+      setAvatarUrl(url);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to upload avatar.");
+    } finally {
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  return (
+    <main className="max-w-6xl mx-auto p-6 space-y-6">
+      {/* Header with avatar */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="relative h-14 w-14 rounded-full overflow-hidden bg-gray-100">
+            {avatarUrl ? (
+              <Image src={avatarUrl} alt="Profile photo" fill sizes="56px" />
+            ) : (
+              <div className="h-full w-full grid place-items-center text-gray-400">Add photo</div>
+            )}
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold">Home</h1>
+            <div className="text-sm text-gray-600">Signed in as <b>{roleLabel}</b>{profileEmail ? ` • ${profileEmail}` : ""}</div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+          <button className="qg-btn qg-btn--white px-3 py-2" onClick={() => fileRef.current?.click()}>
+            Change photo
+          </button>
+          <Link href="/profile" className="qg-btn qg-btn--outline px-3 py-2">Edit Profile</Link>
+        </div>
+      </div>
+
+      {(suspended || deleted) && (
+        <div className="rounded bg-yellow-50 p-3 text-yellow-800">
+          {deleted ? "Your account is scheduled for deletion." : "Your account is currently suspended."} Need help?{" "}
+          <Link href="/support" className="underline">Contact support</Link>.
+        </div>
+      )}
+
+      {/* Top cards */}
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <Card title="Tickets">
+          <div className="text-3xl font-semibold mb-3">{balance}</div>
+          <div className="flex gap-2">
+            <Link href="/wallet" className="qg-btn qg-btn--primary px-3 py-2">Buy Tickets</Link>
+            <Link href="/wallet" className="qg-btn qg-btn--outline px-3 py-2">View History</Link>
+          </div>
+        </Card>
+
+        <Card title="Quick Actions">
+          {role === "employer" || role === "admin" ? (
+            <div className="flex flex-wrap gap-2">
+              <Link href="/post" className="qg-btn qg-btn--primary px-3 py-2">Post Job</Link>
+              <Link href="/admin/payments" className="qg-btn qg-btn--outline px-3 py-2">Review Payments</Link>
+              <Link href="/admin/reviews" className="qg-btn qg-btn--outline px-3 py-2">Moderate Reviews</Link>
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              <Link href="/find" className="qg-btn qg-btn--primary px-3 py-2">Browse Jobs</Link>
+              <Link href="/messages" className="qg-btn qg-btn--outline px-3 py-2">Messages</Link>
+              <Link href="/profile" className="qg-btn qg-btn--outline px-3 py-2">Edit Profile</Link>
+            </div>
+          )}
+        </Card>
+
+        <Card title="Recent messages">
+          <div className="text-sm text-gray-500">Open your inbox to continue chatting.</div>
+          <Link href="/messages" className="mt-3 inline-block qg-btn qg-btn--white px-3 py-2">Open Messages</Link>
+        </Card>
+      </section>
+
+      {/* Role sections */}
+      {role === "employer" || role === "admin" ? (
+        <>
+          <Section title="Your job posts" actionHref="/post" actionLabel="Post new" />
+          <Grid>
+            {myJobs.length === 0 ? (
+              <Empty text="No job posts yet. Create one to receive applications." />
+            ) : (
+              myJobs.map((j) => (
+                <ListCard key={j.id}
+                  title={j.title}
+                  subtitle={j.is_online ? "Online Job" : [j.location_city, j.location_region].filter(Boolean).join(", ") || "—"}
+                  meta={new Date(j.created_at).toLocaleString()}>
+                  <div className="flex gap-2">
+                    <Link className="qg-btn qg-btn--outline px-3 py-1.5" href={`/jobs/${j.id}`}>View</Link>
+                    <Link className="qg-btn qg-btn--white px-3 py-1.5" href={`/jobs/${j.id}/edit`}>Edit</Link>
+                    <span className="ml-auto text-xs text-gray-600">
+                      {pendingCounts[j.id] ? `${pendingCounts[j.id]} pending apps` : "No pending apps"}
+                    </span>
+                  </div>
+                </ListCard>
+              ))
+            )}
+          </Grid>
+        </>
+      ) : (
+        <>
+          <Section title="Your applications" actionHref="/find" actionLabel="Find jobs" />
+          <Grid>
+            {apps.length === 0 ? (
+              <Empty text="You haven't applied to any jobs yet." />
+            ) : (
+              apps.map((a) => (
+                <ListCard key={a.id}
+                  title={a.job?.title ?? "Job"}
+                  subtitle={`Status: ${a.status}`}
+                  meta={new Date(a.updated_at).toLocaleString()}>
+                  <Link className="qg-btn qg-btn--outline px-3 py-1.5" href={`/jobs/${a.job_id}`}>View job</Link>
+                </ListCard>
+              ))
+            )}
+          </Grid>
+
+          <Section title="Active matches" />
+          <Grid>
+            {activeMatches.length === 0 ? (
+              <Empty text="When both parties agree, your active matches appear here." />
+            ) : (
+              activeMatches.map((m) => (
+                <ListCard key={m.id}
+                  title={m.job?.title ?? "Job"}
+                  subtitle={`Status: ${m.status}`}
+                  meta={new Date(m.updated_at).toLocaleString()}>
+                  <Link className="qg-btn qg-btn--outline px-3 py-1.5" href={`/jobs/${m.job_id}`}>Open chat</Link>
+                </ListCard>
+              ))
+            )}
+          </Grid>
+        </>
+      )}
+    </main>
+  );
+}
+
+function Card({ title, children }: { title: string; children: any }) {
+  return (
+    <div className="border rounded p-4">
+      <div className="text-sm text-gray-500 mb-2">{title}</div>
+      {children}
+    </div>
+  );
+}
+function Section({ title, actionHref, actionLabel }: { title: string; actionHref?: string; actionLabel?: string }) {
+  return (
+    <div className="flex items-center justify-between mt-4 mb-2">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {actionHref && actionLabel && <Link href={actionHref} className="qg-btn qg-btn--white px-3 py-1.5">{actionLabel}</Link>}
+    </div>
+  );
+}
+function Grid({ children }: { children: any }) {
+  return <div className="grid grid-cols-1 md:grid-cols-2 gap-3">{children}</div>;
+}
+function ListCard({ title, subtitle, meta, children }: { title: string; subtitle?: string; meta?: string; children?: any }) {
+  return (
+    <div className="border rounded p-4">
+      <div className="font-semibold">{title}</div>
+      {subtitle && <div className="text-sm text-gray-600">{subtitle}</div>}
+      {meta && <div className="text-xs text-gray-500 mt-1">{meta}</div>}
+      <div className="mt-3">{children}</div>
+    </div>
+  );
+}
+function Empty({ text }: { text: string }) {
+  return <div className="border rounded p-4 text-gray-600">{text}</div>;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,12 +4,22 @@ import Card from '@/components/ui/Card';
 import { H1, P } from '@/components/ui/Text';
 import { getProfile } from '@/utils/session';
 import { copy } from '@/copy';
+import { supabase } from '@/lib/supabaseClient';
+import { useRouter } from 'next/router';
 
 export default function Home() {
   const [canPost, setCanPost] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     getProfile().then((p) => setCanPost(!!p?.can_post_job));
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data?.session) router.replace('/home');
+    })();
   }, []);
 
   return (

--- a/supabase/migrations/20250825084500_home_dashboard_avatars.sql
+++ b/supabase/migrations/20250825084500_home_dashboard_avatars.sql
@@ -1,0 +1,38 @@
+-- 1) Add avatar_url to profiles (nullable)
+alter table public.profiles
+  add column if not exists avatar_url text;
+
+-- 2) Create public avatars bucket (if not exists)
+-- (safe if already created earlier)
+select
+  case
+    when exists (select 1 from storage.buckets where id = 'avatars') then null
+    else storage.create_bucket('avatars', public => true)
+  end;
+
+-- 3) RLS policies on storage.objects for avatars bucket
+-- Enable RLS if not already
+alter table storage.objects enable row level security;
+
+-- Allow anyone to read avatars (bucket is public)
+create policy if not exists "avatars_read_public"
+  on storage.objects for select
+  using (bucket_id = 'avatars');
+
+-- Allow authenticated users to upload to their own folder: avatars/{uid}/filename
+create policy if not exists "avatars_insert_own_folder"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and owner = auth.uid()
+  );
+
+-- Allow update/delete only for owner
+create policy if not exists "avatars_update_own"
+  on storage.objects for update
+  using  (bucket_id = 'avatars' and owner = auth.uid())
+  with check (bucket_id = 'avatars' and owner = auth.uid());
+
+create policy if not exists "avatars_delete_own"
+  on storage.objects for delete
+  using (bucket_id = 'avatars' and owner = auth.uid());


### PR DESCRIPTION
## Summary
- add SQL migration for profile avatars and avatars storage bucket
- add avatar upload helper
- implement role-aware /home dashboard with avatar picker
- redirect sign-in flow and landing page to /home

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab094c4ce48327bd80d9cc64b14e46