### PR TITLE
chore: enable codex auto-fix for PR failures

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -1,0 +1,88 @@
+name: Codex Auto-Fix (PR failures)
+
+on:
+  workflow_run:
+    workflows:
+      - Release Check (PR smoke)
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  nudge-codex:
+    if: >
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Derive PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const { data: prs } = await github.request('GET /repos/{owner}/{repo}/pulls', {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100
+            });
+            const pr = prs.find(p => p.head && p.head.sha === run.head_sha);
+            if (!pr) { core.setFailed('PR not found for this run'); return; }
+            core.setOutput('number', pr.number);
+            core.setOutput('sha', run.head_sha);
+
+      - name: Avoid duplicate comments
+        id: dup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = core.getInput('number', { required: true });
+            const { data: comments } = await github.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: Number(number), per_page: 100
+            });
+            const exists = comments.some(c =>
+              c.user.type === 'Bot' &&
+              (c.body || '').includes('<!-- codex-auto-fix -->') &&
+              (c.body || '').includes(context.payload.workflow_run.id.toString())
+            );
+            core.setOutput('exists', exists ? 'true' : 'false');
+          result-encoding: string
+          number: ${{ steps.pr.outputs.number }}
+
+      - name: Ensure `codex` label on PR
+        if: steps.dup.outputs.exists != 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: codex
+          number: ${{ steps.pr.outputs.number }}
+
+      - name: Post Codex fix request comment
+        if: steps.dup.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          SHA="${{ steps.pr.outputs.sha }}"
+          cat > body.txt <<EOF
+          <!-- codex-auto-fix -->
+          @codex please fix failing checks for this PR.
+
+          **Context**
+          - Workflow: Release Check (PR smoke)
+          - Failed run: ${RUN_URL}
+          - Head SHA: ${SHA}
+
+          **What to fix**
+          - Make failing jobs pass (build / smoke) without disabling tests.
+          - Keep PR scope minimal; prefer type-safe fixes.
+          - If TypeScript error includes `Property 'employer_id' does not exist` in `/pages/api/messages/create.ts`,
+            switch `.maybeSingle()` to `.single()` or split the query (applications → job) to avoid array typing.
+
+          When done, push a patch to this same PR and re-run checks.
+          EOF
+          gh pr comment "$PR_NUM" --body-file body.txt

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -26,6 +26,14 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run build
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            .next/**/*.html
+            **/playwright-report/**
 
   e2e_smoke:
     needs: build
@@ -47,9 +55,11 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npm run test:smoke
-      - name: Upload smoke report
+      - name: Upload smoke artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-smoke
-          path: playwright-report/**
+          name: smoke-artifacts
+          path: |
+            test-results/**
+            playwright-report/**


### PR DESCRIPTION
## Summary
* Enabled “self-healing PR mode” by wiring Codex into CI.
* Now, failed PRs will automatically trigger a Codex fix request with context, logs, and links.
* Artifacts from failing runs are uploaded for debugging.

## Testing
* [ ] Open a PR with a deliberate TypeScript error → see failing checks
* [ ] Confirm Codex auto-fix comment is added once
* [ ] Verify `codex` label is present on the PR


------
https://chatgpt.com/codex/tasks/task_e_68afc50d1afc8327833533e31136089e