### PR TITLE
Add demo seed and Metro Manila province

### DIFF
--- a/pages/api/locations/provinces.ts
+++ b/pages/api/locations/provinces.ts
@@ -15,7 +15,8 @@ export default async function handler(
       'Cache-Control',
       'public, s-maxage=3600, stale-while-revalidate=21600'
     );
-    return res.json([]);
+    // NCR is treated as a single province "Metro Manila"
+    return res.json([{ id: 'NCR', name: 'Metro Manila' }]);
   }
 
   let rows: { id: string; name: string }[] | null = null;

--- a/supabase/seed/demo.seed.sql
+++ b/supabase/seed/demo.seed.sql
@@ -1,0 +1,20 @@
+-- Demo users
+insert into auth.users (id, email, email_confirmed_at) values
+  ('00000000-0000-0000-0000-000000000001', 'admin@example.com', now()),
+  ('00000000-0000-0000-0000-000000000002', 'employer@example.com', now()),
+  ('00000000-0000-0000-0000-000000000003', 'worker@example.com', now())
+on conflict do nothing;
+
+-- Profiles
+insert into public.profiles (id, role, full_name) values
+  ('00000000-0000-0000-0000-000000000001', 'seeker', 'Admin User'),
+  ('00000000-0000-0000-0000-000000000002', 'client', 'Demo Employer'),
+  ('00000000-0000-0000-0000-000000000003', 'seeker', 'Demo Worker')
+on conflict (id) do nothing;
+
+-- Sample gigs created by employer
+insert into public.gigs (id, title, description, city, created_by) values
+  (1, 'Demo Gig 1', 'First demo gig', 'Manila', '00000000-0000-0000-0000-000000000002'),
+  (2, 'Demo Gig 2', 'Second demo gig', 'Quezon City', '00000000-0000-0000-0000-000000000002'),
+  (3, 'Demo Gig 3', 'Third demo gig', 'Pasig', '00000000-0000-0000-0000-000000000002')
+on conflict do nothing;

--- a/tests/location/provinces-api.test.ts
+++ b/tests/location/provinces-api.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../../pages/api/locations/provinces';
+
+function mockRes() {
+  const res: any = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.setHeader = (k: string, v: string) => {
+    res.headers[k] = v;
+  };
+  res.jsonData = null;
+  res.json = (data: any) => {
+    res.jsonData = data;
+    return res;
+  };
+  return res;
+}
+
+test('NCR province returns Metro Manila', async () => {
+  const req: any = { query: { region_id: '130000000' } };
+  const res = mockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.jsonData, [{ id: 'NCR', name: 'Metro Manila' }]);
+});


### PR DESCRIPTION
## Summary
- return Metro Manila as the province for NCR in locations API
- seed demo users and gigs
- add tests for NCR province handling

## Testing
- `npx tsx --test tests/location/provinces-api.test.ts`
- `npm run test:smoke` (fails: Process from config.webServer was not able to start. Exit code: 1)


------
https://chatgpt.com/codex/tasks/task_e_68b0565c5d848327b962920598bbd852