### PR TITLE
feat(applications) worker apply flow + validation + E2E

### DIFF
--- a/components/jobs/ApplyForm.tsx
+++ b/components/jobs/ApplyForm.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useState } from 'react';
+import { useSubmitGuard } from '@/hooks/useSubmitGuard';
+
+export default function ApplyForm({ jobId }: { jobId: string }) {
+  const [message, setMessage] = useState('');
+  const [rate, setRate] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [serverError, setServerError] = useState('');
+  const { submitting, guard } = useSubmitGuard();
+
+  const validate = () => {
+    const field: Record<string, string> = {};
+    if (message.trim().length < 20) field.message = 'Message too short';
+    const r = Number(rate);
+    if (!r || r <= 0) field.expectedRate = 'Rate must be > 0';
+    return { field, r };
+  };
+
+  const isValid = message.trim().length >= 20 && Number(rate) > 0;
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    guard(async () => {
+      const { field, r } = validate();
+      setErrors(field);
+      if (Object.keys(field).length) return;
+      setServerError('');
+      const res = await fetch('/api/applications/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jobId, message: message.trim(), expectedRate: r }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        window.location.href = `/applications/${data.id}`;
+      } else {
+        const data = await res.json().catch(() => ({}));
+        if (data.error?.fields) setErrors(data.error.fields);
+        setServerError(data.error?.code || 'Failed to apply');
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      {serverError && (
+        <p className="text-sm text-red-600" aria-live="polite">
+          {serverError === 'JOB_CLOSED'
+            ? 'Applications closed'
+            : serverError === 'DUPLICATE_APPLICATION'
+            ? 'You already applied to this job'
+            : serverError}
+        </p>
+      )}
+      <div>
+        <label htmlFor="txt-message" className="block text-sm mb-1">
+          Message
+        </label>
+        <textarea
+          id="txt-message"
+          data-testid="txt-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          className="border p-2 w-full"
+          aria-invalid={!!errors.message}
+        />
+        {errors.message && (
+          <p className="text-sm text-red-600" aria-live="polite">
+            {errors.message}
+          </p>
+        )}
+      </div>
+      <div>
+        <label htmlFor="txt-rate" className="block text-sm mb-1">
+          Expected rate
+        </label>
+        <input
+          id="txt-rate"
+          type="number"
+          data-testid="txt-rate"
+          value={rate}
+          onChange={(e) => setRate(e.target.value)}
+          className="border p-2 w-full"
+          aria-invalid={!!errors.expectedRate}
+        />
+        {errors.expectedRate && (
+          <p className="text-sm text-red-600" aria-live="polite">
+            {errors.expectedRate}
+          </p>
+        )}
+      </div>
+      <button
+        type="submit"
+        data-testid="btn-apply"
+        className="px-4 py-2 bg-black text-white rounded disabled:opacity-50"
+        disabled={submitting || !isValid}
+      >
+        {submitting ? 'Applying…' : 'Apply'}
+      </button>
+    </form>
+  );
+}

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -1,14 +1,42 @@
-# Applications
+# Applications API
 
-Applications link a gig to an applicant. Row level security ensures only:
+Workers can apply to open jobs once.
 
-- the applicant
-- the gig owner
-- admins
+## Endpoint
 
-can view a given application and its thread.
+`POST /api/applications/create`
 
-Each application has a single messaging thread. When a message is sent, a row is
-inserted into `notifications` for the other participant with `type = 'message'`
-and a JSON payload containing the `application_id`, `thread_id` and a short
-`preview` of the body. A dedicated notifications UI will come later.
+### Request body
+
+```json
+{
+  "jobId": "<job uuid>",
+  "message": "<at least 20 characters>",
+  "expectedRate": 1000
+}
+```
+
+### Success response
+
+`201 Created`
+
+```json
+{ "id": "<application uuid>" }
+```
+
+### Error responses
+
+- `400 { "error": { "code": "VALIDATION_FAILED", "fields": { ... } } }`
+- `400 { "error": { "code": "JOB_CLOSED" } }`
+- `400 { "error": { "code": "DUPLICATE_APPLICATION" } }`
+- `401 { "error": { "code": "UNAUTHORIZED" } }`
+
+## Row Level Security
+
+- Workers may insert their own application if the job is open.
+- Workers can read their own applications.
+- Employers can read applications for their jobs.
+
+## Closing a job
+
+Set `is_closed` to `true` in the `jobs` table to prevent new applications.

--- a/pages/api/applications/create.ts
+++ b/pages/api/applications/create.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSupabase } from '@/lib/supabase-server';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const supabase = getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role_pref")
+    .eq("id", user.id)
+    .maybeSingle();
+  if (profile?.role_pref === "employer")
+    return res.status(403).json({ error: { code: "FORBIDDEN" } });
+
+  const { jobId, message, expectedRate } = req.body || {};
+  const fieldErrors: Record<string, string> = {};
+  if (typeof message !== 'string' || message.trim().length < 20)
+    fieldErrors.message = 'Message too short';
+  const rateNum = Number(expectedRate);
+  if (!rateNum || rateNum <= 0)
+    fieldErrors.expectedRate = 'Expected rate must be > 0';
+  if (!jobId || typeof jobId !== 'string') fieldErrors.jobId = 'Job required';
+  if (Object.keys(fieldErrors).length)
+    return res
+      .status(400)
+      .json({ error: { code: 'VALIDATION_FAILED', fields: fieldErrors } });
+
+  const { data: job } = await supabase
+    .from('jobs')
+    .select('id,is_closed')
+    .eq('id', jobId)
+    .maybeSingle();
+  if (!job || job.is_closed)
+    return res.status(400).json({ error: { code: 'JOB_CLOSED' } });
+
+  const { data: existing } = await supabase
+    .from('applications')
+    .select('id')
+    .eq('job_id', jobId)
+    .eq('worker_id', user.id)
+    .maybeSingle();
+  if (existing)
+    return res.status(400).json({ error: { code: 'DUPLICATE_APPLICATION' } });
+
+  const { data, error } = await supabase
+    .from('applications')
+    .insert({
+      job_id: jobId,
+      worker_id: user.id,
+      message: message.trim(),
+      expected_rate: rateNum,
+    })
+    .select('id')
+    .single();
+  if (error)
+    return res.status(400).json({ error: { code: 'DB_ERROR', message: error.message } });
+
+  res.status(201).json({ id: data.id });
+}

