### PR TITLE
feat(billing): add manual gcash top-up

### DIFF
--- a/components/billing/ProofCard.tsx
+++ b/components/billing/ProofCard.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+interface Proof {
+  id: string;
+  user_id: string;
+  amount: number;
+  credits: number;
+  file_url: string;
+  note?: string | null;
+  status: string;
+  created_at: string;
+  user_email?: string | null;
+}
+
+export default function ProofCard({ proof, children }: { proof: Proof; children?: React.ReactNode }) {
+  const supabase = createClientComponentClient();
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const { data } = supabase.storage.from('gcash-proofs').getPublicUrl(proof.file_url);
+    setUrl(data.publicUrl);
+  }, [proof.file_url, supabase]);
+
+  const isImage = proof.file_url.match(/\.png$|\.jpg$|\.jpeg$/i);
+
+  return (
+    <div className="border rounded p-4 space-y-2">
+      {url && (
+        isImage ? (
+          <img src={url} alt="proof" className="h-32 object-contain" />
+        ) : (
+          <a href={url} target="_blank" rel="noreferrer" className="underline">
+            View file
+          </a>
+        )
+      )}
+      <p>Amount: ₱{proof.amount}</p>
+      <p>Credits: {proof.credits}</p>
+      {proof.user_email && <p>User: {proof.user_email}</p>}
+      <p>Status: {proof.status}</p>
+      <p className="text-xs text-gray-500">
+        Submitted: {new Date(proof.created_at).toLocaleString()}
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/config/billing.ts
+++ b/config/billing.ts
@@ -1,0 +1,3 @@
+export const PRICE_PER_CREDIT = 100; // PHP per credit
+export const MAX_PROOF_SIZE_MB = 10;
+export const ALLOWED_PROOF_TYPES = ['image/png','image/jpeg','application/pdf'];

--- a/docs/manual-gcash.md
+++ b/docs/manual-gcash.md
@@ -1,0 +1,10 @@
+# Manual GCash Top-up
+
+Finance operators can review manual GCash payments in the Supabase `payment_proofs` table and the `gcash-proofs` storage bucket.
+
+1. Users submit proofs via the app.
+2. Visit `/admin/billing` to see pending proofs.
+3. Approve to grant credits via the `grant_credits` RPC or reject with a note.
+4. Files are stored in the private `gcash-proofs` bucket.
+
+Price per credit: ₱100.

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -13,3 +13,16 @@ export async function uploadPublicFile(file: File, prefix = "gigs") {
   const { data } = supabase.storage.from(BUCKET).getPublicUrl(path);
   return data.publicUrl;
 }
+
+export async function uploadProof(file: File, userId: string): Promise<string> {
+  const ext = file.name.split('.').pop() || 'dat';
+  const path = `${userId}/${crypto.randomUUID()}.${ext}`;
+  const { data, error } = await supabase.storage
+    .from('gcash-proofs')
+    .upload(path, file, {
+      upsert: false,
+      contentType: file.type || 'application/octet-stream',
+    });
+  if (error) throw error;
+  return data.path;
+}

--- a/pages/admin/billing.tsx
+++ b/pages/admin/billing.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import ProofCard from '@/components/billing/ProofCard';
+import { withAdminGuard } from '@/components/guards/withAdminGuard';
+import toast from '@/utils/toast';
+
+type Status = 'pending' | 'approved' | 'rejected';
+
+function AdminBillingPage() {
+  const supabase = createClientComponentClient();
+  const [status, setStatus] = useState<Status>('pending');
+  const [proofs, setProofs] = useState<any[]>([]);
+
+  async function load() {
+    const { data } = await supabase
+      .from('payment_proofs')
+      .select('*, profiles:profiles(email)')
+      .eq('status', status)
+      .order('created_at', { ascending: false });
+    setProofs(data || []);
+  }
+
+  useEffect(() => {
+    load();
+  }, [status]);
+
+  async function approve(p: any) {
+    const { error: gErr } = await supabase.rpc('grant_credits', {
+      p_user: p.user_id,
+      p_delta: p.credits,
+    });
+    if (gErr) {
+      toast.error('Failed to grant credits');
+      return;
+    }
+    const { error } = await supabase
+      .from('payment_proofs')
+      .update({
+        status: 'approved',
+        reviewed_at: new Date().toISOString(),
+      })
+      .eq('id', p.id);
+    if (error) toast.error('Update failed');
+    else toast.success('Approved');
+    load();
+  }
+
+  async function reject(p: any) {
+    const { error } = await supabase
+      .from('payment_proofs')
+      .update({
+        status: 'rejected',
+        reviewed_at: new Date().toISOString(),
+      })
+      .eq('id', p.id);
+    if (error) toast.error('Update failed');
+    else toast.success('Rejected');
+    load();
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Manual GCash Proofs</h1>
+      <div className="flex gap-4">
+        {(['pending', 'approved', 'rejected'] as Status[]).map((s) => (
+          <button
+            key={s}
+            className={`underline ${s === status ? 'font-bold' : ''}`}
+            onClick={() => setStatus(s)}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      {proofs.map((p) => (
+        <ProofCard key={p.id} proof={{ ...p, user_email: p.profiles?.email }}>
+          {status === 'pending' && (
+            <div className="flex gap-2">
+              <button
+                className="qg-btn qg-btn--primary"
+                onClick={() => approve(p)}
+              >
+                Approve
+              </button>
+              <button
+                className="qg-btn qg-btn--white"
+                onClick={() => reject(p)}
+              >
+                Reject
+              </button>
+            </div>
+          )}
+        </ProofCard>
+      ))}
+      {proofs.length === 0 && <p>No proofs.</p>}
+    </main>
+  );
+}
+
+export default withAdminGuard(AdminBillingPage);

--- a/pages/billing/history.tsx
+++ b/pages/billing/history.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import ProofCard from '@/components/billing/ProofCard';
+
+export default function BillingHistory() {
+  const supabase = createClientComponentClient();
+  const [proofs, setProofs] = useState<any[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase
+        .from('payment_proofs')
+        .select('*')
+        .order('created_at', { ascending: false });
+      setProofs(data || []);
+    })();
+  }, [supabase]);
+
+  return (
+    <main className="max-w-xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Payment History</h1>
+      {proofs.length === 0 && <p>No proofs yet.</p>}
+      {proofs.map((p) => (
+        <ProofCard key={p.id} proof={p} />
+      ))}
+    </main>
+  );
+}

--- a/pages/billing/manual-gcash.tsx
+++ b/pages/billing/manual-gcash.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { PRICE_PER_CREDIT, MAX_PROOF_SIZE_MB, ALLOWED_PROOF_TYPES } from '@/config/billing';
+import { uploadProof } from '@/lib/storage';
+
+export default function ManualGCashPage() {
+  const supabase = createClientComponentClient();
+  const [amount, setAmount] = useState('');
+  const [credits, setCredits] = useState(0);
+  const [file, setFile] = useState<File | null>(null);
+  const [note, setNote] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  function onAmountChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setAmount(v);
+    const num = Number(v || '0');
+    setCredits(Math.floor(num / PRICE_PER_CREDIT));
+  }
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0] || null;
+    if (f) {
+      if (!ALLOWED_PROOF_TYPES.includes(f.type)) {
+        setError('Invalid file type');
+        return;
+      }
+      if (f.size > MAX_PROOF_SIZE_MB * 1024 * 1024) {
+        setError('File too large');
+        return;
+      }
+    }
+    setError('');
+    setFile(f);
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file || credits < 1) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    const file_url = await uploadProof(file, user.id);
+    await supabase.from('payment_proofs').insert({
+      user_id: user.id,
+      amount: Number(amount),
+      credits,
+      file_url,
+      note: note || null,
+      status: 'pending',
+    });
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <main className="max-w-xl mx-auto p-6 space-y-4 text-center">
+        <p>Submitted for review</p>
+        <Link href="/billing/history" className="underline">
+          View history
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="max-w-xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Manual GCash Top-up</h1>
+      <p>Price per credit: ₱{PRICE_PER_CREDIT}</p>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <label className="block">
+          <span className="text-sm">Amount (₱)</span>
+          <input
+            type="number"
+            min="0"
+            value={amount}
+            onChange={onAmountChange}
+            className="input w-full"
+            required
+          />
+        </label>
+        <p>Credits: {credits}</p>
+        <label className="block">
+          <span className="text-sm">Upload proof</span>
+          <input type="file" accept={ALLOWED_PROOF_TYPES.join(',')} onChange={onFileChange} />
+        </label>
+        <label className="block">
+          <span className="text-sm">Note (optional)</span>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="input w-full"
+          />
+        </label>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="qg-btn qg-btn--primary"
+          disabled={!file || credits < 1}
+        >
+          Submit
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/supabase/migrations/20250902000000_manual_gcash.sql
+++ b/supabase/migrations/20250902000000_manual_gcash.sql
@@ -1,0 +1,50 @@
+-- payment proofs
+create table if not exists public.payment_proofs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  amount numeric(10,2) not null check (amount >= 0),
+  credits int not null check (credits >= 0),
+  file_url text not null,
+  note text,
+  status text not null default 'pending' check (status in ('pending','approved','rejected')),
+  created_at timestamptz not null default now(),
+  reviewed_by uuid references auth.users(id),
+  reviewed_at timestamptz
+);
+
+alter table public.payment_proofs enable row level security;
+
+-- users can create & read own proofs
+create policy "pp read own" on public.payment_proofs
+  for select using (auth.uid() = user_id);
+create policy "pp insert own" on public.payment_proofs
+  for insert with check (auth.uid() = user_id);
+
+-- admins can read/update all
+create policy "pp admin read" on public.payment_proofs
+  for select using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.role='admin'));
+create policy "pp admin update" on public.payment_proofs
+  for update using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.role='admin'));
+
+-- storage bucket for proofs
+insert into storage.buckets (id, name, public) values ('gcash-proofs','gcash-proofs', false)
+on conflict (id) do nothing;
+
+-- storage RLS
+create policy "users upload to own folder" on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'gcash-proofs'
+    and (auth.uid()::text || '/') = (split_part(name,'/',1) || '/')
+  );
+
+create policy "users read own proofs" on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'gcash-proofs'
+    and (auth.uid()::text || '/') = (split_part(name,'/',1) || '/')
+  );
+
+create policy "admins read all proofs" on storage.objects
+  for select to authenticated
+  using (bucket_id = 'gcash-proofs' and exists (select 1 from public.profiles p where p.id=auth.uid() and p.role='admin'));

