### PR TITLE
chore(qa): add Final QA workflow with visual checks + resilient smoke

### DIFF
--- a/.github/workflows/final-qa.yml
+++ b/.github/workflows/final-qa.yml
@@ -1,0 +1,89 @@
+name: Final QA
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  e2e_smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      NODE_ENV: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright (with deps)
+        run: npx playwright install --with-deps
+
+      - name: Resolve Vercel Preview URL
+        id: preview
+        shell: bash
+        run: |
+          if [ -n "${PREVIEW_URL}" ]; then
+            echo "url=${PREVIEW_URL}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${VERCEL_PREVIEW_URL}" ]; then
+            echo "url=${VERCEL_PREVIEW_URL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show BASE_URL
+        run: echo "BASE_URL=${{ steps.preview.outputs.url }}"
+
+      - name: Run smoke tests
+        id: smoke
+        env:
+          BASE_URL: ${{ steps.preview.outputs.url }}
+        run: npm run test:smoke
+        continue-on-error: true
+
+      - name: Always collect smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-artifacts
+          path: |
+            test-results/**
+            playwright-report/**
+            smoke-artifacts.zip
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Take QA screenshots (still try even if smoke failed)
+        if: always()
+        env:
+          BASE_URL: ${{ steps.preview.outputs.url }}
+        run: npm run qa:screens || true
+
+      - name: Upload QA screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-screens
+          path: test-results/screens/**
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Trigger self-heal (only if smoke failed)
+        if: steps.smoke.outcome != 'success'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Codex Self-Heal (E2E)
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          inputs: |
+            previewUrl=${{ steps.preview.outputs.url }}
+            reason=final-qa smoke failed

--- a/docs/QA-SIGNOFF.md
+++ b/docs/QA-SIGNOFF.md
@@ -1,0 +1,20 @@
+# QA Sign-off Checklist
+
+## Core flows
+- [ ] Sign in / Sign up works
+- [ ] Employer: Post job → Applications visible → Hire flow completes
+- [ ] Worker: Apply → Chat → Accept → Mark hired
+- [ ] Messaging: real-time messages appear both sides
+- [ ] Notifications: header bell shows unread + correct items
+
+## Payments
+- [ ] Admin: Approve manual GCash payment → job posting gate lifted
+
+## UI/UX
+- [ ] Header/nav present on all pages; links valid
+- [ ] Job form has Region → Province → City cascade working
+- [ ] Mobile viewport passes smoke layout (no clipped controls)
+
+## Technical
+- [ ] Final QA workflow artifacts reviewed (screens + smoke traces)
+- [ ] No 404/500 in network panel for core pages

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "qa:smoke": "playwright test --project=smoke",
     "qa:full": "playwright test --project=full-e2e",
     "qa:report": "playwright show-report",
+    "qa:screens": "tsx scripts/qa/screenshot-pages.ts",
+    "qa:final": "npm run test:smoke && npm run qa:screens",
     "build:prod": "next build",
     "start:prod": "next start -p 3000",
     "analyze": "ANALYZE=true next build",

--- a/scripts/qa/screenshot-pages.ts
+++ b/scripts/qa/screenshot-pages.ts
@@ -1,0 +1,51 @@
+import { chromium } from "playwright";
+import fs from "fs/promises";
+
+const BASE = (process.env.BASE_URL ?? "http://localhost:3000").replace(/\/$/, "");
+
+type PageSpec = { path: string; waitFor: string; file: string };
+const pages: PageSpec[] = [
+  { path: "/", waitFor: "[data-testid=app-header]", file: "home.png" },
+  { path: "/jobs/new", waitFor: "[data-testid=job-form]", file: "jobs-new.png" },
+  { path: "/jobs", waitFor: "[data-testid=jobs-list]", file: "jobs-list.png" },
+  {
+    path: "/applications",
+    waitFor: "[data-testid=applications-page]",
+    file: "applications.png",
+  },
+  { path: "/messages", waitFor: "[data-testid=messages-page]", file: "messages.png" },
+];
+
+(async () => {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: 1366, height: 900 } });
+  const page = await ctx.newPage();
+
+  const outDir = "test-results/screens";
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const p of pages) {
+    const url = `${BASE}${p.path}`;
+    try {
+      console.log(`Visiting ${url}`);
+      const resp = await page.goto(url, {
+        waitUntil: "domcontentloaded",
+        timeout: 60_000,
+      });
+      if (!resp) throw new Error("no response");
+      await page.waitForLoadState("networkidle", { timeout: 60_000 }).catch(() => {});
+      await page.waitForSelector(p.waitFor, { state: "visible", timeout: 60_000 });
+      await page.screenshot({ path: `${outDir}/${p.file}`, fullPage: true });
+    } catch (e) {
+      console.warn(`WARN: Failed to capture ${url}:`, e);
+      const msg = String(e);
+      await page.setContent(
+        `<div style=\"width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#fee;border:4px solid #f00;font-family:sans-serif;font-size:32px;color:#900;\">Failed to load ${url}: ${msg.replace(/"/g, '&quot;')}\</div>`
+      );
+      await page.screenshot({ path: `${outDir}/${p.file}`, fullPage: true });
+    }
+  }
+
+  await browser.close();
+})();
+


### PR DESCRIPTION
## Summary
- add Final QA workflow running smoke tests and screenshots, with self-heal dispatch
- script to capture key page screenshots using Playwright
- document QA sign-off checklist

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68affabbdf3c8327b3bec1e56e05f53c