### PR TITLE
fix(auth): guard magic-link callback and unify landing login

### DIFF
--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -39,7 +39,7 @@
             >Post Job</a
           >
           <a
-            href="/login"
+            href="/start"
             data-testid="nav-login"
             aria-label="Log in to QuickGig app"
             data-app-root

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -3,6 +3,9 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
+const REDIRECT_GUARD_PAGES = ['/start', '/onboarding', '/profile', '/home'];
+const CALLBACK_FLAG = '__qg_auth_redirected';
+
 export default function AuthCallback() {
   const router = useRouter();
   createClientComponentClient();
@@ -10,6 +13,18 @@ export default function AuthCallback() {
     const params = new URLSearchParams(window.location.search);
     const next =
       params.get('next') || process.env.NEXT_PUBLIC_DEFAULT_REDIRECT || '/start';
+
+    // Skip if we're already on a stable page or we've redirected once.
+    if (REDIRECT_GUARD_PAGES.includes(window.location.pathname)) return;
+    if (
+      REDIRECT_GUARD_PAGES.includes(next) &&
+      sessionStorage.getItem(CALLBACK_FLAG)
+    )
+      return;
+
+    if (REDIRECT_GUARD_PAGES.includes(next)) {
+      sessionStorage.setItem(CALLBACK_FLAG, '1');
+    }
     const id = setTimeout(() => router.replace(next), 150);
     return () => clearTimeout(id);
   }, [router]);


### PR DESCRIPTION
## Summary
- prevent repeated redirects in magic-link callback with sessionStorage guard
- route landing login CTA through /start

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a8c343c8327aef5b81c3c5fd08a