--- a/pages/applications/[id].tsx
+++ b/pages/applications/[id].tsx
@@ -1,111 +1,48 @@
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import useSWR from "swr";
-import ApplicationThread from "@/components/ApplicationThread";
-import MessageComposer from "@/components/MessageComposer";
-import { supabase } from "@/utils/supabaseClient";
-import { getOrCreateThread } from "@/utils/application";
-import { asNumber } from "@/lib/normalize";
-import Card from "@/components/ui/Card";
-import { getString } from "@/utils/getString";
+import type { GetServerSideProps } from 'next';
+import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 
-type ApplicationDetail = {
+interface AppDetail {
   id: string;
-  applicant: string;
-  applicant_profile?: { full_name?: string } | null;
-  gig?: {
-    id: string;
-    title: string;
-    owner: string;
-    owner_profile?: { full_name?: string } | null;
-  } | null;
+  job_id: string;
+  worker_id: string;
+  message: string;
+  expected_rate: number;
+  status: string;
+  job?: { title?: string } | null;
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const supabase = createPagesServerClient(ctx, {
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { redirect: { destination: '/auth', permanent: false } };
+  const id = ctx.params?.id as string;
+  const { data } = await supabase
+    .from('applications')
+    .select('id,job_id,worker_id,message,expected_rate,status,job:jobs(title)')
+    .eq('id', id)
+    .maybeSingle();
+  if (!data) return { notFound: true };
+  return { props: { app: data } };
 };
 
-export default function ApplicationPage() {
-  const router = useRouter();
-  const appId = getString(router.query.id);
-  const [threadId, setThreadId] = useState<number | null>(null);
-  const [user, setUser] = useState<any>(null);
-
-  useEffect(() => {
-    if (!appId) {
-      console.error("Missing application id; redirecting to /applications");
-      router.replace("/applications");
-    }
-  }, [appId, router]);
-
-  useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUser(data.user));
-  }, []);
-
-  const fetcher = async (_: string, id: string): Promise<ApplicationDetail> => {
-    const { data, error } = await supabase
-      .from("applications")
-      .select(
-        `
-      id,
-      applicant,
-      applicant_profile:profiles!applications_applicant_fkey(full_name),
-      gig:gigs(
-        id,
-        title,
-        owner,
-        owner_profile:profiles(full_name)
-      )
-    `,
-      )
-      .eq("id", id)
-      .single();
-    if (error) throw error;
-    return data as unknown as ApplicationDetail;
-  };
-
-  const { data, error, isLoading } = useSWR<ApplicationDetail>(
-    appId ? ["application-by-id", appId] : null,
-    fetcher,
-  );
-
-  const app =
-    data && Array.isArray((data as any).gig)
-      ? { ...data, gig: (data as any).gig[0] }
-      : data;
-
-  useEffect(() => {
-    if (!app?.id) return;
-    getOrCreateThread(app.id).then((th) => setThreadId(asNumber((th as any).id)));
-  }, [app]);
-
-  if (!appId) return <div data-testid="application-redirecting" />;
-  if (isLoading) return <div data-testid="application-loading">Loading…</div>;
-  if (error)
-    return (
-      <div data-testid="application-error">Failed to load application.</div>
-    );
-  if (!app)
-    return <div data-testid="application-empty">Application not found.</div>;
-
-  const ownerName =
-    app.gig?.owner_profile?.full_name ?? app.gig?.owner ?? "Owner";
-  const applicantName =
-    app.applicant_profile?.full_name ?? app.applicant ?? "Applicant";
-  const counterpart = user?.id === app.applicant ? ownerName : applicantName;
-
+export default function ApplicationDetail({ app }: { app: AppDetail }) {
   return (
-    <main data-testid="application-title">
-      <div className="mx-auto flex h-[80vh] max-w-3xl flex-col gap-4 p-4">
-        <p className="text-sm text-brand-subtle">
-          Applications / View application
-        </p>
-        <Card className="p-4 space-y-1">
-          <h1>{app.gig?.title}</h1>
-          <p className="text-sm text-brand-subtle">
-            Conversation with {counterpart}
-          </p>
-        </Card>
-        {threadId && <ApplicationThread threadId={threadId} />}
-        {threadId && user?.id && (
-          <MessageComposer threadId={String(threadId)} userId={user.id} />
-        )}
+    <main className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Application</h1>
+      <p className="text-sm">Job: {app.job?.title || app.job_id}</p>
+      <p>Status: <span className="inline-block rounded bg-gray-200 px-2 py-1 text-sm">{app.status}</span></p>
+      <div>
+        <h2 className="font-semibold">Message</h2>
+        <p>{app.message}</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">Expected rate</h2>
+        <p>{app.expected_rate}</p>
       </div>
     </main>
   );

--- a/pages/jobs/[id].tsx
+++ b/pages/jobs/[id].tsx
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import ApplyForm from '@/components/jobs/ApplyForm';
+import { supabase } from '@/utils/supabaseClient';
+import { getRolePref } from '@/lib/rolePref';
+import { getString } from '@/utils/getString';
+
+export default function JobDetail() {
+  const router = useRouter();
+  const id = getString(router.query.id);
+  const [job, setJob] = useState<any>(null);
+  const [user, setUser] = useState<any>(null);
+  const [role, setRole] = useState<'worker' | 'employer' | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    supabase
+      .from('jobs')
+      .select('id,title,description,owner_id,is_closed')
+      .eq('id', id)
+      .maybeSingle()
+      .then(({ data }) => setJob(data));
+  }, [id]);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(async ({ data }) => {
+      setUser(data.user);
+      if (data.user) {
+        const r = await getRolePref(data.user.id);
+        setRole(r);
+      }
+    });
+  }, []);
+
+  if (!job) return <p>Loading...</p>;
+
+  const isOwner = user?.id === job.owner_id;
+  const isClosed = job.is_closed;
+  const canApply = user && role === 'worker' && !isOwner && !isClosed;
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">{job.title}</h1>
+      <p>{job.description}</p>
+      {isClosed && (
+        <p className="text-red-600" aria-live="polite">
+          Applications closed
+        </p>
+      )}
+      {!user && (
+        <p>
+          <Link href={`/auth?next=/jobs/${id}`}>Log in</Link> to apply.
+        </p>
+      )}
+      {canApply && <ApplyForm jobId={job.id} />}
+    </main>
+  );
+}

