### PR TITLE
fix: role aware routing and role-pref API

### DIFF
--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -72,10 +72,9 @@
         <div class="actions">
             <a
               class="btn btn-primary"
-              href="https://app.quickgig.ph/"
+              href="/home"
               data-testid="cta-start-now"
               aria-label="Open QuickGig app"
-              data-app-root
               >Simulan Na!</a
             >
             <a

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,61 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/auth') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/robots') ||
+    pathname.startsWith('/sitemap')
+  ) {
+    return NextResponse.next();
+  }
+
+  const res = NextResponse.next();
+  const supabase = createMiddlewareClient({ req, res });
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) return res;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role_pref')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const role = profile?.role_pref as 'worker' | 'employer' | null;
+
+  if (!role) {
+    if (pathname.startsWith('/dashboard/')) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/home';
+      return NextResponse.redirect(url);
+    }
+    return res;
+  }
+
+  if (pathname === '/home') {
+    const url = req.nextUrl.clone();
+    url.pathname = role === 'worker' ? '/dashboard/worker' : '/dashboard/employer';
+    return NextResponse.redirect(url);
+  }
+
+  if (pathname.startsWith('/dashboard/')) {
+    const desired = role === 'worker' ? '/dashboard/worker' : '/dashboard/employer';
+    if (pathname !== desired) {
+      const url = req.nextUrl.clone();
+      url.pathname = desired;
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: ['/((?!.*\\.).*)'],
+};

--- a/pages/api/profile/set-role-pref.ts
+++ b/pages/api/profile/set-role-pref.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  const supabase = createServerSupabaseClient({ req, res })
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return res.status(401).json({ error: 'Unauthorized' })
+
+  const { role } = (req.body ?? {}) as { role?: 'worker' | 'employer' }
+  if (role !== 'worker' && role !== 'employer') return res.status(400).json({ error: 'Bad role' })
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ role_pref: role })
+    .eq('id', user.id)
+
+  if (error) return res.status(400).json({ error: error.message })
+  return res.json({ ok: true })
+}

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,59 +1,28 @@
-import Link from 'next/link';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useRouter } from 'next/router';
 
 export default function Home() {
-  const supabase = createClientComponentClient();
-  const [email, setEmail] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const router = useRouter();
 
-  useEffect(() => {
-    (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      setEmail(user?.email ?? null);
-    })();
-  }, []);
+  async function pick(role: 'worker' | 'employer') {
+    setSaving(true);
+    await fetch('/api/profile/set-role-pref', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role }),
+    }).catch(() => {});
+    router.push(role === 'worker' ? '/dashboard/worker' : '/dashboard/employer');
+  }
 
   return (
-    <main className="max-w-6xl mx-auto p-6 space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Home</h1>
-        {email && <span className="text-sm text-gray-600">{email}</span>}
-      </header>
-
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card title="Quick actions">
-          <div className="flex flex-wrap gap-2">
-            <Link className="qg-btn qg-btn--primary px-3 py-2" href="/find">Browse jobs</Link>
-            <Link className="qg-btn qg-btn--outline px-3 py-2" href="/post">Post a job</Link>
-            <Link className="qg-btn qg-btn--white px-3 py-2" href="/profile">Edit profile</Link>
-          </div>
-        </Card>
-        <Card title="Messages">
-          <p className="text-sm text-gray-600">Continue conversations.</p>
-          <Link className="inline-block mt-2 qg-btn qg-btn--white px-3 py-2" href="/messages">Open messages</Link>
-        </Card>
-        <Card title="Tickets">
-          <p className="text-sm text-gray-600">Check your balance and history.</p>
-          <Link className="inline-block mt-2 qg-btn qg-btn--outline px-3 py-2" href="/wallet">Go to wallet</Link>
-        </Card>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold mb-2">Tips</h2>
-        <ul className="list-disc pl-5 text-gray-700 space-y-1 text-sm">
-          <li>Complete your profile for better matches.</li>
-          <li>Enable email notifications to never miss a message.</li>
-        </ul>
-      </section>
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl font-bold mb-4">Welcome to QuickGig.ph</h1>
+      <p className="mb-3">Piliin ang gagamitin mong role:</p>
+      <div className="flex gap-3">
+        <button disabled={saving} onClick={() => pick('worker')} className="qg-btn qg-btn--primary px-4 py-2">Job Seeker</button>
+        <button disabled={saving} onClick={() => pick('employer')} className="qg-btn qg-btn--outline px-4 py-2">Employer</button>
+      </div>
     </main>
-  );
-}
-
-function Card({ title, children }: { title: string; children: any }) {
-  return (
-    <div className="border rounded p-4 bg-white">
-      <div className="text-sm text-gray-500 mb-2">{title}</div>
-      {children}
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- update landing CTA to point at /home
- persist role selection via /api/profile/set-role-pref
- add middleware for role-aware routing and DB-backed role picker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68ab40a289588327a7400f3d33d368a4