### PR TITLE
ci: comment PR on workflow completion

### DIFF
--- a/.github/workflows/pr-status-notifier.yml
+++ b/.github/workflows/pr-status-notifier.yml
@@ -1,0 +1,45 @@
+name: PR Status Notifier
+on:
+  workflow_run:
+    workflows: ["Release Check"]
+    types: [completed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const {owner, repo} = context.repo;
+
+            // Find an open PR for the branch of this run
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', head: `${owner}:${run.head_branch}`
+            });
+            if (!prs.length) { core.info('No open PR for this branch'); return; }
+            const pr = prs[0];
+
+            // Gather job results
+            const jobsPages = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner, repo, run_id: run.id
+            });
+            const jobs = jobsPages.jobs ?? [];
+            const failing = jobs.filter(j => j.conclusion && j.conclusion !== 'success');
+
+            const badge = run.conclusion === 'success' ? '🟢'
+                       : run.conclusion === 'failure' ? '🔴' : '🟡';
+            let body = `${badge} **${run.name}** ${run.conclusion?.toUpperCase()} for \`${run.head_branch}\` @ \`${run.head_sha.slice(0,7)}\`.\n`;
+            if (failing.length) {
+              body += `\n**Failed jobs:**\n` + failing.map(j => `- ${j.name} (${j.conclusion})`).join('\\n');
+            }
+            body += `\n\n[View run logs](${run.html_url})`;
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number, body
+            });


### PR DESCRIPTION
## Summary
- notify PRs when Release Check completes by commenting run results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad71e2113c83279871cd614a561daf