### PR TITLE
ci/e2e: reuse existing server on :3000; stabilize baseURL

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -19,6 +19,7 @@ jobs:
           npx playwright test --reporter=github,html --shard=1/2
           npx playwright test --reporter=github,html --shard=2/2
         env:
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || '' }}
       - name: Upload report

--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Run full E2E
         run: npx playwright test e2e/full --reporter=github,html
         env:
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
           APP_ORIGIN: ${{ vars.APP_ORIGIN }}
           MARKETING_HOST: ${{ vars.MARKETING_HOST }}
           QA_TEST_MODE: ${{ vars.QA_TEST_MODE }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,22 @@
 import { defineConfig } from '@playwright/test';
 
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+
 export default defineConfig({
   use: {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL: BASE_URL,
   },
-  webServer: process.env.BASE_URL
+  webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
         command: 'npx next start -p 3000',
         url: 'http://localhost:3000',
         timeout: 120_000,
-        reuseExistingServer: !process.env.CI,
+        reuseExistingServer: true,
         env: {
           NEXT_PUBLIC_SUPABASE_URL:
             process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321',
@@ -28,13 +31,13 @@ export default defineConfig({
       testMatch: ['tests/smoke/**/*.spec.ts', '**/*.smoke.ts'],
       timeout: 45_000,
       expect: { timeout: 7_000 },
-      use: { baseURL: 'http://localhost:3000' },
+      use: { baseURL: BASE_URL },
     },
     {
       name: 'e2e',
       testMatch: ['tests/e2e/**/*.spec.ts'],
       use: {
-        baseURL: 'http://localhost:3000',
+        baseURL: BASE_URL,
         video: 'retain-on-failure',
         trace: 'retain-on-failure',
         screenshot: 'only-on-failure',


### PR DESCRIPTION
## Summary
- reuse existing :3000 Next server for Playwright
- standardize Playwright baseURL via `PLAYWRIGHT_BASE_URL`

## Changes
- default Playwright baseURL to `PLAYWRIGHT_BASE_URL` and always reuse running server
- export `PLAYWRIGHT_BASE_URL` in full and nightly E2E workflows

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in src/app/(marketing)/landing/page.tsx)*
- `npm run test:smoke` *(fails: Next.js server failed to start – missing `.next` build)*

## Acceptance
- [ ] Playwright can reuse pre-started server at :3000
- [ ] CI workflows use stable `PLAYWRIGHT_BASE_URL`

## Notes
- lint and smoke tests require further fixes outside this change


------
https://chatgpt.com/codex/tasks/task_e_68b246d65e9c8327b41bfcbb2ee9369f