### PR TITLE
refactor: use absolute app links on landing

### DIFF
--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,30 +1,17 @@
-import Link from 'next/link';
 import { withAppOrigin } from '@/lib/url';
 
 export default function LandingHeader() {
   return (
     <nav className="...">
-      <Link
-        href={withAppOrigin('/find')}
-        prefetch={false}
-        className="..."
-      >
+      <a href={withAppOrigin('/find')} className="...">
         Find work
-      </Link>
-      <Link
-        href={withAppOrigin('/post')}
-        prefetch={false}
-        className="..."
-      >
+      </a>
+      <a href={withAppOrigin('/post')} className="...">
         Post job
-      </Link>
-      <Link
-        href={withAppOrigin('/login')}
-        prefetch={false}
-        className="..."
-      >
+      </a>
+      <a href={withAppOrigin('/login')} className="...">
         Login
-      </Link>
+      </a>
     </nav>
   );
 }

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,17 +1,16 @@
-import Link from 'next/link';
 import { withAppOrigin } from '@/lib/url';
 
 export default function LandingHero() {
   return (
     <section className="...">
-      <Link href={withAppOrigin('/')} prefetch={false} className="btn btn-primary">
+      <a href={withAppOrigin('/')} className="btn btn-primary">
         Simulan na
-      </Link>
-      <Link href={withAppOrigin('/find')} prefetch={false} className="btn btn-secondary">
+      </a>
+      <a href={withAppOrigin('/find')} className="btn btn-secondary">
         Browse jobs
-      </Link>
+      </a>
       {/* If you show a “Mag-post ng Gig” button here, link it too */}
-      {/* <Link href={withAppOrigin('/post')} prefetch={false} className="btn">Mag-post ng Gig</Link> */}
+      {/* <a href={withAppOrigin('/post')} className="btn">Mag-post ng Gig</a> */}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- ensure landing header and hero buttons link to app origin

## Changes
- replace Next.js Links with anchors using `withAppOrigin` in landing header
- switch landing hero buttons to `<a>` elements resolving to app origin

## Testing
- `npm run build`
- `npm run test:e2e:full` *(fails: browserType.launch executable doesn't exist; Playwright browsers missing)*
- `npx playwright install` *(fails: download forbidden)*

## Acceptance
- Landing header and hero CTAs point to absolute `app.quickgig.ph` URLs

## CI
- pending

## Rollback
- revert this PR

## Notes
- Playwright browsers unavailable in environment; tests not executed


------
https://chatgpt.com/codex/tasks/task_e_68b27f04a9dc832789a778f1cbb454f7