### PR TITLE
feat: add posting credits and orders APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ curl -X POST -H "Content-Type: application/json" -d '{"proof_url":"https://.../r
 curl -X POST -H "Content-Type: application/json" -d '{"decision":"paid"}' https://app.quickgig.ph/api/orders/<id>/decide
 curl https://app.quickgig.ph/api/users/me/eligibility
 ```
+
+## Deployment notes
+
+* After deploy, run **/api/admin/seed** once to promote `SEED_ADMIN_EMAIL` to admin.
+* Apply the migration via Supabase Studio → SQL or `supabase db push`.

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -1,11 +1,11 @@
 import { GetServerSideProps } from 'next';
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import React from 'react';
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const supa = createServerSupabaseClient(ctx);
   const { data: { user } } = await supa.auth.getUser();
   if (!user) return { redirect: { destination: '/', permanent: false } };
-
   const { data: me } = await supa.from('profiles').select('role').eq('id', user.id).single();
   if (me?.role !== 'admin') return { redirect: { destination: '/', permanent: false } };
 
@@ -14,29 +14,45 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 };
 
 export default function AdminOrders({ orders }: { orders: any[] }) {
+  const [busy, setBusy] = React.useState<string | null>(null);
+
   const approve = async (id: string) => {
+    setBusy(id);
     const res = await fetch('/api/orders/approve', {
-      method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ order_id: id })
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order_id: id })
     });
+    setBusy(null);
     if (!res.ok) return alert('Approve failed');
     location.reload();
   };
+
+  const viewProof = async (path: string) => {
+    const res = await fetch('/api/orders/proof-url', {
+      method: 'POST', headers: { 'Content-Type':'application/json' },
+      body: JSON.stringify({ path })
+    });
+    if (!res.ok) return alert('Cannot open proof');
+    const { url } = await res.json();
+    window.open(url, '_blank');
+  };
+
   return (
     <main className="max-w-3xl mx-auto p-6 space-y-4">
       <h1 className="text-2xl font-semibold">Orders</h1>
       <ul className="space-y-3">
         {orders.map(o => (
-          <li key={o.id} className="border rounded-xl p-3">
-            <div className="flex justify-between items-center">
-              <div>
-                <div className="font-medium">{o.status.toUpperCase()} • ₱{o.amount} • {o.credits} credits</div>
-                <div className="text-sm opacity-70">{o.user_id}</div>
-              </div>
-              {o.status === 'pending' && (
-                <button className="px-3 py-2 rounded-xl bg-black text-white" onClick={()=>approve(o.id)}>
-                  Approve
-                </button>
-              )}
+          <li key={o.id} className="border rounded-xl p-3 flex justify-between items-center">
+            <div>
+              <div className="font-medium">{o.status.toUpperCase()} • ₱{o.amount} • {o.credits} credits</div>
+              <div className="text-sm opacity-70">{new Date(o.created_at).toLocaleString()}</div>
+            </div>
+            <div className="flex gap-2">
+              {o.proof_path && <button className="px-3 py-2 rounded-xl border" onClick={()=>viewProof(o.proof_path)}>View proof</button>}
+              {o.status === 'pending' &&
+                <button className="px-3 py-2 rounded-xl bg-black text-white" disabled={busy===o.id} onClick={()=>approve(o.id)}>
+                  {busy===o.id ? 'Approving…' : 'Approve'}
+                </button>}
             </div>
           </li>
         ))}
@@ -44,4 +60,3 @@ export default function AdminOrders({ orders }: { orders: any[] }) {
     </main>
   );
 }
-

--- a/pages/api/admin/seed.ts
+++ b/pages/api/admin/seed.ts
@@ -3,18 +3,16 @@ import { createClient } from '@supabase/supabase-js';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (process.env.NODE_ENV === 'production' && req.method !== 'POST') return res.status(405).end();
-
   const email = process.env.SEED_ADMIN_EMAIL;
   if (!email) return res.status(200).json({ ok: true, note: 'SEED_ADMIN_EMAIL not set' });
 
   const admin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-  const { data: user, error: uerr } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
-  if (uerr) return res.status(400).json({ error: uerr.message });
+  const { data: users, error } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (error) return res.status(400).json({ error: error.message });
 
-  const target = user.users.find(u => u.email?.toLowerCase() === email.toLowerCase());
-  if (!target) return res.status(200).json({ ok: true, note: 'user not found yet' });
+  const u = users.users.find(x => x.email?.toLowerCase() === email.toLowerCase());
+  if (!u) return res.status(200).json({ ok: true, note: 'user not found yet (sign in first)' });
 
-  await admin.from('profiles').upsert({ id: target.id, role: 'admin' }, { onConflict: 'id' });
+  await admin.from('profiles').upsert({ id: u.id, role: 'admin' }, { onConflict: 'id' });
   return res.status(200).json({ ok: true });
 }
-

--- a/pages/api/gigs/create.ts
+++ b/pages/api/gigs/create.ts
@@ -12,8 +12,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'MISSING_FIELDS' });
 
   const { data, error } = await supabase.rpc('decrement_credit_and_create_gig', {
-    p_title: title, p_description: description,
-    p_region_code: region_code, p_city_code: city_code, p_budget: budget ?? null
+    p_title: title,
+    p_description: description,
+    p_region_code: region_code,
+    p_city_code: city_code,
+    p_budget: budget ?? null,
   });
 
   if (error) {

--- a/pages/api/orders/proof-url.ts
+++ b/pages/api/orders/proof-url.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const supa = createServerSupabaseClient({ req, res });
+  const { data: { user } } = await supa.auth.getUser();
+  if (!user) return res.status(401).end();
+
+  const { data: me } = await supa.from('profiles').select('role').eq('id', user.id).single();
+  if (me?.role !== 'admin') return res.status(403).end();
+
+  const { path } = req.body || {};
+  if (!path) return res.status(400).json({ error: 'MISSING_PATH' });
+
+  const { data, error } = await supa.storage.from('payments').createSignedUrl(path, 600);
+  if (error) return res.status(400).json({ error: error.message });
+  return res.status(200).json({ url: data.signedUrl });
+}

--- a/pages/employer/post.tsx
+++ b/pages/employer/post.tsx
@@ -10,20 +10,17 @@ export default function PostJobPage() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const res = await fetch('/api/gigs/create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
       body: JSON.stringify({
-        title: form.title,
-        description: form.description,
-        region_code: form.region_code,
-        city_code: form.city_code,
-        budget: form.budget ? Number(form.budget) : null
-      })
+        ...form,
+        budget: form.budget ? Number(form.budget) : null,
+      }),
     });
     if (res.status === 402) { setBuyOpen(true); return; }
     if (!res.ok) { alert('Failed to create gig'); return; }
     const { gig_id } = await res.json();
-    window.location.href = `/gigs/${gig_id}`;
+    window.location.href = `/find`; // or `/gigs/${gig_id}` once detail page exists
   };
 
   return (

--- a/pages/find/index.tsx
+++ b/pages/find/index.tsx
@@ -1,45 +1,59 @@
 'use client';
-
 import React from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import LocationSelect from '@/components/LocationSelect';
 
 export default function FindPage() {
-  const [region_code, setRegion] = React.useState('');
-  const [city_code, setCity]     = React.useState('');
+  const supa = createClientComponentClient();
   const [q, setQ] = React.useState('');
-  const [items, setItems] = React.useState<any[] | null>(null);
+  const [region_code, setRegion] = React.useState('');
+  const [city_code, setCity] = React.useState('');
+  const [items, setItems] = React.useState<any[]>([]);
+  const [loading, setLoading] = React.useState(false);
 
-  React.useEffect(() => {
-    // TODO: replace with real fetch once gigs exist; keep non-fatal now.
-    setItems([]); // safe default so UI never blanks
-  }, []);
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    let query = supa.from('gigs')
+      .select('id,title,description,region_code,city_code,created_at')
+      .order('created_at', { ascending: false })
+      .limit(50);
+    if (region_code) query = query.eq('region_code', region_code);
+    if (city_code)  query = query.eq('city_code', city_code);
+    if (q.trim())   query = query.ilike('title', `%${q}%`);
+    const { data, error } = await query;
+    setItems(error ? [] : (data ?? []));
+    setLoading(false);
+  }, [supa, q, region_code, city_code]);
+
+  React.useEffect(() => { load(); }, [load]);
 
   return (
     <main className="max-w-5xl mx-auto p-6 space-y-4 min-h-[60vh]">
       <h1 className="text-2xl font-semibold">Browse jobs</h1>
 
       <div className="grid gap-3 sm:grid-cols-3">
-        <input
-          className="border rounded-xl p-2"
-          placeholder="Search keywords"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-        />
+        <input className="border rounded-xl p-2" placeholder="Search keywords"
+               value={q} onChange={(e)=>setQ(e.target.value)} />
         <LocationSelect
           value={{ region_code, city_code }}
-          onChange={(v) => { setRegion(v.region_code || ''); setCity(v.city_code || ''); }}
+          onChange={(v)=>{ setRegion(v.region_code || ''); setCity(v.city_code || ''); }}
           className="sm:col-span-2"
         />
       </div>
 
-      {!items || items.length === 0 ? (
-        <p className="opacity-70">No gigs yet. Try a different filter or check back soon.</p>
+      <button className="px-3 py-2 rounded-xl border" onClick={load} disabled={loading}>
+        {loading ? 'Loading…' : 'Refresh'}
+      </button>
+
+      {!items.length ? (
+        <p className="opacity-70">No gigs found.</p>
       ) : (
         <ul className="grid gap-3">
-          {items.map((g: any) => (
+          {items.map(g => (
             <li key={g.id} className="border rounded-xl p-3">
               <div className="font-medium">{g.title}</div>
-              <div className="text-sm opacity-70">{g.city_name || g.city_code}</div>
+              <div className="text-sm opacity-70">{g.region_code} • {g.city_code}</div>
+              <p className="text-sm mt-1 line-clamp-3">{g.description}</p>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- add SQL migration for profiles, gigs, orders and RPCs
- expose gig and order APIs with admin seed and proof URLs
- wire Find and admin Orders pages to live data

## Changes
- migrate profiles, gigs, orders and storage policies
- add gig creation, order create/approve/proof API routes and admin seed
- list gigs on Find page and allow admins to approve orders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .`
- `npm run typecheck`

## Acceptance
- Build + smoke pass
- /find lists gigs when they exist
- POST /api/gigs/create decrements credits & inserts gig; 402 when empty
- /admin/orders lists orders; 'View proof' opens signed URL; 'Approve' adds credits

## Notes
- After deploy, apply migration and run `/api/admin/seed` once.


------
https://chatgpt.com/codex/tasks/task_e_68b158e2359c8327922bc8cdd21b9df3