### PR TITLE
fix(locations): full PH cascades + NCR special case + shared component + seeds + tests

### DIFF
--- a/components/jobs/NewJobForm.tsx
+++ b/components/jobs/NewJobForm.tsx
@@ -14,8 +14,10 @@ function validate(form: { title: string; description: string; loc: Loc }) {
   if (form.description.trim().length < 20) {
     errors.description = 'Description too short';
   }
+  const NCR = '130000000';
   if (!form.loc.region) errors.region = 'Region required';
-  if (!form.loc.province) errors.province = 'Province required';
+  if (form.loc.region && form.loc.region !== NCR && !form.loc.province)
+    errors.province = 'Province required';
   if (!form.loc.city) errors.city = 'City required';
   return errors;
 }
@@ -47,7 +49,7 @@ export default function NewJobForm() {
           title,
           description,
           region_code: loc.region,
-          province_code: loc.province,
+          province_code: loc.province ?? null,
           city_code: loc.city,
         }),
       });

--- a/tests/e2e/post-job.spec.ts
+++ b/tests/e2e/post-job.spec.ts
@@ -39,33 +39,31 @@ test('@full post job flow', async ({ page }) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({
-        regions: [
-          { code: '040000000', name: 'CALABARZON' },
-          { code: 'NCR', name: 'NCR' },
-        ],
-      }),
+      body: JSON.stringify([
+        { id: '040000000', name: 'CALABARZON' },
+        { id: '130000000', name: 'NCR' },
+      ]),
     });
   });
-  await page.route('/api/locations/provinces?region=040000000', (route) => {
+  await page.route('/api/locations/provinces?region_id=040000000', (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ provinces: [{ code: '042100000', name: 'Cavite' }] }),
+      body: JSON.stringify([{ id: '042100000', name: 'Cavite' }]),
     });
   });
-  await page.route('/api/locations/cities?province=042100000', (route) => {
+  await page.route('/api/locations/cities?region_id=040000000&province_id=042100000', (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ cities: [{ code: '042108000', name: 'Bacoor' }] }),
+      body: JSON.stringify([{ id: '042108000', name: 'Bacoor' }]),
     });
   });
-  await page.route('/api/locations/cities?province=NCR', (route) => {
+  await page.route('/api/locations/cities?region_id=130000000', (route) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ cities: [{ code: 'MKT', name: 'Makati' }] }),
+      body: JSON.stringify([{ id: 'MKT', name: 'Makati' }]),
     });
   });
 
@@ -109,8 +107,8 @@ test('@full post job flow', async ({ page }) => {
     '[data-testid=txt-description]',
     'This is a long description for NCR flow.',
   );
-  await page.selectOption('[data-testid=sel-region]', 'NCR');
-  await expect(page.locator('[data-testid=sel-province]')).toHaveValue('NCR');
+  await page.selectOption('[data-testid=sel-region]', '130000000');
+  await expect(page.locator('[data-testid=sel-province]')).toHaveCount(0);
   await page.selectOption('[data-testid=sel-city]', 'MKT');
   await page.click('[data-testid=btn-submit]');
   await expect(page.getByText('Job posted!')).toBeVisible();

--- a/tests/unit/locations.api.test.ts
+++ b/tests/unit/locations.api.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const realFetch = global.fetch;
+
+function call(handler: any, query: any) {
+  return new Promise((resolve) => {
+    const req = { query } as any;
+    const res = {
+      setHeader() {},
+      status() { return this; },
+      json(data: any) { resolve(data); },
+    } as any;
+    handler(req, res);
+  });
+}
+
+test('regions API returns data', async () => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://sb';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'k';
+  global.fetch = (async (url: any) => {
+    if (String(url).includes('/ph_regions')) {
+      return new Response(
+        JSON.stringify([{ code: '130000000', name: 'NCR' }]),
+        { status: 200 },
+      );
+    }
+    return new Response('[]', { status: 200 });
+  }) as any;
+  const mod = await import('../../pages/api/locations/regions');
+  const data: any = await call(mod.default, {});
+  assert.ok(Array.isArray(data));
+  assert.ok(data.length > 0);
+});
+
+test('NCR cities include Quezon City and Taguig', async () => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://sb';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'k';
+  global.fetch = (async (url: any) => {
+    if (String(url).includes('/ph_cities')) {
+      return new Response(
+        JSON.stringify([
+          { code: '137402000', name: 'Quezon City' },
+          { code: '137607000', name: 'Taguig' },
+        ]),
+        { status: 200 },
+      );
+    }
+    return new Response('[]', { status: 200 });
+  }) as any;
+  const mod = await import('../../pages/api/locations/cities');
+  const data: any = await call(mod.default, { region_id: '130000000' });
+  const names = data.map((c: any) => c.name);
+  assert.ok(names.includes('Quezon City'));
+  assert.ok(names.includes('Taguig'));
+});
+
+test.after(() => {
+  global.fetch = realFetch;
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+});


### PR DESCRIPTION
## Summary
- add region, province, and city API endpoints with NCR handling and caching
- share PHCascade component across job form with province hidden for NCR
- add health endpoint and unit tests covering NCR city list

## Testing
- `npx tsx tests/unit/locations.api.test.ts`
- `npx tsx tests/unit/geo.test.ts`
- `npm run lint`
- `npm run test:smoke` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68b046bd21b4832794db46d4d606339e