### PR TITLE
ci: bootstrap self-heal runner

### DIFF
--- a/.github/workflows/self_heal.yml
+++ b/.github/workflows/self_heal.yml
@@ -1,43 +1,21 @@
-name: Codex self-heal
-
+name: Self Heal
 on:
-  workflow_dispatch:
-    inputs:
-      failed_job_url:
-        description: "URL of the failed QA job"
-        required: true
-        type: string
-      preview_url:
-        description: "Deployed preview URL"
-        required: true
-        type: string
-      base_url:
-        description: "BASE_URL to use for seeding / API calls"
-        required: true
-        type: string
-      pr_number:
-        description: "Pull Request number to push fixes to"
-        required: true
-        type: string
-
+  workflow_run:
+    workflows: ["Release Check (PR smoke)", "Final QA (full)"]
+    types: [completed]
 permissions:
   contents: write
-  actions: write
   pull-requests: write
-
+  actions: read
 jobs:
-  codex-self-heal:
+  heal:
+    if: ${{ contains(fromJson('["failure","cancelled","timed_out"]'), github.event.workflow_run.conclusion) }}
     runs-on: ubuntu-latest
-    env:
-      FAILED_JOB_URL: ${{ github.event.inputs.failed_job_url }}
-      BASE_URL: ${{ github.event.inputs.base_url }}
-      PREVIEW_URL: ${{ github.event.inputs.preview_url }}
-      PR_NUMBER: ${{ github.event.inputs.pr_number }}
     steps:
-      - name: Echo context for debugging
-        run: |
-          echo "FAILED_JOB_URL=${FAILED_JOB_URL}"
-          echo "PREVIEW_URL=${PREVIEW_URL}"
-          echo "BASE_URL=${BASE_URL}"
-          echo "PR_NUMBER=${PR_NUMBER}"
-      # … your Codex task/patch steps follow …
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Post note if artifacts exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.info('Self-heal bootstrap active. A follow-up PR can push automated fixes.')


### PR DESCRIPTION
## Summary
- add minimal workflow to bootstrap codex self-heal on failed QA workflows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0684d82708327abbc030441295fce