### PR TITLE
ci(playwright): move video config to CI file & remove bad CLI flag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - name: Run smoke
-        run: npm run qa:smoke
+        run: npx playwright test -c playwright.ci.ts
         env:
           CI: 'true'
       - name: Upload artifacts (always)
@@ -67,7 +67,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
       - name: Run full e2e
-        run: npm run qa:full
+        run: npx playwright test -c playwright.ci.ts
         env:
           CI: 'true'
       - name: Upload artifacts (always)

--- a/playwright.ci.ts
+++ b/playwright.ci.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+export default defineConfig({
+  // Inherit anything defined in the base config if present
+  ...(baseConfig as any),
+  reporter: [['github'], ...((baseConfig as any)?.reporter ?? [])],
+  use: {
+    ...((baseConfig as any)?.use ?? {}),
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+});


### PR DESCRIPTION
## Summary
- add a CI-specific Playwright config inheriting base settings
- run smoke and e2e tests using the new CI config

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac81a374c48327abdc0273a87b3d85