### PR TITLE
chore/navigation: canonicalize CTAs, add redirects, friendlier 404, link checks

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,11 +7,11 @@ import { copy } from '@/copy';
 import AppLogo from '@/components/AppLogo';
 
 const links = [
-  { href: '/gigs', label: copy.nav.findWork, id: 'app-nav-find-work' },
+  { href: '/find', label: copy.nav.findWork, id: 'app-nav-find-work' },
   { href: '/gigs?mine=1', label: copy.nav.myGigs, id: 'app-nav-my-gigs' },
   { href: '/applications', label: copy.nav.applications, id: 'app-nav-applications' },
   { href: '/saved', label: copy.nav.saved, id: 'app-nav-saved' },
-  { href: '/gigs/new', label: copy.nav.postJob, id: 'app-nav-post-job' },
+  { href: '/post', label: copy.nav.postJob, id: 'app-nav-post-job' },
 ];
 
 function IconMenu() {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,11 +10,11 @@ import { isAdmin } from '@/utils/admin';
 import Container from './Container';
 
 const links = [
-  { href: '/gigs', label: copy.nav.findWork, id: 'app-nav-find-work' },
+  { href: '/find', label: copy.nav.findWork, id: 'app-nav-find-work' },
   { href: '/gigs?mine=1', label: copy.nav.myGigs, id: 'app-nav-my-gigs' },
   { href: '/applications', label: copy.nav.applications, id: 'app-nav-applications' },
   { href: '/saved', label: copy.nav.saved, id: 'app-nav-saved' },
-  { href: '/gigs/new', label: copy.nav.postJob, id: 'app-nav-post-job' },
+  { href: '/post', label: copy.nav.postJob, id: 'app-nav-post-job' },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -80,11 +80,11 @@
             >
             <a
               class="btn btn-ghost"
-              href="/start?intent=worker"
-              data-testid="cta-browse-jobs"
-              aria-label="Maghanap ng trabaho sa QuickGig app"
+              href="/start?intent=employer"
+              data-testid="cta-post-job"
+              aria-label="Post job on QuickGig app"
               data-app-root
-              >Maghanap ng Trabaho</a
+              >Post a Job</a
             >
           </div>
       </div>

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,13 @@ module.exports = withBundleAnalyzer({
     ];
   },
   async redirects() {
-    return [];
+    return [
+      { source: '/start-worker', destination: '/start?intent=worker', permanent: true },
+      { source: '/start-employer', destination: '/start?intent=employer', permanent: true },
+      { source: '/post-job', destination: '/post', permanent: true },
+      { source: '/gigs/new', destination: '/post', permanent: true },
+      { source: '/jobs', destination: '/find', permanent: true },
+      { source: '/jobs/:path*', destination: '/find', permanent: true },
+    ];
   },
 });

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,10 +1,21 @@
-export default function NotFound(){
+export default function NotFound() {
   return (
-    <main className="min-h-[60vh] flex items-center justify-center text-center p-8">
-      <div>
-        <h1 className="text-3xl font-semibold mb-2">Page not found</h1>
-        <a href="/" className="px-4 py-2 rounded bg-black text-white">Go home</a>
+    <main className="mx-auto max-w-lg p-8 text-center space-y-4">
+      <h1 className="text-2xl font-semibold">Page not found</h1>
+      <p className="text-slate-600">
+        Sorry, hindi namin mahanap ang page na ito. Try one of these:
+      </p>
+      <div className="flex gap-3 justify-center">
+        <a href="/start?intent=worker" className="qg-btn qg-btn--primary px-4 py-2">
+          Find work
+        </a>
+        <a href="/start?intent=employer" className="qg-btn qg-btn--outline px-4 py-2">
+          Post a job
+        </a>
       </div>
+      <p className="text-sm text-slate-500">
+        Or go to <a className="qg-link" href="/">home</a>.
+      </p>
     </main>
-  )
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,13 +34,6 @@ export default function Home() {
             {copy.nav.postJob}
           </Link>
         )}
-        <Link
-          href="/auth?focus=email"
-          className="btn-secondary"
-          data-testid="cta-auth"
-        >
-          Sign up / Mag-login
-        </Link>
       </div>
     </Card>
   );

