### PR TITLE
refactor landing CTAs to absolute app routes

### DIFF
--- a/components/MobileStickyCTA.tsx
+++ b/components/MobileStickyCTA.tsx
@@ -1,25 +1,15 @@
-'use client';
-import { appHref } from '@/lib/appOrigin';
+"use client";
+import LandingCTAs from '@/components/landing/LandingCTAs';
 
 export default function MobileStickyCTA() {
   // Visible only on small screens; avoid overlapping with iOS home bar.
   return (
     <div className="sm:hidden fixed inset-x-0 bottom-0 z-40 bg-white/95 backdrop-blur border-t border-gray-200 px-4 pt-3 pb-[calc(12px+env(safe-area-inset-bottom))]">
-      <div className="max-w-5xl mx-auto grid grid-cols-2 gap-3">
-        <a
-          href={appHref('/find')}
-          className="inline-flex items-center justify-center rounded-xl border px-4 py-3 text-sm font-medium"
-          aria-label="Browse Jobs"
-        >
-          Browse Jobs
-        </a>
-        <a
-          href={appHref('/post')}
-          className="inline-flex items-center justify-center rounded-xl bg-black text-white px-4 py-3 text-sm font-semibold"
-          aria-label="Post a Job"
-        >
-          Post a Job
-        </a>
+      <div className="max-w-5xl mx-auto">
+        <LandingCTAs
+          findClassName="flex-1 inline-flex items-center justify-center rounded-xl border px-4 py-3 text-sm font-medium"
+          postClassName="flex-1 inline-flex items-center justify-center rounded-xl bg-black text-white px-4 py-3 text-sm font-semibold"
+        />
       </div>
     </div>
   );

--- a/components/app/AppHeader.tsx
+++ b/components/app/AppHeader.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import Link from 'next/link';
+import { withAppOrigin } from '@/lib/url';
+import LandingCTAs from '@/components/landing/LandingCTAs';
 
 export default function AppHeader() {
   return (
     <header className="w-full border-b bg-white">
       <nav className="mx-auto flex max-w-6xl items-center justify-end gap-6 p-4 text-sm">
-        <Link href="/find">Find work</Link>
-        <Link href="/post">Post job</Link>
-        <Link href="/login">Login</Link>
+        <LandingCTAs findClassName="hover:underline" postClassName="hover:underline" />
+        <a href={withAppOrigin('/login')} className="hover:underline">
+          Login
+        </a>
       </nav>
     </header>
   );

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,14 +1,13 @@
 import { withAppOrigin } from '@/lib/url';
+import LandingCTAs from '@/components/landing/LandingCTAs';
 
 export default function LandingHeader() {
   return (
     <nav className="...">
-      <a href={withAppOrigin('/find')} className="...">
-        Find work
-      </a>
-      <a href={withAppOrigin('/post')} className="...">
-        Post job
-      </a>
+      <LandingCTAs
+        findClassName="hover:underline"
+        postClassName="btn btn-primary"
+      />
       <a href={withAppOrigin('/login')} className="...">
         Login
       </a>

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,16 +1,12 @@
-import { withAppOrigin } from '@/lib/url';
+import LandingCTAs from '@/components/landing/LandingCTAs';
 
 export default function LandingHero() {
   return (
     <section className="...">
-      <a href={withAppOrigin('/')} className="btn btn-primary">
-        Simulan na
-      </a>
-      <a href={withAppOrigin('/find')} className="btn btn-secondary">
-        Browse jobs
-      </a>
-      {/* If you show a “Mag-post ng Gig” button here, link it too */}
-      {/* <a href={withAppOrigin('/post')} className="btn">Mag-post ng Gig</a> */}
+      <LandingCTAs
+        findClassName="px-4 py-2 rounded-md bg-gray-100"
+        postClassName="px-4 py-2 rounded-md bg-blue-600 text-white"
+      />
     </section>
   );
 }

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -37,7 +37,7 @@
             >Maghanap ng Trabaho</a
           >
           <a
-            href="/post"
+            href="/posts"
             data-testid="nav-post"
             aria-label="Post job on QuickGig app"
             data-app-root
@@ -86,7 +86,7 @@
           >
           <a
             class="btn btn-ghost"
-            href="/post"
+            href="/posts"
             data-testid="cta-post-job"
             aria-label="Post job on QuickGig app"
             data-app-root

--- a/next.config.js
+++ b/next.config.js
@@ -48,6 +48,9 @@ const baseConfig = {
   },
   async redirects() {
     return [
+      // legacy to canonical
+      { source: "/post", destination: "/posts", permanent: true },
+      { source: "/finds", destination: "/find", permanent: true },
       {
         source: "/simulan",
         destination: "/start?intent=worker",

--- a/src/app/(marketing)/landing/page.tsx
+++ b/src/app/(marketing)/landing/page.tsx
@@ -1,27 +1,24 @@
-import Link from 'next/link';
 import LandingHeader from '@/components/landing/Header';
-import { appHref } from '@/lib/appOrigin';
+import LandingCTAs from '@/components/landing/LandingCTAs';
 
 export default function LandingPage() {
   return (
     <>
       <LandingHeader />
-      <main className="...">
-        <h1>
-          Kahit saan sa Pinas, <span className="accent">may gig para sa'yo!</span>
-        </h1>
-        <p>
-          Ang pinakamabilis na paraan para makahanap ng trabaho o mag-hire ng skilled professionals. Dito sa QuickGig.ph, madali lang!
-        </p>
-        <div className="actions">
-          <Link href={appHref('/')} prefetch={false} className="btn btn-primary">
-            Simulan na
-          </Link>
-          <Link href={appHref('/find')} prefetch={false} className="btn btn-secondary">
-            Browse jobs
-          </Link>
-        </div>
-      </main>
-    </>
-  );
-}
+        <main className="...">
+          <h1>
+            Kahit saan sa Pinas, <span className="accent">may gig para sa&apos;yo!</span>
+          </h1>
+          <p>
+            Ang pinakamabilis na paraan para makahanap ng trabaho o mag-hire ng skilled professionals. Dito sa QuickGig.ph, madali lang!
+          </p>
+          <div className="actions">
+            <LandingCTAs
+              findClassName="px-4 py-2 rounded-md bg-gray-100"
+              postClassName="px-4 py-2 rounded-md bg-blue-600 text-white"
+            />
+          </div>
+        </main>
+      </>
+    );
+  }

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { withAppOrigin } from "@/lib/url";
+import { ROUTE_FIND, ROUTE_POSTS } from "@/config/routes";
+
+type Props = {
+  findClassName?: string;
+  postClassName?: string;
+};
+
+export default function LandingCTAs({ findClassName = "", postClassName = "" }: Props) {
+  return (
+    <div className="flex gap-3">
+      <a href={withAppOrigin(ROUTE_FIND)} className={findClassName}>
+        Find Work
+      </a>
+      <a href={withAppOrigin(ROUTE_POSTS)} className={postClassName}>
+        Post Job
+      </a>
+    </div>
+  );
+}

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,0 +1,3 @@
+export const ROUTE_FIND   = "/find";
+export const ROUTE_POSTS  = "/posts";
+export const ROUTE_CREATE = "/create";

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,14 +1,15 @@
 export function getAppOrigin(): string {
-  // Prefer public var for client, fallback to APP_ORIGIN if present.
-  const fromPublic = process.env.NEXT_PUBLIC_APP_ORIGIN || '';
-  const fromBuild  = process.env.APP_ORIGIN || '';
-  const origin = (fromPublic || fromBuild || '').trim();
-  return origin.replace(/\/+$/, ''); // drop trailing slash
+  const fromPublic = process.env.NEXT_PUBLIC_APP_ORIGIN || "";
+  const fromBuild  = process.env.APP_ORIGIN || "";
+  const raw = (fromPublic || fromBuild || "").trim();
+  // Ensure we have a scheme; if someone sets app.quickgig.ph, prefix https://
+  const withScheme = raw && !/^https?:\/\//i.test(raw) ? `https://${raw}` : raw;
+  return (withScheme || "").replace(/\/+$/, "");
 }
 
 export function withAppOrigin(path: string): string {
-  const p = path.startsWith('/') ? path : `/${path}`;
+  const p = path.startsWith("/") ? path : `/${path}`;
   const origin = getAppOrigin();
-  // If origin is empty (dev preview), still return absolute-ish path so app works locally.
-  return origin ? `${origin}${p}`.replace(/([^:]\/)\/+/g, '$1') : p;
+  // If origin is empty (local dev), return p so local works.
+  return origin ? `${origin}${p}`.replace(/([^:]\/)\/+/g, "$1") : p;
 }


### PR DESCRIPTION
## Summary
- ensure landing and header CTAs point to canonical app URLs
- centralize route paths and CTA rendering
- add redirects for legacy /post and /finds links

## Changes
- add canonical route constants and URL origin helper
- introduce shared `<LandingCTAs>` component and replace scattered links
- wire header, hero, mobile sticky CTA, marketing page, and static HTML to use `/find` and `/posts`
- add resilient redirects in `next.config.js`

## Testing Steps
- `npm run lint`
- `npm run test:smoke` *(fails: missing Playwright browsers)*
- `npm run test:e2e:full` *(fails: missing Playwright browsers)*

## Acceptance
- Landing and header CTAs link to `https://app.quickgig.ph/find` and `/posts`
- `/post` and `/finds` redirect to `/posts` and `/find`
- Existing `/create` guard unaffected

## CI
- PR smoke: **failed** (missing Playwright browsers)
- Full QA: not run

## Rollback
- Revert this PR; no data migration needed.

------
https://chatgpt.com/codex/tasks/task_e_68b283b741e883279decd944856bd4a8