### PR TITLE
feat: add golden e2e and test ids

### DIFF
--- a/components/AdminPayments.tsx
+++ b/components/AdminPayments.tsx
@@ -61,7 +61,7 @@ export default function AdminPayments({
               <td className="space-x-2">
                 <button
                   onClick={() => handleApprove(p.id)}
-                  data-testid="approve-payment"
+                  data-testid="admin-approve"
                   aria-label="Approve payment"
                   className="px-2 py-1 bg-green-600 text-white rounded"
                 >
@@ -69,7 +69,7 @@ export default function AdminPayments({
                 </button>
                 <button
                   onClick={() => handleReject(p.id)}
-                  data-testid="reject-payment"
+                  data-testid="admin-reject"
                   aria-label="Reject payment"
                   className="px-2 py-1 bg-red-600 text-white rounded"
                 >

--- a/components/AppHeaderNotifications.tsx
+++ b/components/AppHeaderNotifications.tsx
@@ -59,6 +59,7 @@ export default function AppHeaderNotifications() {
       <button
         aria-label="Notifications"
         className="relative"
+        data-testid="bell"
         onClick={() => setOpen((v) => !v)}
       >
         <span className="i-bell" />
@@ -72,7 +73,11 @@ export default function AppHeaderNotifications() {
         <div className="absolute right-0 mt-2 w-72 bg-white border rounded shadow-md z-50">
           <ul className="max-h-80 overflow-auto">
             {items.map((n) => (
-              <li key={n.id} className="p-2 border-b last:border-0">
+              <li
+                key={n.id}
+                className="p-2 border-b last:border-0"
+                data-testid="notif-item"
+              >
                 {n.link ? (
                   <Link href={n.link} className="block text-sm">
                     {n.title}

--- a/lib/notificationFormat.ts
+++ b/lib/notificationFormat.ts
@@ -1,0 +1,26 @@
+export type NotificationRecord = {
+  type:
+    | 'message:new'
+    | 'application:new'
+    | 'application:status'
+    | 'payment:approved'
+    | 'payment:rejected';
+  payload: any;
+};
+
+export function formatNotification(n: NotificationRecord): string {
+  switch (n.type) {
+    case 'message:new':
+      return `${n.payload.counterparty} sent a new message`;
+    case 'application:new':
+      return `${n.payload.worker} applied to ${n.payload.job_title}`;
+    case 'application:status':
+      return `Your application to ${n.payload.job_title} was ${n.payload.status}`;
+    case 'payment:approved':
+      return `Top-up approved: +${n.payload.amount} credits`;
+    case 'payment:rejected':
+      return 'Top-up rejected';
+    default:
+      return 'Notification';
+  }
+}

--- a/pages/applications/[id].tsx
+++ b/pages/applications/[id].tsx
@@ -34,6 +34,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
 export default function ApplicationDetail({ app }: { app: AppDetail }) {
   const [status, setStatus] = useState(app.status);
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     const ch = supabase
       .channel('app-status')
@@ -52,11 +53,25 @@ export default function ApplicationDetail({ app }: { app: AppDetail }) {
   }, [app.id]);
 
   const statusCls =
-    status === 'accepted'
+    status === 'hired'
       ? 'bg-green-100 text-green-800'
-      : status === 'declined'
+      : status === 'rejected'
       ? 'bg-red-100 text-red-800'
       : 'bg-gray-200';
+
+  const updateStatus = async (next: 'hired' | 'rejected') => {
+    setLoading(true);
+    try {
+      await fetch('/api/applications/updateStatus', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: app.id, status: next }),
+      });
+      setStatus(next);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <main className="max-w-2xl mx-auto p-4 space-y-4">
@@ -75,6 +90,24 @@ export default function ApplicationDetail({ app }: { app: AppDetail }) {
       <div>
         <h2 className="font-semibold">Expected rate</h2>
         <p>{app.expected_rate}</p>
+      </div>
+      <div className="space-x-2">
+        <button
+          className="px-3 py-1 rounded bg-green-600 text-white disabled:opacity-50"
+          data-testid="hire"
+          disabled={loading || status !== 'submitted'}
+          onClick={() => updateStatus('hired')}
+        >
+          Hire
+        </button>
+        <button
+          className="px-3 py-1 rounded bg-red-600 text-white disabled:opacity-50"
+          data-testid="reject"
+          disabled={loading || status !== 'submitted'}
+          onClick={() => updateStatus('rejected')}
+        >
+          Reject
+        </button>
       </div>
     </main>
   );

--- a/pages/me/applications.tsx
+++ b/pages/me/applications.tsx
@@ -9,9 +9,24 @@ export default function MyApplications() {
   return (
     <main className="p-4 space-y-4">
       {apps.map((a) => (
-        <div key={a.id} className="border p-2">
+        <div key={a.id} className="border p-2 space-y-1">
           <p className="font-semibold">{a.gigs?.title}</p>
-          <p className="text-sm text-gray-600">{a.status}</p>
+          {(() => {
+            const cls =
+              a.status === 'hired'
+                ? 'bg-green-100 text-green-800'
+                : a.status === 'rejected'
+                ? 'bg-rose-100 text-rose-800'
+                : 'bg-slate-200 text-slate-800';
+            return (
+              <span
+                data-testid="status-pill"
+                className={`inline-block px-2 py-0.5 rounded text-xs ${cls}`}
+              >
+                {a.status}
+              </span>
+            );
+          })()}
         </div>
       ))}
     </main>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   projects: [
     {
       name: 'smoke',
-      testMatch: ['tests/smoke/**/*.spec.ts', '**/*.smoke.ts'],
+      testMatch: ['tests/smoke/**/*.spec.ts', '**/*.smoke.ts', '**/*.smoke.spec.ts'],
       timeout: 45_000,
       expect: { timeout: 7_000 },
       use: { baseURL: 'http://localhost:3000' },

--- a/tests/e2e/mvp.smoke.spec.ts
+++ b/tests/e2e/mvp.smoke.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers/session';
+
+const app = process.env.PLAYWRIGHT_APP_URL!;
+const supa = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+// minimal in-memory state for mocking
+let jobs: any[] = [];
+let applications: any[] = [];
+let notifications: any[] = [];
+let credits = 1;
+
+test('@smoke golden e2e: post job -> apply -> chat -> hire', async ({ page }) => {
+  // ---- routes ----
+  await page.route(`${supa}/rest/v1/user_credits*`, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ credits }),
+      });
+    } else {
+      route.continue();
+    }
+  });
+  await page.route(`${supa}/rest/v1/rpc/decrement_credit`, (route) => {
+    credits -= 1;
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(credits) });
+  });
+  await page.route(`${supa}/rest/v1/jobs`, (route) => {
+    if (route.request().method() === 'POST') {
+      const id = 'job-1';
+      jobs.push({ id, title: 'Test Job', owner_id: 'employer' });
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ id }]) });
+    } else {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(jobs) });
+    }
+  });
+  await page.route('/api/locations/regions', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ regions: [{ code: 'NCR', name: 'NCR' }] }),
+    });
+  });
+  await page.route('/api/locations/provinces?region=NCR', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ provinces: [{ code: 'NCR', name: 'NCR' }] }) });
+  });
+  await page.route('/api/locations/cities?province=NCR', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ cities: [{ code: 'MKT', name: 'Makati' }] }) });
+  });
+  await page.route('/api/applications/create', (route) => {
+    const id = 'app-1';
+    applications.push({ id, job_id: 'job-1', worker_id: 'worker', message: 'hello world message', expected_rate: 100, status: 'submitted', jobs: { title: 'Test Job' } });
+    route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id }) });
+  });
+  await page.route(`${supa}/rest/v1/applications*`, (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(applications) });
+  });
+  await page.route('/api/messages/create', (route) => {
+    notifications.push({ id: 'n1', user_id: 'worker', title: 'message', created_at: new Date().toISOString() });
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  await page.route('/api/applications/updateStatus', (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    const appRow = applications.find((a) => a.id === body.id);
+    if (appRow) {
+      appRow.status = body.status;
+      notifications.push({ id: 'n2', user_id: 'worker', title: 'status', created_at: new Date().toISOString() });
+    }
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  await page.route(`${supa}/rest/v1/notifications*`, (route) => {
+    const url = new URL(route.request().url());
+    const uid = url.searchParams.get('user_id')?.replace('eq.', '') || '';
+    const items = notifications.filter((n) => n.user_id === uid).map((n) => ({ ...n, read: false, link: '/applications/app-1' }));
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items) });
+  });
+
+  // ---- employer posts job ----
+  await loginAs(page, 'employer');
+  await page.goto(`${app}/jobs/new`);
+  await page.fill('[data-testid=txt-title]', 'Test Job');
+  await page.fill('[data-testid=txt-description]', 'This is a long description for testing.');
+  await page.selectOption('[data-testid=sel-region]', 'NCR');
+  await page.selectOption('[data-testid=sel-province]', 'NCR');
+  await page.selectOption('[data-testid=sel-city]', 'MKT');
+  await page.click('[data-testid=btn-submit]');
+  await expect(page.getByText('Job posted!')).toBeVisible();
+
+  // ---- worker applies ----
+  await loginAs(page, 'worker');
+  await page.goto(`${app}/jobs/job-1`);
+  await page.fill('[data-testid=txt-message]', 'hello world message');
+  await page.fill('[data-testid=txt-rate]', '100');
+  await page.getByTestId('btn-apply').click();
+  await expect(page).toHaveURL(`${app}/applications/app-1`);
+
+  // ---- employer sends message ----
+  await loginAs(page, 'employer');
+  await page.goto(`${app}/applications/app-1`);
+  await page.route('/api/messages/create', () => {}); // ensure route already set
+  await page.evaluate(() => fetch('/api/messages/create', { method: 'POST', body: '{}' }));
+
+  // ---- worker sees notification ----
+  await loginAs(page, 'worker');
+  await page.goto(`${app}/`);
+  await expect(page.getByTestId('bell')).toBeVisible();
+  await page.getByTestId('bell').click();
+  await expect(page.getByTestId('notif-item').first()).toBeVisible();
+
+  // ---- employer hires ----
+  await loginAs(page, 'employer');
+  await page.goto(`${app}/applications/app-1`);
+  await page.getByTestId('hire').click();
+
+  // ---- worker sees hired status ----
+  await loginAs(page, 'worker');
+  await page.goto(`${app}/me/applications`);
+  await expect(page.getByTestId('status-pill')).toContainText('hired');
+});

--- a/tests/unit/notificationFormat.test.ts
+++ b/tests/unit/notificationFormat.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatNotification } from '../../lib/notificationFormat';
+
+test('message:new mapping', () => {
+  const msg = formatNotification({
+    type: 'message:new',
+    payload: { counterparty: 'Ana' },
+  });
+  assert.equal(msg, 'Ana sent a new message');
+});
+
+test('application:status mapping', () => {
+  const msg = formatNotification({
+    type: 'application:status',
+    payload: { job_title: 'Test', status: 'hired' },
+  });
+  assert.equal(msg, 'Your application to Test was hired');
+});
+


### PR DESCRIPTION
## Summary
- add bell and item test ids for header notifications
- expose hire/reject/status pill hooks for automation
- add golden end-to-end smoke and notification formatter helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx tsx --test tests/unit/notificationFormat.test.ts tests/unit/geo.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`
- `npm run test:smoke` *(fails: browserType.launch: Executable doesn't exist / download 403)*


------
https://chatgpt.com/codex/tasks/task_e_68afd10bc0f08327b0cc69715753b8ac