--- a/supabase/migrations/20250903000000_applications.sql
+++ b/supabase/migrations/20250903000000_applications.sql
@@ -1,0 +1,40 @@
+create table if not exists public.applications (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.jobs(id) on delete cascade,
+  worker_id uuid not null references public.profiles(id) on delete restrict,
+  message text not null,
+  expected_rate numeric not null check (expected_rate > 0),
+  status text not null default 'submitted' check (status in ('submitted','withdrawn','declined','accepted')),
+  created_at timestamptz not null default now(),
+  unique (job_id, worker_id)
+);
+
+alter table public.applications enable row level security;
+
+-- Workers can insert their own application if job is open
+create policy "worker can insert own application"
+on public.applications for insert
+ to authenticated
+ with check (
+  auth.uid() = worker_id
+  and exists (
+    select 1 from public.jobs j
+    where j.id = job_id and coalesce(j.is_closed, false) = false
+  )
+);
+
+-- Workers can read their own apps; employers can read apps to their jobs
+create policy "worker read own applications"
+on public.applications for select
+ to authenticated
+ using (auth.uid() = worker_id);
+
+create policy "employer read apps for their jobs"
+on public.applications for select
+ to authenticated
+ using (exists (
+  select 1 from public.jobs j
+  where j.id = job_id and j.owner_id = auth.uid()
+));
+
+alter table public.jobs add column if not exists is_closed boolean not null default false;

