### PR TITLE
ci(e2e): fix pnpm not found by installing pnpm before setup-node

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -39,17 +39,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Install deps
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary
- ensure pnpm is available before node cache logic
- fix Full E2E workflow crash at job start

## Changes
- reorder steps in full-e2e workflow to install pnpm before setup-node

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to collect page data for /gigs/[id])* 
- `pnpm test:smoke` *(fails: Process from config.webServer was not able to start)*

## Acceptance
- Full E2E GitHub Action sets up pnpm and node successfully and runs tests

## CI
- PR smoke + clickmap green

## Rollback
- revert this PR

## Notes
- none


------
https://chatgpt.com/codex/tasks/task_e_68b2db2ecb0c832787e605c17b173074