### PR TITLE
fix(landing-cta): route Simulan na + Sign up to app start

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -106,9 +106,9 @@ export default function Header() {
                 Mag-login
               </LinkSafe>
               <LinkSafe
-                href="/signup"
+                href="/start"
                 data-testid="app-signup"
-                app-nav="/signup"
+                app-nav="/start"
                 className="hidden md:inline-flex qg-btn qg-btn--primary h-11 min-h-[44px]"
               >
                 Sign Up
@@ -151,9 +151,9 @@ export default function Header() {
                 </LinkSafe>
               )}
               <LinkSafe
-                href="/signup"
+                href="/start"
                 data-testid="app-signup"
-                app-nav="/signup"
+                app-nav="/start"
                 className="qg-btn qg-btn--primary w-full h-11 min-h-[44px] text-center flex items-center justify-center"
               >
                 Sign Up

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -47,7 +47,7 @@
           >
           <a
               class="btn btn-primary"
-              href="/login"
+              href="/start"
               data-testid="cta-signup"
               aria-label="Sign up on QuickGig app"
               data-app-root

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,8 @@ module.exports = withBundleAnalyzer({
   },
   async redirects() {
     return [
+      { source: '/simulan', destination: '/start?intent=worker', permanent: true },
+      { source: '/signup', destination: '/start', permanent: true },
       { source: '/start-worker', destination: '/start?intent=worker', permanent: true },
       { source: '/start-employer', destination: '/start?intent=employer', permanent: true },
       { source: '/post-job', destination: '/post', permanent: true },

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -42,3 +42,18 @@ test.describe('No dead links on landing', () => {
     }
   });
 });
+
+test.describe('legacy routes redirect', () => {
+  test('old paths forward to start flow', async ({ request }) => {
+    const cases: Array<[string, string]> = [
+      ['/simulan', '/start?intent=worker'],
+      ['/signup', '/start'],
+    ];
+    for (const [src, dest] of cases) {
+      const res = await request.get(src, { maxRedirects: 0 });
+      expect(res.status(), `${src} should redirect`).toBeGreaterThanOrEqual(300);
+      expect(res.status()).toBeLessThan(400);
+      expect(res.headers()['location']).toBe(dest);
+    }
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -12,12 +12,15 @@ const base = APP_URL.replace(/\/+$/, '');
 // Accept root with optional query/fragment
 const rootRe = new RegExp(`^${esc(base)}/?(?:[?#].*)?$`, 'i');
 
-// TEMP: accept legacy routes while caches/CDN propagate, remove soon.
-const findRe = new RegExp(`^${esc(base)}/find(?:[?#].*)?$`, 'i');
-const postRe = new RegExp(`^${esc(base)}/post(?:[?#].*)?$`, 'i');
-
-const acceptable = (href: string | null | undefined) =>
-  !!href && (rootRe.test(href) || findRe.test(href) || postRe.test(href)); // TODO: drop findRe & postRe
+const workerStartRe = new RegExp(
+  `^${esc(base)}/start\\?intent=worker(?:[?#].*)?$`,
+  'i',
+);
+const employerStartRe = new RegExp(
+  `^${esc(base)}/start\\?intent=employer(?:[?#].*)?$`,
+  'i',
+);
+const startRe = new RegExp(`^${esc(base)}/start(?:[?#].*)?$`, 'i');
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
@@ -26,21 +29,23 @@ test.beforeEach(async ({ page }) => {
 test('landing → app header visible', async ({ page }) => {
   await page.goto('https://quickgig.ph');
 
-  const checkCta = async (name: RegExp) => {
+  const checkCta = async (name: RegExp, target: RegExp) => {
     const cta = page.getByRole('link', { name }).first();
     await expect(cta).toBeVisible({ timeout: 10000 });
     const href = await cta.getAttribute('href');
     console.log('[smoke] CTA href:', href);
-    expect(acceptable(href)).toBeTruthy(); // TEMP relaxed
+    expect(href, 'href should exist').not.toBeNull();
+    expect(target.test(href!)).toBeTruthy();
     await Promise.all([
-      page.waitForURL(rootRe, { timeout: 10_000 }),
+      page.waitForURL(target, { timeout: 10_000 }),
       cta.click(),
     ]);
     await page.goBack({ waitUntil: 'load' }).catch(() => {});
   };
 
-  await checkCta(/find work|browse jobs|maghanap ng trabaho/i);
-  await checkCta(/post job/i);
+  await checkCta(/simulan na/i, workerStartRe);
+  await checkCta(/post job/i, employerStartRe);
+  await checkCta(/sign up/i, startRe);
 
   // ---- Header logo (prefer href, else click) ----
   const logoLink = page


### PR DESCRIPTION
## Summary
- update landing and header CTAs to point at `/start` and `/start?intent=worker`
- add redirects for legacy `/simulan` and `/signup` paths
- extend smoke and link tests for new start flow

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npx playwright test tests/smoke.spec.ts tests/links.spec.ts` *(fails: 403 Forbidden to install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68abacef1ab883278d7aad36f958262b