--- a/tests/e2e/applications.spec.ts
+++ b/tests/e2e/applications.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers/session';
+
+const app = process.env.PLAYWRIGHT_APP_URL!;
+const supa = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+test('@full worker apply happy path and credits isolation', async ({ page }) => {
+  await loginAs(page, 'worker');
+  const job = {
+    id: 'job-1',
+    title: 'Open Job',
+    description: 'Job desc',
+    owner_id: 'employer-1',
+    is_closed: false,
+  };
+  await page.route(`${supa}/rest/v1/jobs*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([job]),
+      });
+    }
+  });
+  await page.route('/api/applications/create', (route) => {
+    route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'app-1' }),
+    });
+  });
+  await page.route(`${supa}/rest/v1/applications*`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'app-1',
+          job_id: 'job-1',
+          worker_id: 'worker-1',
+          message: 'This is a long message for testing.',
+          expected_rate: 123,
+          status: 'submitted',
+          jobs: { title: 'Open Job' },
+        },
+      ]),
+    });
+  });
+  let credits = 5;
+  await page.route(`${supa}/rest/v1/user_credits*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ credits }),
+      });
+    }
+  });
+
+  await page.goto(`${app}/jobs/job-1`);
+  await page.fill('[data-testid=txt-message]', 'This is a long message for testing.');
+  await page.fill('[data-testid=txt-rate]', '123');
+  await page.getByTestId('btn-apply').click();
+  await expect(page).toHaveURL(`${app}/applications/app-1`);
+  await expect(page.getByText('Application')).toBeVisible();
+
+  // credits unchanged after application
+  await loginAs(page, 'employer');
+  await page.goto(app);
+  await expect(page.getByTestId('credits-pill')).toHaveText('Credits: 5');
+});
+
+test('@full duplicate application blocked', async ({ page }) => {
+  await loginAs(page, 'worker');
+  const job = {
+    id: 'job-1',
+    title: 'Open Job',
+    description: 'Job desc',
+    owner_id: 'employer-1',
+    is_closed: false,
+  };
+  await page.route(`${supa}/rest/v1/jobs*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([job]),
+      });
+    }
+  });
+  await page.route('/api/applications/create', (route) => {
+    route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: { code: 'DUPLICATE_APPLICATION' } }),
+    });
+  });
+  await page.goto(`${app}/jobs/job-1`);
+  await page.fill('[data-testid=txt-message]', 'This is a long message for testing.');
+  await page.fill('[data-testid=txt-rate]', '123');
+  await page.getByTestId('btn-apply').click();
+  await expect(page.getByText('You already applied to this job')).toBeVisible();
+});
+
+test('@full validation errors on apply form', async ({ page }) => {
+  await loginAs(page, 'worker');
+  const job = {
+    id: 'job-1',
+    title: 'Open Job',
+    description: 'Job desc',
+    owner_id: 'employer-1',
+    is_closed: false,
+  };
+  await page.route(`${supa}/rest/v1/jobs*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([job]),
+      });
+    }
+  });
+  await page.goto(`${app}/jobs/job-1`);
+  await page.fill('[data-testid=txt-message]', 'short');
+  await page.fill('[data-testid=txt-rate]', '0');
+  await page.getByTestId('btn-apply').click();
+  await expect(page.getByText('Message too short')).toBeVisible();
+  await expect(page.getByText('Rate must be > 0')).toBeVisible();
+});
+
+test('@full closed job blocks applications', async ({ page }) => {
+  await loginAs(page, 'worker');
+  const job = {
+    id: 'job-2',
+    title: 'Closed Job',
+    description: 'Job desc',
+    owner_id: 'employer-1',
+    is_closed: true,
+  };
+  await page.route(`${supa}/rest/v1/jobs*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([job]),
+      });
+    }
+  });
+  await page.goto(`${app}/jobs/job-2`);
+  await expect(page.getByText('Applications closed')).toBeVisible();
+  await expect(page.locator('[data-testid=btn-apply]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add applications table with RLS and job close flag
- implement worker application API endpoint with validation
- UI apply form, job detail & application detail pages
- document application API and add e2e coverage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run test:smoke` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68afb63cd8cc83278ba8e5106a28d733