### PR TITLE
feat: make vercel org optional for preview

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
       NEXT_PUBLIC_LANDING_URL: ${{ env.PREVIEW_URL || secrets.NEXT_PUBLIC_LANDING_URL || secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
       NEXT_PUBLIC_SITE_URL:     ${{ secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
       NEXT_PUBLIC_APP_URL:      ${{ secrets.NEXT_PUBLIC_APP_URL  || 'http://localhost:3000' }}
+      VERCEL_ORG_ID:            ${{ secrets.VERCEL_ORG_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,7 +35,6 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         run: node scripts/get-vercel-preview-url.mjs > url.txt
       - run: echo "BASE_URL=$(cat url.txt)" >> $GITHUB_ENV
       - name: Install Playwright
@@ -67,6 +67,7 @@ jobs:
       NEXT_PUBLIC_LANDING_URL: ${{ env.PREVIEW_URL || secrets.NEXT_PUBLIC_LANDING_URL || secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
       NEXT_PUBLIC_SITE_URL:     ${{ secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
       NEXT_PUBLIC_APP_URL:      ${{ secrets.NEXT_PUBLIC_APP_URL  || 'http://localhost:3000' }}
+      VERCEL_ORG_ID:            ${{ secrets.VERCEL_ORG_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -79,7 +80,6 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         run: node scripts/get-vercel-preview-url.mjs > url.txt
       - run: echo "BASE_URL=$(cat url.txt)" >> $GITHUB_ENV
       - name: Install Playwright

--- a/scripts/get-vercel-preview-url.mjs
+++ b/scripts/get-vercel-preview-url.mjs
@@ -8,22 +8,17 @@ const {
   GITHUB_REF,
 } = process.env;
 
-if (!VERCEL_TOKEN) {
-  console.error('Missing VERCEL_TOKEN');
-  process.exit(1);
-}
-if (!VERCEL_PROJECT_ID) {
-  console.error('Missing VERCEL_PROJECT_ID');
-  process.exit(1);
+if (!VERCEL_TOKEN || !VERCEL_PROJECT_ID) {
+  throw new Error('Missing VERCEL_TOKEN or VERCEL_PROJECT_ID env vars.');
 }
 
 const commitSha = GITHUB_SHA;
 const commitRef = GITHUB_REF?.split('/').pop();
 
-const params = new URLSearchParams({ projectId: VERCEL_PROJECT_ID, limit: '20' });
-if (VERCEL_ORG_ID) params.set('teamId', VERCEL_ORG_ID);
+const query = new URLSearchParams({ projectId: VERCEL_PROJECT_ID, limit: '20' });
+if (VERCEL_ORG_ID) query.set('teamId', VERCEL_ORG_ID);
 
-const apiUrl = `https://api.vercel.com/v13/deployments?${params}`;
+const apiUrl = `https://api.vercel.com/v13/deployments?${query}`;
 const maxAttempts = 60; // 10 minutes
 
 for (let attempt = 1; attempt <= maxAttempts; attempt++) {


### PR DESCRIPTION
## Summary
- make Vercel preview script only require token and project id
- allow CI to run without VERCEL_ORG_ID while still forwarding it when set

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `VERCEL_TOKEN=1 VERCEL_PROJECT_ID=1 node scripts/get-vercel-preview-url.mjs` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1a0725948327a2661a06e4c7d34c