### PR TITLE
feat(routing+ui): connect landing CTAs to app and add Post Job entry

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -54,6 +54,13 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npx playwright install --with-deps
+      - name: Smoke (landing↔app CTAs)
+        env:
+          PREVIEW_URL: ${{ vars.PREVIEW_URL || env.PREVIEW_URL }}
+          LANDING_URL: ${{ vars.LANDING_URL || env.LANDING_URL }}
+        run: |
+          npx playwright test e2e/landing-post.spec.ts --reporter=line
+          npx playwright test e2e/app-home-search.spec.ts --reporter=line
       - run: npm run test:smoke
       - name: Upload Playwright report
         if: always()

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,7 +8,7 @@ import AppLogo from "@/components/AppLogo";
 import { getStubRole } from "@/lib/testAuth";
 
 const links = [
-  { href: "/find?focus=search", label: copy.nav.findWork, id: "nav-find" },
+  { href: "/search", label: copy.nav.findWork, id: "nav-find" },
   { href: "/gigs?mine=1", label: copy.nav.myGigs, id: "app-nav-my-gigs" },
   {
     href: "/applications",
@@ -16,7 +16,7 @@ const links = [
     id: "app-nav-applications",
   },
   { href: "/saved", label: copy.nav.saved, id: "app-nav-saved" },
-  { href: "/post?intent=employer", label: copy.nav.postJob, id: "nav-post" },
+  { href: "/post", label: copy.nav.postJob, id: "nav-post" },
 ];
 
 function IconMenu() {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,7 +11,7 @@ import Container from "./Container";
 import { getStubRole } from "@/lib/testAuth";
 
 const links = [
-  { href: "/find?focus=search", label: copy.nav.findWork, id: "nav-find" },
+  { href: "/search", label: copy.nav.findWork, id: "nav-find" },
   { href: "/gigs?mine=1", label: copy.nav.myGigs, id: "app-nav-my-gigs" },
   {
     href: "/applications",
@@ -19,7 +19,7 @@ const links = [
     id: "app-nav-applications",
   },
   { href: "/saved", label: copy.nav.saved, id: "app-nav-saved" },
-  { href: "/post?intent=employer", label: copy.nav.postJob, id: "nav-post" },
+  { href: "/post", label: copy.nav.postJob, id: "nav-post" },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -29,10 +29,10 @@ export default function Nav() {
   return (
     <nav className="p-4 border-b mb-4 flex gap-4">
       <Link href="/home">Home</Link>
-      <Link href="/find?focus=search" data-testid="nav-find">
+      <Link href="/search" data-testid="nav-find">
         {copy.nav.findWork}
       </Link>
-      <Link href="/post?intent=employer" data-testid="nav-post">
+      <Link href="/post" data-testid="nav-post">
         {copy.nav.postJob}
       </Link>
       {session ? (

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -34,7 +34,7 @@ export default function TopNav() {
           QuickGig.ph
         </Link>
         <div className="ml-auto flex items-center gap-4 text-sm">
-          <Link href="/find?focus=search" data-testid="nav-find">
+          <Link href="/search" data-testid="nav-find">
             {copy.nav.findWork}
           </Link>
           {loggedIn && <Link href="/dashboard/gigs">{copy.nav.myGigs}</Link>}
@@ -50,7 +50,7 @@ export default function TopNav() {
             </Link>
           )}
           <Link
-            href="/post?intent=employer"
+            href="/post"
             data-testid="nav-post"
             className={`btn-primary ${loggedIn && !eligible ? "opacity-50 pointer-events-none" : ""}`}
             title={

--- a/components/home/HomeEmployer.tsx
+++ b/components/home/HomeEmployer.tsx
@@ -199,7 +199,7 @@ export default function HomeEmployer() {
             </div>
           ) : (
             <div className="flex flex-wrap gap-2">
-              <Link href="/find?focus=search" className="qg-btn qg-btn--primary px-3 py-2">
+              <Link href="/search" className="qg-btn qg-btn--primary px-3 py-2">
                 Browse Jobs
               </Link>
               <Link

--- a/components/home/HomeSeeker.tsx
+++ b/components/home/HomeSeeker.tsx
@@ -51,7 +51,7 @@ export default function HomeSeeker() {
           </p>
           <div className="flex flex-wrap gap-2">
             <Link
-              href="/find?focus=search"
+              href="/search"
               className="qg-btn qg-btn--primary px-4 py-2 rounded-xl"
             >
               Browse jobs
@@ -97,7 +97,7 @@ export default function HomeSeeker() {
       <section>
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-lg font-medium">Suggested jobs for you</h2>
-          <Link href="/find?focus=search" className="text-sm text-blue-600 underline">
+          <Link href="/search" className="text-sm text-blue-600 underline">
             See all
           </Link>
         </div>
@@ -137,7 +137,7 @@ export default function HomeSeeker() {
       <section>
         <h2 className="text-lg font-medium mb-3">Quick actions</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          <Link href="/find?focus=search" className="border rounded-xl p-4 hover:shadow-sm">
+          <Link href="/search" className="border rounded-xl p-4 hover:shadow-sm">
             Browse jobs
           </Link>
           <Link

--- a/components/nav/AppHeader.tsx
+++ b/components/nav/AppHeader.tsx
@@ -49,18 +49,18 @@ export default function AppHeader() {
         <nav aria-label="Primary" className="hidden md:flex items-center gap-6">
           {!user && (
             <>
-              <Link href="/find?focus=search" data-testid="nav-find">Find work</Link>
-              <Link href="/jobs/new" data-testid="nav-post">Post job</Link>
+              <Link href="/search" data-testid="nav-find">Find work</Link>
+              <Link href="/post" data-testid="nav-post">Post job</Link>
               <Link href="/login" data-testid="nav-login">Login</Link>
             </>
           )}
           {user && role === "worker" && (
-            <Link href="/find?focus=search" data-testid="nav-find">Find work</Link>
+            <Link href="/search" data-testid="nav-find">Find work</Link>
           )}
           {user && role === "employer" && (
             <>
-              <Link href="/jobs/new" data-testid="nav-post">Post job</Link>
-              <Link href="/find?focus=search" data-testid="nav-find">Find work</Link>
+              <Link href="/post" data-testid="nav-post">Post job</Link>
+              <Link href="/search" data-testid="nav-find">Find work</Link>
             </>
           )}
           {user && role === "employer" && credits !== undefined && (
@@ -92,14 +92,14 @@ export default function AppHeader() {
             {!user && (
               <>
                 <Link
-                  href="/find?focus=search"
+                  href="/search"
                   className="py-2"
                   data-testid="nav-find"
                 >
                   Find work
                 </Link>
                 <Link
-                  href="/jobs/new"
+                  href="/post"
                   className="py-2"
                   data-testid="nav-post"
                 >
@@ -111,16 +111,16 @@ export default function AppHeader() {
               </>
             )}
             {user && role === "worker" && (
-              <Link href="/find?focus=search" className="py-2" data-testid="nav-find">
+              <Link href="/search" className="py-2" data-testid="nav-find">
                 Find work
               </Link>
             )}
             {user && role === "employer" && (
               <>
-                <Link href="/jobs/new" className="py-2" data-testid="nav-post">
+                <Link href="/post" className="py-2" data-testid="nav-post">
                   Post job
                 </Link>
-                <Link href="/find?focus=search" className="py-2" data-testid="nav-find">
+                <Link href="/search" className="py-2" data-testid="nav-find">
                   Find work
                 </Link>
               </>

--- a/e2e/app-home-search.spec.ts
+++ b/e2e/app-home-search.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+const APP = process.env.PREVIEW_URL || 'http://localhost:3000';
+
+test.setTimeout(90_000);
+test('App home “Maghanap ng Trabaho” opens /search', async ({ page }) => {
+  await page.goto(APP, { waitUntil: 'domcontentloaded' });
+  const findBtn = page.getByRole('link', { name: /maghanap ng trabaho|find work|browse jobs/i }).first();
+  await expect(findBtn).toBeVisible();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+    findBtn.click(),
+  ]);
+  expect(new URL(page.url()).pathname).toMatch(/^\/search\/?$/);
+});

--- a/e2e/landing-post.spec.ts
+++ b/e2e/landing-post.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+const LANDING = process.env.LANDING_URL || process.env.PREVIEW_URL || 'http://localhost:3000';
+
+test.setTimeout(90_000);
+test('Landing “Post Job/Simulan Na!” opens app /post', async ({ page }) => {
+  await page.goto(LANDING, { waitUntil: 'domcontentloaded' });
+  const postLink = page.getByRole('link', { name: /post job|simulan na/i }).first();
+  await expect(postLink).toBeVisible();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+    postLink.click(),
+  ]);
+  const url = new URL(page.url());
+  expect(url.pathname).toMatch(/^\/post\/?$/);
+  // Form button exists
+  await expect(page.getByRole('button', { name: /post job/i })).toBeVisible();
+});

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -30,17 +30,19 @@
         <nav>
           <a href="#features">Features</a>
           <a
-            href="/find?focus=search"
+            href="/search"
             data-testid="nav-find"
-            aria-label="Maghanap ng trabaho sa QuickGig app"
+            aria-label="Find work on QuickGig app"
             data-app-root
-            >Maghanap ng Trabaho</a
+            rel="noopener"
+            >Find Work</a
           >
           <a
-            href="/post?intent=employer"
+            href="/post"
             data-testid="nav-post"
             aria-label="Post job on QuickGig app"
             data-app-root
+            rel="noopener"
             >Post Job</a
           >
           <a
@@ -48,14 +50,16 @@
             data-testid="nav-login"
             aria-label="Log in to QuickGig app"
             data-app-root
+            rel="noopener"
             >Login</a
           >
           <a
             class="btn btn-primary"
-            href="/start"
+            href="/signup"
             data-testid="cta-signup"
             aria-label="Sign up on QuickGig app"
             data-app-root
+            rel="noopener"
             >Sign Up</a
           >
         </nav>
@@ -78,19 +82,21 @@
           <a
             id="cta-start"
             class="qg-btn qg-btn--primary"
-            href="/search?intent=worker"
+            href="/post"
             data-testid="cta-start-now"
-            aria-label="Open QuickGig app"
+            aria-label="Post job on QuickGig app"
             data-app-root
+            rel="noopener"
             >Simulan Na!</a
           >
           <a
             class="btn btn-ghost"
-            href="/post?intent=employer"
-            data-testid="cta-post-job"
-            aria-label="Post job on QuickGig app"
+            href="/search"
+            data-testid="cta-browse-jobs"
+            aria-label="Browse jobs on QuickGig app"
             data-app-root
-            >Post a Job</a
+            rel="noopener"
+            >Browse Jobs</a
           >
         </div>
       </div>
@@ -136,25 +142,32 @@
             >Privacy</a
           >
           <a
-            href="/search?intent=worker"
+            href="/search"
             data-testid="footer-open-app"
             aria-label="Open the QuickGig app"
             data-app-root
+            rel="noopener"
             >Open the App</a
           >
         </nav>
       </div>
     </footer>
     <script>
-      const APP_URL =
-        window.NEXT_PUBLIC_APP_URL ||
-        window.APP_URL ||
-        "https://app.quickgig.ph";
-      const appRoot = APP_URL.replace(/\/+$/, "");
+      function resolveAppOrigin() {
+        if (window.NEXT_PUBLIC_APP_ORIGIN)
+          return window.NEXT_PUBLIC_APP_ORIGIN;
+        const { protocol, hostname, port } = window.location;
+        const guess = hostname.startsWith("app.")
+          ? `${protocol}//${hostname}${port ? ":" + port : ""}`
+          : `${protocol}//app.${hostname}${port ? ":" + port : ""}`;
+        return guess;
+      }
+      const appRoot = resolveAppOrigin().replace(/\/+$/, "");
       document.querySelectorAll("[data-app-root]").forEach((el) => {
         const path = el.getAttribute("href") || "/";
         const normalized = path.startsWith("/") ? path : `/${path}`;
         el.setAttribute("href", `${appRoot}${normalized}`);
+        if (!el.getAttribute("rel")) el.setAttribute("rel", "noopener");
       });
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>

--- a/lib/appOrigin.ts
+++ b/lib/appOrigin.ts
@@ -1,0 +1,16 @@
+export function resolveAppOrigin() {
+  // Explicit env wins (set in Vercel for prod)
+  if (process.env.NEXT_PUBLIC_APP_ORIGIN) return process.env.NEXT_PUBLIC_APP_ORIGIN;
+
+  // Guess: if we're on landing host, prefer app.<host>; otherwise same origin
+  if (typeof window !== 'undefined') {
+    const { protocol, hostname, port } = window.location;
+    const guess = hostname.startsWith('app.')
+      ? `${protocol}//${hostname}${port ? ':' + port : ''}`
+      : `${protocol}//app.${hostname}${port ? ':' + port : ''}`;
+    return guess;
+  }
+
+  // SSR/CI fallback
+  return 'https://app.quickgig.ph';
+}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -9,13 +9,13 @@ export default function NotFound() {
       </p>
       <div className="flex gap-3 justify-center">
         <Link
-          href="/find?focus=search"
+          href="/search"
           className="qg-btn qg-btn--primary px-4 py-2"
         >
           Find work
         </Link>
         <Link
-          href="/post?intent=employer"
+          href="/post"
           className="qg-btn qg-btn--outline px-4 py-2"
         >
           Post a job

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -89,7 +89,7 @@ export default function Home() {
               >
                 Complete profile
               </Link>
-              <Link href="/find?focus=search" className="qg-btn qg-btn--outline px-4 py-2">
+              <Link href="/search" className="qg-btn qg-btn--outline px-4 py-2">
                 Find jobs near you
               </Link>
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,7 @@ export default function Home() {
       <P>Connect with opportunities — find work or hire talent quickly.</P>
       <div className="flex justify-center gap-4">
         <Link
-          href="/find?focus=search"
+          href="/search"
           className="btn-primary"
           data-testid="cta-findwork"
         >
@@ -26,7 +26,7 @@ export default function Home() {
         </Link>
         {canPost && (
           <Link
-            href="/jobs/new"
+            href="/post"
             className="btn-secondary"
             data-testid="cta-postjob"
           >

--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -1,9 +1,17 @@
+"use client";
+
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { createJob } from "@/lib/jobs";
 import { requireTicket } from "@/lib/tickets";
 import { useRequireUser } from "@/lib/useRequireUser";
-import LocationSelect, { LocationValue } from "@/components/location/LocationSelect";
+import type { LocationValue } from "@/components/location/LocationSelect";
 import { staticPhData } from "@/lib/ph-data";
+
+const LocationSelect = dynamic(() => import("@/components/location/LocationSelect"), {
+  ssr: false,
+  loading: () => <div className="opacity-60">Loading locations…</div>,
+});
 
 export default function PostJobPage() {
   const { ready, userId, timedOut } = useRequireUser();

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function SignupRedirect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/start');
+  }, [router]);
+  return <p className="p-6">Redirecting...</p>;
+}

--- a/scripts/qa/screenshot-pages.ts
+++ b/scripts/qa/screenshot-pages.ts
@@ -6,7 +6,7 @@ const BASE = (process.env.BASE_URL ?? "http://localhost:3000").replace(/\/$/, ""
 type PageSpec = { path: string; waitFor: string; file: string };
 const pages: PageSpec[] = [
   { path: "/", waitFor: "[data-testid=app-header]", file: "home.png" },
-  { path: "/jobs/new", waitFor: "[data-testid=job-form]", file: "jobs-new.png" },
+  { path: "/post", waitFor: "[data-testid=job-form]", file: "jobs-new.png" },
   { path: "/jobs", waitFor: "[data-testid=jobs-list]", file: "jobs-list.png" },
   {
     path: "/applications",

--- a/tests/e2e/credits.spec.ts
+++ b/tests/e2e/credits.spec.ts
@@ -48,7 +48,7 @@ test('@full credits flow', async ({ page }) => {
   await page.goto(app);
   await expect(page.getByTestId('credits-pill')).toHaveText('Credits: 3');
 
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await page.fill('input[name=title]', 'Test');
   await page.fill('textarea[name=description]', 'Desc');
   await page.fill('input[name=price]', '5');
@@ -56,7 +56,7 @@ test('@full credits flow', async ({ page }) => {
   await expect(page.getByTestId('credits-pill')).toHaveText('Credits: 2');
 
   credits = 0;
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await expect(page.getByText('You have 0 credits')).toBeVisible();
 
   await loginAs(page, 'admin');

--- a/tests/e2e/post-job.spec.ts
+++ b/tests/e2e/post-job.spec.ts
@@ -70,7 +70,7 @@ test('@full post job flow', async ({ page }) => {
   await loginAs(page, 'employer');
 
   // Happy path
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await page.fill('[data-testid=txt-title]', 'Test Job');
   await page.fill(
     '[data-testid=txt-description]',
@@ -84,12 +84,12 @@ test('@full post job flow', async ({ page }) => {
   await expect(page.getByTestId('credits-pill')).toHaveText('Credits: 0');
 
   // No credits gate
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await expect(page.getByText('You have 0 credits')).toBeVisible();
 
   // Validation: short title / missing city
   credits = 1;
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await page.fill('[data-testid=txt-title]', 'no');
   await page.fill(
     '[data-testid=txt-description]',
@@ -101,7 +101,7 @@ test('@full post job flow', async ({ page }) => {
   await expect(page.getByTestId('btn-submit')).toBeDisabled();
 
   // NCR flow
-  await page.goto(`${app}/jobs/new`);
+  await page.goto(`${app}/post`);
   await page.fill('[data-testid=txt-title]', 'Another Job');
   await page.fill(
     '[data-testid=txt-description]',

--- a/tests/qa/forms.spec.ts
+++ b/tests/qa/forms.spec.ts
@@ -11,7 +11,7 @@ test.describe('forms and flows', () => {
 
   test('employer can create job', async ({ page }) => {
     await loginAs(page, 'employer');
-    await page.goto('/jobs/new');
+    await page.goto('/post');
     await waitForAppReady(page);
     await smartFill(page);
     await page.getByRole('button', { name: /submit|post|create/i }).click().catch(()=>{});
@@ -19,7 +19,7 @@ test.describe('forms and flows', () => {
       page.waitForURL(/\/jobs/),
       page.getByText(/success/i).waitFor({ timeout: 5_000 }).catch(() => {}),
     ]);
-    recordVisit('/jobs/new');
+    recordVisit('/post');
   });
 
   test('worker can apply to a job', async ({ page }) => {

--- a/tests/qa/routes.ts
+++ b/tests/qa/routes.ts
@@ -4,7 +4,7 @@ import { waitForAppReady } from './helpers/waits';
 export const routes = [
   '/',
   '/jobs',
-  '/jobs/new',
+  '/post',
   '/applications',
   '/messages',
   '/offers',


### PR DESCRIPTION
## Summary
- route landing CTAs to app with origin resolver
- expose Post Job links in app nav and home; add /signup redirect
- add Post Job page using dynamic LocationSelect and Playwright smoke tests

## Changes
- add `lib/appOrigin` and wire landing header/hero/footer to app
- update app headers, hero, and tests to use `/search` and `/post`
- create `/signup` redirect page
- add Playwright tests and CI smoke step

## Testing Steps
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run build`
- `npx playwright test e2e/landing-post.spec.ts --reporter=line` *(fails: missing browser)*
- `npx playwright test e2e/app-home-search.spec.ts --reporter=line` *(fails: missing browser)*

## Acceptance
- Landing “Post Job”, “Find Work”, “Login”, and “Sign Up” open the app
- App navbar and home hero link to `/post` and `/search`
- `/post` page renders with LocationSelect (NCR 17 LGUs) and posts jobs
- CI smoke tests cover landing→/post and app-home→/search flows

## Notes
- Playwright browsers could not be installed in this environment, so smoke tests were attempted but failed

------
https://chatgpt.com/codex/tasks/task_e_68b08b4b8618832781a82ec6391ec478