### PR TITLE
feat(messages): threaded chat on applications

### DIFF
--- a/components/messages/MessageInput.tsx
+++ b/components/messages/MessageInput.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+export default function MessageInput({ applicationId }: { applicationId: string }) {
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const send = async () => {
+    const body = text.trim();
+    if (body.length < 1 || body.length > 4000) return;
+    setSending(true);
+    await fetch('/api/messages/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, body }),
+    });
+    setSending(false);
+    setText('');
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (!sending) send();
+    }
+  };
+
+  return (
+    <div className="mt-2 flex gap-2">
+      <textarea
+        className="flex-1 border rounded p-2"
+        rows={2}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={onKeyDown}
+        disabled={sending}
+        data-testid="msg-input"
+      />
+      <button
+        onClick={send}
+        disabled={sending}
+        className="px-3 py-2 bg-brand-accent text-white rounded"
+        data-testid="btn-send"
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/components/messages/Thread.tsx
+++ b/components/messages/Thread.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+import { supabase } from '@/utils/supabaseClient';
+import { timeAgo } from '@/utils/time';
+
+interface Message {
+  id: string;
+  application_id: string;
+  sender_id: string;
+  body: string;
+  created_at: string;
+}
+
+export default function Thread({ applicationId }: { applicationId: string }) {
+  const [items, setItems] = useState<Message[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [uid, setUid] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUid(data.user?.id || null));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const res = await fetch(
+        `/api/messages/history?applicationId=${applicationId}&limit=30`,
+      );
+      const json = await res.json();
+      if (!cancelled) {
+        setItems(json.items || []);
+        if (json.items?.length) setCursor(json.items[0].created_at);
+        listRef.current?.scrollTo(0, listRef.current.scrollHeight);
+      }
+    };
+    load();
+    const ch = supabase
+      .channel(`messages:${applicationId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'messages',
+          filter: `application_id=eq.${applicationId}`,
+        },
+        (payload) => {
+          setItems((prev) => [...prev, payload.new as Message]);
+          const m = payload.new as Message;
+          if (m.sender_id === uid) {
+            setTimeout(
+              () => listRef.current?.scrollTo(0, listRef.current!.scrollHeight),
+              0,
+            );
+          } else if (uid) {
+            supabase
+              .from('notifications')
+              .update({ read: true })
+              .eq('user_id', uid)
+              .eq('link', `/applications/${applicationId}`);
+          }
+        },
+      )
+      .subscribe();
+    return () => {
+      cancelled = true;
+      supabase.removeChannel(ch);
+    };
+  }, [applicationId, uid]);
+
+  const loadOlder = async () => {
+    if (!cursor) return;
+    const res = await fetch(
+      `/api/messages/history?applicationId=${applicationId}&cursor=${encodeURIComponent(
+        cursor,
+      )}&limit=30`,
+    );
+    const json = await res.json();
+    if (json.items?.length) {
+      setItems((prev) => [...json.items, ...prev]);
+      setCursor(json.items[0].created_at);
+    }
+  };
+
+  useEffect(() => {
+    if (!uid) return;
+    supabase
+      .from('notifications')
+      .update({ read: true })
+      .eq('user_id', uid)
+      .eq('link', `/applications/${applicationId}`);
+  }, [uid, applicationId]);
+
+  return (
+    <div className="space-y-2">
+      {cursor && (
+        <button
+          onClick={loadOlder}
+          className="text-sm underline"
+          data-testid="btn-load-older"
+        >
+          Load older
+        </button>
+      )}
+      <div
+        ref={listRef}
+        className="flex flex-col gap-2 max-h-80 overflow-y-auto"
+      >
+        {items.map((m) => {
+          const mine = uid === m.sender_id;
+          return (
+            <div
+              key={m.id}
+              data-testid="msg-bubble"
+              className={`flex flex-col ${mine ? 'items-end' : 'items-start'}`}
+            >
+              <div
+                className={`px-3 py-2 rounded-2xl max-w-[80%] ${
+                  mine
+                    ? 'bg-brand-accent text-white'
+                    : 'bg-brand-surface text-brand'
+                }`}
+              >
+                {m.body}
+              </div>
+              <div className="text-xs text-brand-subtle">
+                {timeAgo(m.created_at)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -1,0 +1,35 @@
+# Messaging
+
+## Schema
+
+- `messages`
+  - `id` UUID primary key
+  - `application_id` references `applications.id`
+  - `sender_id` references `profiles.id`
+  - `body` text 1-4000 chars
+  - `created_at` timestamp
+- Optional `message_reads` for read receipts
+
+## Row Level Security
+
+Only the worker and employer involved in the application may select or insert messages.
+Policies enforce `auth.uid()` matches either the worker or the job's employer.
+
+## Realtime
+
+Subscribe to the channel `messages:<applicationId>` using Supabase Realtime:
+
+```
+supabase.channel(`messages:${applicationId}`)
+  .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages', filter: `application_id=eq.${applicationId}` }, handler)
+  .subscribe();
+```
+
+## Notifications
+
+Each new message inserts a notification for the other participant with type `message_new` and a link to `/applications/<id>`.
+The navbar listens for notification inserts and shows an unread badge.
+
+## Rate limiting
+
+Message sends are limited to 15 per user per minute. Exceeding the limit returns `RATE_LIMITED`.

--- a/pages/api/messages/create.ts
+++ b/pages/api/messages/create.ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSupabase } from '@/lib/supabase-server';
+
+const WINDOW_MS = 60 * 1000;
+const LIMIT = 15;
+const hits: Record<string, number[]> = {};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const supabase = getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+
+  const { applicationId, body } = req.body || {};
+  const fieldErrors: Record<string, string> = {};
+  if (!applicationId || typeof applicationId !== 'string')
+    fieldErrors.applicationId = 'applicationId required';
+  const text = typeof body === 'string' ? body.trim() : '';
+  if (text.length < 1 || text.length > 4000)
+    fieldErrors.body = 'Message length 1-4000';
+  if (Object.keys(fieldErrors).length)
+    return res
+      .status(400)
+      .json({ error: { code: 'VALIDATION_FAILED', fields: fieldErrors } });
+
+  const now = Date.now();
+  const arr = hits[user.id] || (hits[user.id] = []);
+  while (arr.length && now - arr[0] > WINDOW_MS) arr.shift();
+  if (arr.length >= LIMIT)
+    return res.status(429).json({ error: { code: 'RATE_LIMITED' } });
+  arr.push(now);
+
+  const { data, error } = await supabase
+    .from('messages')
+    .insert({
+      application_id: applicationId,
+      sender_id: user.id,
+      body: text,
+    })
+    .select('id')
+    .single();
+  if (error)
+    return res.status(400).json({ error: { code: 'DB_ERROR', message: error.message } });
+  const msgId = data.id;
+
+  const { data: app } = await supabase
+    .from('applications')
+    .select('worker_id, job:jobs(title,employer_id)')
+    .eq('id', applicationId)
+    .maybeSingle();
+  const other =
+    app?.worker_id === user.id ? app?.job?.employer_id : app?.worker_id;
+  if (other) {
+    await supabase.from('notifications').insert({
+      user_id: other,
+      type: 'message_new',
+      title: `New message about ${app?.job?.title || 'a job'}`,
+      body: text.slice(0, 80),
+      link: `/applications/${applicationId}`,
+    });
+  }
+
+  res.status(201).json({ id: msgId });
+}

--- a/pages/api/messages/history.ts
+++ b/pages/api/messages/history.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSupabase } from '@/lib/supabase-server';
+import { asString } from '@/lib/normalize';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const supabase = getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+
+  const applicationId = asString(req.query.applicationId);
+  const cursor = asString(req.query.cursor);
+  const limit = Number(asString(req.query.limit)) || 30;
+  if (!applicationId)
+    return res.status(400).json({ error: { code: 'APPLICATION_REQUIRED' } });
+
+  let query = supabase
+    .from('messages')
+    .select('*')
+    .eq('application_id', applicationId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (cursor) query = query.lt('created_at', cursor);
+  const { data, error } = await query;
+  if (error)
+    return res.status(400).json({ error: { code: 'DB_ERROR', message: error.message } });
+
+  res.json({ items: (data || []).reverse() });
+}

--- a/supabase/migrations/20250905000000_messages.sql
+++ b/supabase/migrations/20250905000000_messages.sql
@@ -1,0 +1,53 @@
+-- Messages table
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  application_id uuid not null references public.applications(id) on delete cascade,
+  sender_id uuid not null references public.profiles(id) on delete restrict,
+  body text not null check (char_length(body) >= 1 and char_length(body) <= 4000),
+  created_at timestamptz not null default now()
+);
+
+alter table public.messages enable row level security;
+
+-- RLS: only participants of the application can read/send messages
+create policy "participants can select messages"
+on public.messages for select
+to authenticated
+using (
+  exists (
+    select 1 from public.applications a
+    join public.jobs j on j.id = a.job_id
+    where a.id = application_id
+      and (a.worker_id = auth.uid() or j.employer_id = auth.uid())
+  )
+);
+
+create policy "participants can insert messages"
+on public.messages for insert
+to authenticated
+with check (
+  sender_id = auth.uid() and exists (
+    select 1 from public.applications a
+    join public.jobs j on j.id = a.job_id
+    where a.id = application_id
+      and (a.worker_id = auth.uid() or j.employer_id = auth.uid())
+  )
+);
+
+-- Optional: lightweight read receipts table (future-ready; not required in UI yet)
+create table if not exists public.message_reads (
+  message_id uuid references public.messages(id) on delete cascade,
+  user_id uuid references public.profiles(id) on delete cascade,
+  read_at timestamptz not null default now(),
+  primary key (message_id, user_id)
+);
+alter table public.message_reads enable row level security;
+create policy "participants update reads" on public.message_reads
+  for insert to authenticated
+  with check (exists (
+    select 1 from public.messages m
+    join public.applications a on a.id = m.application_id
+    join public.jobs j on j.id = a.job_id
+    where m.id = message_id
+      and (a.worker_id = auth.uid() or j.employer_id = auth.uid())
+  ));

--- a/tests/e2e/messages.spec.ts
+++ b/tests/e2e/messages.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers/session';
+
+const app = process.env.PLAYWRIGHT_APP_URL!;
+const supa = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+test('@full worker can send message', async ({ page }) => {
+  await loginAs(page, 'worker');
+  await page.route(`${supa}/rest/v1/applications*`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'app-1',
+          job_id: 'job-1',
+          worker_id: 'worker-1',
+          status: 'accepted',
+          job: { title: 'Job', employer_id: 'employer-1' },
+        },
+      ]),
+    });
+  });
+  await page.route(`${supa}/rest/v1/profiles*`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 'employer-1', full_name: 'Employer' }]),
+    });
+  });
+  await page.route('**/api/messages/history?*', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) });
+  });
+  let body: any = null;
+  await page.route('**/api/messages/create', (route) => {
+    body = JSON.parse(route.request().postData() || '{}');
+    route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'm1' }) });
+  });
+  await page.goto(`${app}/applications/app-1`);
+  await page.fill('[data-testid=msg-input]', 'Hello there');
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('msg-bubble')).toContainText('Hello there');
+  expect(body.body).toBe('Hello there');
+});
+


### PR DESCRIPTION
## Summary
- add `messages` table and RLS policies
- support posting and fetching messages with notifications and rate limits
- wire application page with realtime chat thread and input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afbf8932e08327982b84085c91f25a