### PR TITLE
feat: add codex self-heal workflow

### DIFF
--- a/.github/workflows/codex-self-heal.yml
+++ b/.github/workflows/codex-self-heal.yml
@@ -1,0 +1,66 @@
+name: Codex Auto-Fix
+
+on:
+  workflow_run:
+    workflows: ["Release Check (PR smoke) / e2e_smoke (pull_request)"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  self-heal:
+    if: >
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR metadata
+        id: pr
+        uses: potiuk/get-workflow-origin@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Exit if PR lacks codex label
+        run: |
+          echo "Checking labels…"
+          gh pr view ${{ steps.pr.outputs.pull_request_number }} --json labels -q '.labels[].name' | grep -q '^codex$' || {
+            echo "No codex label; skipping."; exit 78;
+          }
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download failing run artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./artifacts
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Discover Vercel preview URL
+        id: preview
+        run: |
+          url=$(gh pr view ${{ steps.pr.outputs.pull_request_number }} --json comments -q '.comments[].body' | grep -Eo '(https?://[^ ]+vercel\.app[^ ]*)' | head -n1 || true)
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Invoke Codex Self-Heal
+        uses: openai/codex-self-heal@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          connector-id: ${{ secrets.CODEX_CONNECTOR_ID }}
+          mode: pr-self-heal
+          pr-number: ${{ steps.pr.outputs.pull_request_number }}
+          fail-job-name: "e2e_smoke"
+          artifacts-path: "./artifacts"
+          preview-url: ${{ steps.preview.outputs.url }}
+          commit-message-prefix: "codex: auto-fix"
+          max-edits: 5

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -39,6 +39,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    outputs:
+      preview_url: ${{ steps.vercel.outputs.preview_url }}
     env:
       DISABLE_STRIPE: '1'
       NEXT_TELEMETRY_DISABLED: 1
@@ -54,7 +56,17 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npx playwright install --with-deps
-      - run: npm run test:smoke
+      - name: Fetch Vercel preview URL
+        id: vercel
+        run: |
+          url=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[].body' | grep -Eo '(https?://[^ ]+vercel\.app[^ ]*)' | head -n1 || true)
+          echo "preview_url=$url" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests (retry once, longer timeout)
+        run: |
+          npx playwright test --project=smoke --retries=1 --timeout=60000 || \
+          npx playwright test --project=smoke --retries=0 --timeout=60000
       - name: Upload smoke artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -63,3 +75,15 @@ jobs:
           path: |
             test-results/**
             playwright-report/**
+          if-no-files-found: warn
+      - name: Comment failure with trace links
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: smoke-links
+          message: |
+            ❌ Smoke failed. Artifacts:
+            - Trace: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
+            - Preview: ${{ steps.vercel.outputs.preview_url || 'n/a' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/codex-self-heal.md
+++ b/docs/codex-self-heal.md
@@ -1,0 +1,13 @@
+# Codex Self-Heal
+
+PRs labeled with `codex` automatically recover from failing smoke tests.
+
+When the `e2e_smoke` job in **Release Check (PR smoke)** fails:
+
+1. CI uploads Playwright traces, videos and screenshots under the `smoke-artifacts/` artifact and comments links on the PR.
+2. A follow up workflow (`codex-self-heal.yml`) downloads the artifacts, discovers the Vercel preview URL and invokes Codex to diagnose and push a fix.
+3. Codex commits directly to the PR branch. For forks, it opens a patch PR from a `codex/fix-<sha>` branch.
+
+To opt in, add the `codex` label to your pull request. Remove the label to skip self-healing.
+
+Artifacts and Vercel preview links appear in the failure comment and in the workflow run artifacts.


### PR DESCRIPTION
## Summary
- add workflow to auto-heal failing e2e smoke runs using Codex
- enhance PR smoke to retry tests, surface preview URL, and comment artifact links
- document how Codex self-heal works and how to opt out

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff63da68083279f5014922cea1a28