### PR TITLE
meta: add PR template with reflection & lessons

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,32 @@
-## Summary
-_What does this change do?_
+## Why (context + intent)
+- Goal: <what this change moves us toward in the product milestone>
+- User impact: <what improves for workers/employers/admins>
+- Scope: <what’s in / what’s explicitly out>
 
-## Checklist
-- [ ] PR smoke green
-- [ ] Codex review ran (local or CI) and addressed comments
-- [ ] E2E (manual) run triggered if applicable
-- [ ] Docs updated (if needed)
+## What changed (summary)
+- <bullet list of concrete edits>
+
+## Lessons applied from previous tasks
+- <What went wrong before + what we’re doing differently now>
+- <Alignment with repo conventions (package manager, env names, CI patterns)>
+
+## Risks & mitigations
+- Risks: <behavioral/infra/test>
+- Mitigations: <gates, fallbacks, feature flags>
+
+## Validation plan
+- Local: <commands run>
+- CI: <which workflows should go green + artifacts to check>
+- Manual: <quick checklist to smoke the feature>
+
+## Rollback plan
+- <simple steps to revert / safe toggles>
+
+---
+
+### Checklist (must-keep)
+- [ ] Uses the project’s package manager per lockfile (npm vs pnpm)
+- [ ] Re-uses existing env names (no new secrets unless required)
+- [ ] Seeds/cleans test data deterministically (if tests touch data)
+- [ ] Always uploads Playwright/Next logs on failure
+- [ ] Adds/updates docs or comments if behavior changes


### PR DESCRIPTION
## Summary
- Adds .github/PULL_REQUEST_TEMPLATE.md so every PR includes context, lessons from past tasks, risks/mitigations, validation, and a must-keep checklist. No CI checks added.

## Changes
- Replace existing PR template with sections for context, lessons, risks, validation, rollback, and checklist.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

## Acceptance
- PR smoke + clickmap should remain green; full QA unaffected.

## Notes
- None.


------
https://chatgpt.com/codex/tasks/task_e_68b2e962d1988327973028e46fb68a76