### PR TITLE
ci(e2e): use seed-aware Full E2E workflow

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -1,63 +1,131 @@
 name: Full E2E
-
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Optional external BASE_URL; empty = run locally"
+        required: false
+        default: ""
   push:
     branches: [ "main" ]
 
 concurrency:
   group: full-e2e-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    env:
+      NODE_ENV: production
+      PORT: 3000
+      LOCAL_BASE_URL: http://localhost:3000
+
+      # ------- EXISTING app/env variables -------
+      NEXT_PUBLIC_APP_ORIGIN: ${{ secrets.NEXT_PUBLIC_APP_ORIGIN }}
+      APP_ORIGIN: ${{ secrets.NEXT_PUBLIC_APP_ORIGIN }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+
+      # ------- OPTIONAL E2E secrets (safe fallbacks if absent) -------
+      E2E_KEY: ${{ secrets.E2E_KEY }}
+      E2E_EMPLOYER_EMAIL: ${{ secrets.E2E_EMPLOYER_EMAIL }}
+      E2E_WORKER_EMAIL:   ${{ secrets.E2E_WORKER_EMAIL }}
+      E2E_PASSWORD:       ${{ secrets.E2E_PASSWORD }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
           cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
+        run: |
+          npx playwright install --with-deps
+          node -e "console.log('Playwright version:', require('@playwright/test/package.json').version)"
 
       - name: Build
-        env:
-          NEXT_PUBLIC_APP_ORIGIN: ${{ secrets.NEXT_PUBLIC_APP_ORIGIN }}
-          APP_ORIGIN: ${{ secrets.APP_ORIGIN }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-        run: pnpm build
+        run: pnpm run build
 
       - name: Start app (background)
         run: |
-          pnpm start &>/dev/null &
-          echo "Waiting for app to be ready..."
-          npx wait-on http://localhost:3000
+          nohup pnpm run start -- -p $PORT > .next-app.log 2>&1 &
+          echo $! > .app-pid
+          for i in {1..60}; do
+            if curl -fsS "http://localhost:${PORT}/" >/dev/null; then echo "Server is up"; break; fi
+            sleep 1
+          done
 
-      - name: Run Full E2E
+      - name: Determine BASE_URL
+        id: base
+        run: |
+          if [ -n "${{ github.event.inputs.base_url }}" ]; then
+            echo "BASE_URL=${{ github.event.inputs.base_url }}" >> $GITHUB_OUTPUT
+          else
+            echo "BASE_URL=${LOCAL_BASE_URL}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Seed data (idempotent; no-op if E2E_KEY unset)
         env:
-          BASE_URL: http://localhost:3000
-        run: pnpm exec playwright test
+          BASE_URL: ${{ steps.base.outputs.BASE_URL }}
+        run: |
+          if [ -n "$E2E_KEY" ]; then
+            curl -sS -X POST "$BASE_URL/api/e2e/seed" -H "x-e2e-key: $E2E_KEY" -f
+          else
+            # No E2E_KEY configured; endpoint tolerates and returns 204 in previews
+            curl -sS -X POST "$BASE_URL/api/e2e/seed" || true
+          fi
+
+      - name: Run Full E2E regression pack
+        env:
+          BASE_URL: ${{ steps.base.outputs.BASE_URL }}
+        run: npx playwright test -c playwright.e2e.config.ts tests/e2e/regression --reporter=html,line
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-e2e
           path: playwright-report
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 7
+
+      - name: Upload Next server log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-app.log
+          path: .next-app.log
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        env:
+          BASE_URL: ${{ steps.base.outputs.BASE_URL }}
+        run: |
+          if [ -n "$E2E_KEY" ]; then
+            curl -sS -X POST "$BASE_URL/api/e2e/cleanup" -H "x-e2e-key: $E2E_KEY" || true
+          else
+            curl -sS -X POST "$BASE_URL/api/e2e/cleanup" || true
+          fi
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f .app-pid ]; then kill $(cat .app-pid) || true; fi

--- a/components/home/HomeEmployer.tsx
+++ b/components/home/HomeEmployer.tsx
@@ -167,7 +167,7 @@ export default function HomeEmployer() {
       {/* Top cards */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-3">
         <Card title="Tickets">
-          <div className="text-3xl font-semibold mb-3">{balance}</div>
+          <div data-testid="ticket-balance" className="text-3xl font-semibold mb-3">{balance}</div>
           <div className="flex gap-2">
             <Link href="/wallet" className="qg-btn qg-btn--primary px-3 py-2">
               Buy Tickets

--- a/pages/api/e2e/cleanup.ts
+++ b/pages/api/e2e/cleanup.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  // Optional protection (same contract as /seed)
+  const requiredKey = process.env.E2E_KEY;
+  if (requiredKey && req.headers["x-e2e-key"] !== requiredKey) return res.status(401).end();
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
+  const role = process.env.SUPABASE_SERVICE_ROLE as string | undefined;
+  if (!url || !role) return res.status(204).end();
+
+  const supabase = createClient(url, role, { auth: { persistSession: false } });
+
+  // Clean up artifacts tagged as 'e2e' (tables must exist in our schema)
+  try {
+    await supabase.from("applications").delete().eq("tag", "e2e");
+  } catch {}
+  try {
+    await supabase.from("gigs").delete().eq("tag", "e2e");
+  } catch {}
+  try {
+    await supabase.from("threads").delete().eq("tag", "e2e");
+  } catch {}
+
+  return res.status(200).json({ ok: true });
+}

--- a/pages/api/e2e/seed.ts
+++ b/pages/api/e2e/seed.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  // Optional protection: if E2E_KEY is set, require it; else, allow no-op seeding
+  const requiredKey = process.env.E2E_KEY;
+  if (requiredKey && req.headers["x-e2e-key"] !== requiredKey) return res.status(401).end();
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
+  const role = process.env.SUPABASE_SERVICE_ROLE as string | undefined;
+  if (!url || !role) {
+    // If Supabase vars are not present (e.g., preview site), just succeed no-op
+    return res.status(204).end();
+  }
+
+  const supabase = createClient(url, role, { auth: { persistSession: false } });
+
+  // Idempotent seed; values can be provided via optional E2E_* secrets, or defaults used.
+  const employerEmail = process.env.E2E_EMPLOYER_EMAIL || "e2e-employer@quickgig.ph";
+  const workerEmail = process.env.E2E_WORKER_EMAIL || "e2e-worker@quickgig.ph";
+  const passwd = process.env.E2E_PASSWORD || "E2e!Pass123";
+
+  try {
+    await supabase.auth.admin.createUser({ email: employerEmail, password: passwd, email_confirm: true });
+  } catch {}
+  try {
+    await supabase.auth.admin.createUser({ email: workerEmail, password: passwd, email_confirm: true });
+  } catch {}
+
+  const { data: users } = await supabase
+    .from("users")
+    .select("id,email")
+    .in("email", [employerEmail, workerEmail]);
+
+  const employer_id = users?.find((u) => u.email === employerEmail)?.id;
+  const worker_id = users?.find((u) => u.email === workerEmail)?.id;
+
+  // profiles table holds role + tickets in our app. Idempotent upsert.
+  if (employer_id || worker_id) {
+    await supabase
+      .from("profiles")
+      .upsert([
+        employer_id ? { user_id: employer_id, role: "employer", tickets: 3 } : undefined,
+        worker_id ? { user_id: worker_id, role: "worker", tickets: 3 } : undefined,
+      ].filter(Boolean) as any);
+  }
+
+  return res.status(200).json({ ok: true, employer_id, worker_id });
+}

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -117,7 +117,7 @@ export default function Home() {
         <input type="file" onChange={onAvatar} disabled={uploading} />
       </div>
       <div className="border rounded p-4 space-y-2">
-        <p>Ticket balance: {balance}</p>
+        <p data-testid="ticket-balance">Ticket balance: {balance}</p>
         <Link href="/post" className="qg-btn qg-btn--primary px-4 py-2">
           Post a job
         </Link>

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -1,21 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
-
 export default defineConfig({
-  testDir: "./tests",
-  testMatch: "e2e/**/*.spec.ts",
-  timeout: 120_000,
-  retries: 2,
-  workers: 4,
-  reporter: [["html", { outputFolder: "playwright-report", open: "never" }]],
+  testDir: "tests/e2e",
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
   use: {
-    baseURL: process.env.PLAYWRIGHT_APP_URL,
-    trace: "on-first-retry",
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    headless: true,
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
   },
-  projects: [
-    { name: "chromium-desktop", use: { ...devices["Desktop Chrome"] } },
-    { name: "chromium-mobile", use: { ...devices["iPhone 12"] } },
-  ],
-  outputDir: "test-results",
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  reporter: [["html", { open: "never" }]],
 });


### PR DESCRIPTION
## Summary
- add E2E seed/cleanup API routes using only existing Supabase env vars
- run Playwright regression via simplified config and workflow
- expose ticket balance for dashboard tests

## Changes
- new `/api/e2e/seed` and `/api/e2e/cleanup` endpoints
- replace `full-e2e.yml` GitHub workflow and `playwright.e2e.config.ts`
- add `data-testid="ticket-balance"` to dashboard ticket counters

## Testing Steps
- `pnpm lint`
- `pnpm build` *(fails: NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY required)*
- `pnpm test:smoke` *(fails: production build missing)*

## Acceptance
- E2E endpoints tolerate missing secrets and are idempotent
- Full E2E workflow relies only on existing env names, optional E2E secrets
- Ticket balance accessible in dashboards via `data-testid`

## Notes
- Ensure Supabase env variables exist in CI for successful build/test


------
https://chatgpt.com/codex/tasks/task_e_68b2d731dcb083279229149f0e970bfe