--- a/tests/e2e/billing.spec.ts
+++ b/tests/e2e/billing.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers/session';
+
+const app = process.env.PLAYWRIGHT_APP_URL!;
+const supa = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+test('@full manual gcash flow', async ({ page }) => {
+  let employerCredits = 0;
+  const proofs: any[] = [];
+
+  await page.route(`${supa}/rest/v1/user_credits*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ credits: employerCredits }),
+      });
+    }
+  });
+  await page.route(`${supa}/rest/v1/rpc/grant_credits`, (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    employerCredits += body.p_delta || 0;
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(employerCredits),
+    });
+  });
+  await page.route(`${supa}/rest/v1/payment_proofs*`, (route) => {
+    const method = route.request().method();
+    if (method === 'POST') {
+      const body = JSON.parse(route.request().postData() || '{}');
+      const proof = {
+        id: 'proof1',
+        created_at: new Date().toISOString(),
+        status: 'pending',
+        ...body,
+      };
+      proofs.push(proof);
+      route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify([proof]),
+      });
+    } else if (method === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(proofs.filter((p) => !route.request().url().includes('status=eq.') || p.status === 'pending')),
+      });
+    } else if (method === 'PATCH') {
+      const url = new URL(route.request().url());
+      const id = url.searchParams.get('id')?.replace('eq.', '') || '';
+      const body = JSON.parse(route.request().postData() || '{}');
+      const idx = proofs.findIndex((p) => p.id === id);
+      proofs[idx] = { ...proofs[idx], ...body };
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([proofs[idx]]),
+      });
+    }
+  });
+  await page.route(`${supa}/storage/v1/object/gcash-proofs/*`, (route) => {
+    route.fulfill({ status: 200, body: '' });
+  });
+
+  await loginAs(page, 'employer');
+  await page.goto(`${app}/billing/manual-gcash`);
+  await page.fill('input[type=number]', '100');
+  await page.setInputFiles('input[type=file]', 'public/logo-icon.png');
+  await page.click('button[type=submit]');
+  await expect(page.getByText('Submitted for review')).toBeVisible();
+  await page.click('text=View history');
+  await expect(page.getByText('pending')).toBeVisible();
+
+  await loginAs(page, 'admin');
+  await page.goto(`${app}/admin/billing`);
+  await page.click('text=Approve');
+  await expect(page.getByText('No proofs')).toBeVisible();
+
+  await loginAs(page, 'employer');
+  await page.goto(app);
+  await expect(page.getByTestId('credits-pill')).toHaveText('Credits: 1');
+});


### PR DESCRIPTION
## Summary
- allow employers to upload GCash payment proofs and view history
- admins can review pending proofs and grant credits
- document manual GCash flow and add migration for payment proof storage

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`
- `npm run test:smoke` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install chromium` *(fails: Download failed 403)*
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68af1cc0a3b4832782d50785ddd042ea