### PR TITLE
chore(devx): add Codex workflow automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+_What does this change do?_
+
+## Checklist
+- [ ] PR smoke green
+- [ ] Codex review ran (local or CI) and addressed comments
+- [ ] E2E (manual) run triggered if applicable
+- [ ] Docs updated (if needed)

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,17 @@
+name: Codex Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  codex-review:
+    if: ${{ secrets.CODEX_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm i -g @openai/codex
+      - name: Run Codex review
+        env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: codex review --config ./codex/config.json --github-annotate

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ supabase/.branches/
 **/*.jpg
 **/*.jpeg
 **/*.webp
+
+# codex
+.codex-cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# QuickGig + Codex workflow
+
+## Generate a feature PR (CLI)
+```bash
+# examples
+npm run codex:locations
+npm run codex:billing
+```
+
+Codex will:
+
+1. create a branch
+2. apply changes
+3. open a PR with description
+
+## Run automated review (local)
+
+```bash
+npm run codex:review
+```
+
+Or rely on CI if `CODEX_API_KEY` is configured.
+
+## IDE usage
+
+* Install Codex extension → you can run the same tasks or “Refactor with Codex” on selected files.
+
+## Quality gates
+
+* PR smoke must be ✅
+* Full E2E (manual) for flows that touch auth/billing/posting
+* Address Codex review comments before merge
+

--- a/codex/config.json
+++ b/codex/config.json
@@ -1,0 +1,17 @@
+{
+  "project": "QuickGig",
+  "defaultBranch": "main",
+  "review": {
+    "severity": ["security", "correctness", "types", "perf", "accessibility", "tests", "docs"],
+    "ignorePaths": ["**/playwright-report/**", "**/test-results/**", "public/**"]
+  },
+  "conventions": {
+    "branchPrefix": {
+      "feat": "feat/",
+      "fix": "fix/",
+      "chore": "chore/",
+      "docs": "docs/"
+    },
+    "commitStyle": "conventional"
+  }
+}

--- a/codex/tasks/credits_gate.md
+++ b/codex/tasks/credits_gate.md
@@ -1,0 +1,3 @@
+Title: Server-side credits gate for /jobs/new
+Constraints: redirect unauth -> /auth; gate on credits<=0; show form when >0; decrement on success.
+Acceptance: No blank screens; smoke green.

--- a/codex/tasks/e2e_reliability.md
+++ b/codex/tasks/e2e_reliability.md
@@ -1,0 +1,3 @@
+Title: Fix E2E reliability (stub auth, Node 20, artifact upload)
+Constraints: Do not modify PR smoke; only affect full E2E job. Keep secrets out of repo.
+Acceptance: Full E2E green; smoke unchanged.

--- a/codex/tasks/locations_cascade.md
+++ b/codex/tasks/locations_cascade.md
@@ -1,0 +1,3 @@
+Title: PH Region/Province/City cascades for Post Job
+Constraints: exhaustive lists, required validation, API verifies hierarchy.
+Acceptance: Cannot submit without complete selection; server rejects mismatches.

--- a/codex/tasks/manual_gcash.md
+++ b/codex/tasks/manual_gcash.md
@@ -1,0 +1,3 @@
+Title: Manual GCash top-up -> admin approve -> grant credits
+Constraints: secure RLS; proofs storage bucket; admin-only approve/reject.
+Acceptance: Pending->Approved increases credits; artifacts/tests pass.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,12 @@
     "test:release": "playwright test -c playwright.ci.ts --reporter=github,html",
     "autofix:ci": "tsx scripts/autofix.ts",
     "test:smoke": "playwright test --project=smoke",
-    "test:e2e": "playwright test --project=e2e"
+    "test:e2e": "playwright test --project=e2e",
+    "codex:pr": "codex run -p ./codex/tasks/credits_gate.md",
+    "codex:e2e": "codex run -p ./codex/tasks/e2e_reliability.md",
+    "codex:billing": "codex run -p ./codex/tasks/manual_gcash.md",
+    "codex:locations": "codex run -p ./codex/tasks/locations_cascade.md",
+    "codex:review": "codex review --config ./codex/config.json"
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.10.0",


### PR DESCRIPTION
## Summary
- add Codex config and reusable task prompts
- wire Codex scripts and optional review workflow
- document Codex-based contribution flow

## Testing
- `npm run lint`
- `npm run test:smoke` *(fails: Could not find a production build)*
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL env var required)*
- `npm run codex:review` *(fails: codex: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afab19b2d88327877c5945c1e7ebd0