--- a/tests/e2e/gigs.spec.ts
+++ b/tests/e2e/gigs.spec.ts
@@ -8,12 +8,12 @@ test('@full admin can post gig and view listing', async ({ page }) => {
   const admin = getDemoEmail('admin');
   if (qa) await stubSignIn(page, admin);
   const title = `QA Gig ${Date.now()}`;
-  await page.goto(`${app}/gigs/new`, { waitUntil: 'load' });
+  await page.goto(`${app}/post`, { waitUntil: 'load' });
   await page.getByLabel(/Title|Pamagat/i).fill(title);
   await page.getByLabel(/Description|Paglalarawan/i).fill('End-to-end tested gig.');
   await page.getByRole('button', { name: /publish|post/i }).click();
   await expect(page.getByText(/posted|na-post/i)).toBeVisible();
-  await page.goto(`${app}/gigs`, { waitUntil: 'load' });
+  await page.goto(`${app}/find`, { waitUntil: 'load' });
   await expect(page.getByText(title)).toBeVisible();
   await page.getByRole('link', { name: title }).click();
   await expect(page.getByRole('heading', { name: title })).toBeVisible();

--- a/tests/full.e2e.spec.ts
+++ b/tests/full.e2e.spec.ts
@@ -23,7 +23,7 @@ test('create gig → save → upload proof → admin approves', async ({ page, b
   if (await postJob.isVisible({ timeout: 2000 }).catch(() => false)) {
     await postJob.click()
   } else {
-    await page.goto(`${APP_URL}/gigs/new`)
+    await page.goto(`${APP_URL}/post`)
   }
   await page.waitForLoadState('domcontentloaded')
 
@@ -62,7 +62,7 @@ test('create gig → save → upload proof → admin approves', async ({ page, b
   ])
   if (!navigated) {
     // Fallback: open from list by title if present; otherwise continue
-    await page.goto(`${APP_URL}/gigs`)
+    await page.goto(`${APP_URL}/find`)
     const item = page.getByRole('link', { name: /Playwright Test Gig/i }).first()
     if (await item.isVisible().catch(() => false)) {
       await item.click()

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const CANON = new Set([
+  '/start?intent=worker',
+  '/start?intent=employer',
+  '/find',
+  '/post',
+  '/', '/home',
+]);
+
+test.describe('Landing CTAs are canonical', () => {
+  test('hero has exactly two CTAs with canonical hrefs', async ({ page }) => {
+    await page.goto('/');
+    const ctas = await page
+      .locator('a:has-text("Find work"), a:has-text("Simulan na"), a:has-text("Post job"), a:has-text("Post a job")')
+      .all();
+    // allow 1 or 2 depending on copy; enforce canonical hrefs
+    expect(ctas.length).toBeGreaterThanOrEqual(1);
+    for (const a of ctas) {
+      const href = await a.getAttribute('href');
+      expect(href).toBeTruthy();
+      // allow canonical target or canonical start
+      const ok = [...CANON].some(c => href!.startsWith(c));
+      expect(ok, `Bad CTA href: ${href}`).toBeTruthy();
+    }
+  });
+});
+
+test.describe('No dead links on landing', () => {
+  test('all <a> resolve to 200/3xx and not 404', async ({ page, request }) => {
+    await page.goto('/');
+    const links = await page.$$eval('a[href]', as =>
+      as.map(a => (a as HTMLAnchorElement).getAttribute('href') || '').filter(Boolean)
+    );
+    const unique = Array.from(new Set(links)).filter(href =>
+      href.startsWith('/') && !href.startsWith('/api')
+    );
+
+    for (const href of unique) {
+      const res = await request.get(href);
+      expect(res.status(), `Dead link ${href}`).toBeLessThan(400);
+    }
+  });
+});

--- a/tests/nav.audit.spec.ts
+++ b/tests/nav.audit.spec.ts
@@ -4,17 +4,17 @@ import { stubAuth } from './utils/stubAuth';
 test('nav audit', async ({ page }) => {
   await stubAuth(page);
   const targets: { id: string; path: string | RegExp; marker: string | string[] }[] = [
-    { id: 'nav-find', path: '/gigs', marker: 'gigs-list' },
+    { id: 'nav-find', path: '/find', marker: 'gigs-list' },
     { id: 'nav-my-gigs', path: '/gigs?mine=1', marker: 'my-gigs' },
     { id: 'nav-applications', path: '/applications', marker: 'applications-list' },
     { id: 'nav-saved', path: '/saved', marker: 'saved-list' },
-    { id: 'nav-post', path: /\/(billing|gigs\/new)/, marker: ['paywall-redirect', 'gig-editor'] },
+    { id: 'nav-post', path: /\/(billing|post)/, marker: ['paywall-redirect', 'gig-editor'] },
     { id: 'nav-profile', path: '/profile', marker: 'profile-save' },
   ];
 
   const ctaMap: Record<string, { path: string | RegExp; marker: string | string[] }> = {
-    'cta-find': { path: '/gigs', marker: 'gigs-list' },
-    'cta-post': { path: /\/(billing|gigs\/new)/, marker: ['paywall-redirect', 'gig-editor'] },
+    'cta-find': { path: '/find', marker: 'gigs-list' },
+    'cta-post': { path: /\/(billing|post)/, marker: ['paywall-redirect', 'gig-editor'] },
   };
 
   await page.goto('/');

--- a/tests/qa/ui.cta.spec.ts
+++ b/tests/qa/ui.cta.spec.ts
@@ -1,22 +1,14 @@
 import { test, expect } from '@playwright/test';
-
-test('auth CTA focuses email', async ({ page }) => {
-  await page.goto('/');
-  await page.getByTestId('cta-auth').click();
-  await expect(page).toHaveURL('/auth?focus=email');
-  await expect(page.locator('#email')).toBeFocused();
-});
-
 test('find work CTA focuses search', async ({ page }) => {
   await page.goto('/');
   await page.getByTestId('cta-findwork').click();
-  await expect(page).toHaveURL('/gigs?focus=search');
+  await expect(page).toHaveURL('/find?focus=search');
   await expect(page.locator('#search')).toBeFocused();
 });
 
 test('post job CTA focuses title', async ({ page }) => {
   await page.goto('/');
   await page.getByTestId('cta-postjob').click();
-  await expect(page).toHaveURL('/gigs/new?focus=title');
+  await expect(page).toHaveURL('/post?focus=title');
   await expect(page.locator('#title')).toBeFocused();
 });

--- a/tests/smoke/basic.spec.ts
+++ b/tests/smoke/basic.spec.ts
@@ -9,6 +9,6 @@ test('app nav and auth redirect', async ({ page }) => {
   await expect(page.getByTestId('app-nav-find-work')).toBeVisible();
   await page.getByTestId('app-login').click();
   await expect(page).toHaveURL(/auth/);
-  const res = await page.goto(`${app}/gigs`, { waitUntil: 'load' });
+  const res = await page.goto(`${app}/find`, { waitUntil: 'load' });
   expect(res?.status()).toBe(200);
 });


### PR DESCRIPTION
## Summary
- normalize CTAs across landing and app nav
- redirect legacy routes to canonical `/start`, `/find`, and `/post`
- friendlier 404 page with clear next steps
- add Playwright test to guard against dead links and wrong CTAs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint:href` *(fails: Cannot find package 'fast-glob')*
- `npx playwright test tests/links.spec.ts` *(fails: 403 Forbidden fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68aba7c432448327a8ccb527037eac86