### PR TITLE
feat(onboarding-routing): neutral /home + role pick + split dashboards

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -22,9 +22,9 @@ export default function Nav() {
 
   return (
     <nav className="p-4 border-b mb-4 flex gap-4">
-      <Link href="/">Home</Link>
-      <Link href="/find-work">{copy.nav.findWork}</Link>
-      <Link href="/post-job">{copy.nav.postJob}</Link>
+      <Link href="/home">Home</Link>
+      <Link href="/find">{copy.nav.findWork}</Link>
+      <Link href="/post">{copy.nav.postJob}</Link>
       {session ? (
         <button onClick={logout}>Logout</button>
       ) : (

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,9 +25,9 @@ export default function TopNav() {
   return (
     <nav className="w-full sticky top-0 z-20 border-b border-brand-border bg-brand-bg backdrop-blur text-brand">
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-4">
-        <Link href="/" className="font-semibold">QuickGig.ph</Link>
+        <Link href="/home" className="font-semibold">QuickGig.ph</Link>
         <div className="ml-auto flex items-center gap-4 text-sm">
-          <Link href="/find-work">{copy.nav.findWork}</Link>
+          <Link href="/find">{copy.nav.findWork}</Link>
           {loggedIn && <Link href="/dashboard/gigs">{copy.nav.myGigs}</Link>}
           {loggedIn && <Link href="/applications">{copy.nav.applications}</Link>}
           {loggedIn && <Link href="/saved">{copy.nav.saved}</Link>}
@@ -38,7 +38,7 @@ export default function TopNav() {
             </Link>
           )}
           <Link
-            href="/post-job"
+            href="/post"
             className={`btn-primary ${loggedIn && !eligible ? 'opacity-50 pointer-events-none' : ''}`}
             title={
               loggedIn && !eligible

--- a/lib/rolePref.ts
+++ b/lib/rolePref.ts
@@ -1,0 +1,49 @@
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+export type RolePref = 'worker' | 'employer';
+
+export async function getRolePref(userId?: string): Promise<RolePref | null> {
+  try {
+    if (!userId) {
+      // client-only fallback
+      if (typeof window !== 'undefined') {
+        const v = window.localStorage.getItem('role_pref');
+        return v === 'worker' || v === 'employer' ? v : null;
+      }
+      return null;
+    }
+    const supabase = createClientComponentClient();
+    // try DB first
+    const { data } = await supabase
+      .from('profiles')
+      .select('role_pref')
+      .eq('id', userId)
+      .maybeSingle();
+    if (data?.role_pref) return data.role_pref as RolePref;
+    // fallback to localStorage (client only)
+    if (typeof window !== 'undefined') {
+      const v = window.localStorage.getItem('role_pref');
+      return v === 'worker' || v === 'employer' ? v : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setRolePref(value: RolePref, userId?: string) {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('role_pref', value);
+    }
+    if (userId) {
+      const supabase = createClientComponentClient();
+      await supabase
+        .from('profiles')
+        .update({ role_pref: value })
+        .eq('id', userId);
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useRouter } from 'next/router'
 import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { getRolePref } from '@/lib/rolePref'
 
 export default function AuthCallback() {
   const supabase = useRef(createBrowserSupabaseClient()).current
@@ -22,7 +23,12 @@ export default function AuthCallback() {
       if (!user) { router.replace('/'); return }
       const { data: prof } = await supabase.from('profiles')
         .select('full_name').eq('id', user.id).maybeSingle()
-      router.replace(!prof?.full_name ? '/profile' : '/home')
+      if (!prof?.full_name) {
+        router.replace('/profile')
+        return
+      }
+      const pref = await getRolePref(user.id)
+      router.replace(!pref ? '/onboarding/role' : pref === 'worker' ? '/find' : '/post')
     }
     run()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/pages/dashboard/employer.tsx
+++ b/pages/dashboard/employer.tsx
@@ -1,0 +1,4 @@
+import HomeEmployer from '@/components/home/HomeEmployer';
+export default function EmployerDashboard() {
+  return <HomeEmployer />;
+}

--- a/pages/dashboard/worker.tsx
+++ b/pages/dashboard/worker.tsx
@@ -1,0 +1,4 @@
+import HomeSeeker from '@/components/home/HomeSeeker';
+export default function WorkerDashboard() {
+  return <HomeSeeker />;
+}

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,23 +1,59 @@
+import Link from 'next/link';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
-import HomeSeeker from '@/components/home/HomeSeeker';
-import HomeEmployer from '@/components/home/HomeEmployer';
 
-export default function HomePage() {
-  const [isEmployer, setIsEmployer] = useState<boolean | null>(null);
+export default function Home() {
+  const supabase = createClientComponentClient();
+  const [email, setEmail] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
       const { data: { user } } = await supabase.auth.getUser();
-      if (!user) {
-        window.location.href = '/login';
-        return;
-      }
-      const { data, error } = await supabase.from('gigs').select('id').eq('owner', user.id).limit(1);
-      setIsEmployer(!error && data && data.length > 0);
+      setEmail(user?.email ?? null);
     })();
   }, []);
 
-  if (isEmployer === null) return <div className="p-4">Loading…</div>;
-  return isEmployer ? <HomeEmployer /> : <HomeSeeker />;
+  return (
+    <main className="max-w-6xl mx-auto p-6 space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Home</h1>
+        {email && <span className="text-sm text-gray-600">{email}</span>}
+      </header>
+
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card title="Quick actions">
+          <div className="flex flex-wrap gap-2">
+            <Link className="qg-btn qg-btn--primary px-3 py-2" href="/find">Browse jobs</Link>
+            <Link className="qg-btn qg-btn--outline px-3 py-2" href="/post">Post a job</Link>
+            <Link className="qg-btn qg-btn--white px-3 py-2" href="/profile">Edit profile</Link>
+          </div>
+        </Card>
+        <Card title="Messages">
+          <p className="text-sm text-gray-600">Continue conversations.</p>
+          <Link className="inline-block mt-2 qg-btn qg-btn--white px-3 py-2" href="/messages">Open messages</Link>
+        </Card>
+        <Card title="Tickets">
+          <p className="text-sm text-gray-600">Check your balance and history.</p>
+          <Link className="inline-block mt-2 qg-btn qg-btn--outline px-3 py-2" href="/wallet">Go to wallet</Link>
+        </Card>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Tips</h2>
+        <ul className="list-disc pl-5 text-gray-700 space-y-1 text-sm">
+          <li>Complete your profile for better matches.</li>
+          <li>Enable email notifications to never miss a message.</li>
+        </ul>
+      </section>
+    </main>
+  );
+}
+
+function Card({ title, children }: { title: string; children: any }) {
+  return (
+    <div className="border rounded p-4 bg-white">
+      <div className="text-sm text-gray-500 mb-2">{title}</div>
+      {children}
+    </div>
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { getProfile } from '@/utils/session';
 import { copy } from '@/copy';
 import { supabase } from '@/lib/supabaseClient';
 import { useRouter } from 'next/router';
+import { getRolePref } from '@/lib/rolePref';
 
 export default function Home() {
   const [canPost, setCanPost] = useState(false);
@@ -17,8 +18,14 @@ export default function Home() {
 
   useEffect(() => {
     (async () => {
-      const { data } = await supabase.auth.getSession();
-      if (data?.session) router.replace('/home');
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      const pref = await getRolePref(user.id);
+      if (!pref) {
+        router.replace('/onboarding/role');
+      } else {
+        router.replace(pref === 'worker' ? '/find' : '/post');
+      }
     })();
   }, []);
 
@@ -28,7 +35,7 @@ export default function Home() {
       <P>Connect with opportunities — find work or hire talent quickly.</P>
       <div className="flex justify-center gap-4">
         <Link
-          href="/gigs?focus=search"
+          href="/find"
           className="btn-primary"
           data-testid="cta-findwork"
         >
@@ -36,7 +43,7 @@ export default function Home() {
         </Link>
         {canPost && (
           <Link
-            href="/gigs/new?focus=title"
+            href="/post"
             className="btn-secondary"
             data-testid="cta-postjob"
           >

--- a/pages/onboarding/role.tsx
+++ b/pages/onboarding/role.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { getRolePref, setRolePref, type RolePref } from '@/lib/rolePref';
+
+export default function RolePick() {
+  const router = useRouter();
+  const supabase = createClientComponentClient();
+  const [uid, setUid] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        router.replace('/login');
+        return;
+      }
+      setUid(user.id);
+      const existing = await getRolePref(user.id);
+      if (existing) {
+        router.replace(existing === 'worker' ? '/find' : '/post');
+      }
+    })();
+  }, []);
+
+  async function choose(value: RolePref) {
+    await setRolePref(value, uid ?? undefined);
+    router.replace(value === 'worker' ? '/find' : '/post');
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold">How do you want to use QuickGig?</h1>
+      <p className="text-gray-600">Pick one to personalize your experience. You can change later.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <button onClick={() => choose('worker')} className="qg-btn qg-btn--primary px-4 py-6 rounded-xl text-left">
+          I’m looking for work
+          <div className="text-sm text-gray-800 mt-1">Browse jobs and apply quickly.</div>
+        </button>
+        <button onClick={() => choose('employer')} className="qg-btn qg-btn--white px-4 py-6 rounded-xl text-left">
+          I’m hiring
+          <div className="text-sm text-gray-600 mt-1">Post a job and manage applicants.</div>
+        </button>
+      </div>
+      <button onClick={() => router.replace('/home')} className="qg-link text-sm">Skip for now</button>
+    </main>
+  );
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -44,7 +44,7 @@
       "name": "Find Work",
       "short_name": "Find Work",
       "description": "Browse available gigs and jobs",
-      "url": "/find-work",
+      "url": "/find",
       "icons": [
         {
           "src": "/logo-icon.png",
@@ -57,7 +57,7 @@
       "name": "Post Job",
       "short_name": "Post Job",
       "description": "Post a new job or gig",
-      "url": "/post-job",
+      "url": "/post",
       "icons": [
         {
           "src": "/logo-icon.png",

--- a/scripts/smoke-prod.mjs
+++ b/scripts/smoke-prod.mjs
@@ -22,5 +22,5 @@ function showHead(url, label = url) {
   // Landing + redirects
   showHead("https://quickgig.ph/", "quickgig.ph");
   showHead("https://www.quickgig.ph/", "www.quickgig.ph");
-  showHead("https://quickgig.ph/post-job", "quickgig.ph/post-job");
+  showHead("https://quickgig.ph/post", "quickgig.ph/post");
 })();

--- a/supabase/migrations/20250825_role_pref.sql
+++ b/supabase/migrations/20250825_role_pref.sql
@@ -1,0 +1,3 @@
+alter table public.profiles
+  add column if not exists role_pref text
+  check (role_pref in ('worker','employer'));


### PR DESCRIPTION
## Summary
- add optional `role_pref` column on profiles and helper to read/write with local fallback
- create neutral `/home`, role onboarding page, and worker/employer dashboards
- update auth and landing redirects plus navigation paths to `/find` and `/post`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab37b87be08327975cb7b16bb33996