### PR TITLE
feat: server-side credits gate for job posting

### DIFF
--- a/components/credits/CreditsGate.tsx
+++ b/components/credits/CreditsGate.tsx
@@ -1,0 +1,35 @@
+'use client';
+import Link from 'next/link';
+import { useState } from 'react';
+import { PRICE_PER_CREDIT } from '@/config/billing';
+
+export default function CreditsGate() {
+  const [loading] = useState(false);
+  return (
+    <div className="rounded-xl border p-4 bg-slate-50 dark:bg-slate-900">
+      <p className="mb-2">
+        You’re out of posting credits. Buy more to continue.
+      </p>
+      <p className="text-sm opacity-80 mb-4">
+        Current price: ₱{PRICE_PER_CREDIT} / credit
+      </p>
+      <div className="flex gap-3">
+        <Link
+          data-testid="buy-credits"
+          href="/billing/manual-gcash"
+          className="px-3 py-2 rounded-lg border shadow-sm"
+        >
+          Buy credits (GCash)
+        </Link>
+        <Link
+          href="/support"
+          className="px-3 py-2 rounded-lg border"
+        >
+          Contact support
+        </Link>
+      </div>
+      {loading && <div className="mt-3 text-sm">Checking account…</div>}
+    </div>
+  );
+}
+

--- a/components/jobs/NewJobForm.tsx
+++ b/components/jobs/NewJobForm.tsx
@@ -1,0 +1,70 @@
+'use client';
+import { useState } from 'react';
+
+export default function NewJobForm() {
+  const [title, setTitle] = useState('');
+  const [desc, setDesc] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [ok, setOk] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch('/api/jobs/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title, desc }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      setOk(true);
+    } catch (e: any) {
+      setErr(e.message || 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (ok) {
+    return (
+      <div className="rounded-lg border p-4">
+        ✅ Job posted! Your credits have been updated.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm mb-1">Title</label>
+        <input
+          data-testid="job-title"
+          className="w-full border rounded p-2"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Description</label>
+        <textarea
+          className="w-full border rounded p-2 min-h-[120px]"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+          required
+        />
+      </div>
+      <button
+        data-testid="job-submit"
+        disabled={busy}
+        className="px-4 py-2 rounded bg-black text-white"
+      >
+        {busy ? 'Posting…' : 'Post job'}
+      </button>
+      {err && <p className="text-red-600 text-sm">{err}</p>}
+    </form>
+  );
+}
+

--- a/lib/credits-server.ts
+++ b/lib/credits-server.ts
@@ -1,0 +1,32 @@
+import { cookies, headers } from 'next/headers';
+import { createServerClient } from '@supabase/auth-helpers-nextjs';
+
+export async function getServerSupabase() {
+  const cookieStore = cookies();
+  const hdrs = headers();
+  const url =
+    hdrs.get('x-forwarded-host') || hdrs.get('host') || 'localhost:3000';
+  const proto = hdrs.get('x-forwarded-proto') || 'http';
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (k) => cookieStore.get(k)?.value } }
+  );
+  const origin = `${proto}://${url}`;
+  return { supabase, origin };
+}
+
+export async function getSessionAndCredits() {
+  const { supabase } = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { user: null, credits: 0 } as const;
+  const { data } = await supabase
+    .from('user_credits')
+    .select('credits')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  return { user, credits: data?.credits ?? 0 } as const;
+}
+

--- a/pages/api/jobs/create.ts
+++ b/pages/api/jobs/create.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerClient } from '@supabase/auth-helpers-nextjs';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (k) => (req.cookies as any)[k] } }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return res.status(401).send('auth required');
+
+  const { title, desc } = (req.body || {}) as {
+    title?: string;
+    desc?: string;
+  };
+  if (!title) return res.status(400).send('title required');
+
+  const { error: insertErr } = await supabase.from('jobs').insert({
+    user_id: user.id,
+    title,
+    description: desc,
+  });
+  if (insertErr) return res.status(400).send(insertErr.message);
+
+  const { error: decErr } = await supabase.rpc('decrement_credit');
+  if (decErr) {
+    return res
+      .status(409)
+      .send(`posted but credit update failed: ${decErr.message}`);
+  }
+
+  return res.status(200).json({ ok: true });
+}
+

--- a/pages/jobs/new.tsx
+++ b/pages/jobs/new.tsx
@@ -1,30 +1,35 @@
-import { useRouter } from 'next/router';
-import GigForm from '@/components/gigs/GigForm';
-import { createGig } from '@/lib/gigs/api';
-import CreditsGate from '@/components/credits/Gate';
-import { consumeOneCredit } from '@/lib/credits';
-import { mutate } from 'swr';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getSessionAndCredits } from '@/lib/credits-server';
+import NewJobForm from '@/components/jobs/NewJobForm';
+import CreditsGate from '@/components/credits/CreditsGate';
 
-export default function NewJob() {
-  const router = useRouter();
+export default async function NewJobPage() {
+  const { user, credits } = await getSessionAndCredits();
+
+  if (!user) {
+    redirect('/auth');
+  }
+
+  if (credits <= 0) {
+    return (
+      <main className="max-w-2xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-semibold">You have 0 credits</h1>
+        <CreditsGate />
+        <div className="pt-4">
+          <Link className="underline" href="/">
+            Back to home
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
   return (
-    <main className="p-4">
-      <CreditsGate>
-        <GigForm
-          onSubmit={async (g) => {
-            const { data } = await createGig(g);
-            if (data) {
-              try {
-                await consumeOneCredit();
-                mutate('credits');
-              } catch {
-                // non-blocking
-              }
-              router.push(`/gigs/${data.id}`);
-            }
-          }}
-        />
-      </CreditsGate>
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Post a Job</h1>
+      <NewJobForm />
     </main>
   );
 }
+

--- a/tests/e2e/post-job.credits.spec.ts
+++ b/tests/e2e/post-job.credits.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers/session';
+import { qaPost } from '../utils/qa';
+
+const APP = process.env.PLAYWRIGHT_APP_URL || 'https://app.quickgig.ph';
+
+test.skip('[full-e2e] employer posts job with credits', async ({
+  page,
+  request,
+}) => {
+  const title = `Credits Job ${Date.now()}`;
+  const employer = { email: `employer+credits${Date.now()}@example.com` };
+
+  await qaPost(request, '/api/qa/users/upsert', {
+    email: employer.email,
+    role: 'employer',
+    tickets: 2,
+  });
+
+  await loginAs(page, 'employer');
+  await page.goto(`${APP}/jobs/new`);
+
+  await page.getByTestId('job-title').fill(title);
+  await page.getByLabel(/description/i).fill('Auto job description');
+  await page.getByTestId('job-submit').click();
+
+  await expect(
+    page.getByText(/job posted|credits have been updated/i)
+  ).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- add server utilities to retrieve session and credits
- gate `/jobs/new` on the server and render job form only when credits are available
- create API endpoint to post jobs and decrement credits
- add Playwright stub for posting jobs with credits

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx playwright test tests/e2e/post-job.credits.spec.ts` *(fails: Could not find a production build)*

------
https://chatgpt.com/codex/tasks/task_e_68afa795ebdc83279b393d915c8535bf