### PR TITLE
feat: add reflection doc and full location dropdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,23 @@
-## Why (context + intent)
-- Goal: <what this change moves us toward in the product milestone>
-- User impact: <what improves for workers/employers/admins>
-- Scope: <what’s in / what’s explicitly out>
+## Summary
+- <what this change moves us toward and user impact>
 
-## What changed (summary)
+## Changes
 - <bullet list of concrete edits>
 
-## Lessons applied from previous tasks
-- <What went wrong before + what we’re doing differently now>
-- <Alignment with repo conventions (package manager, env names, CI patterns)>
+## Testing
+- <commands run>
 
-## Risks & mitigations
-- Risks: <behavioral/infra/test>
-- Mitigations: <gates, fallbacks, feature flags>
+## Smoke
+- <quick smoke validation>
 
-## Validation plan
-- Local: <commands run>
-- CI: <which workflows should go green + artifacts to check>
-- Manual: <quick checklist to smoke the feature>
+## Acceptance
+- <acceptance criteria>
 
-## Rollback plan
-- <simple steps to revert / safe toggles>
+## Notes / Next Steps
+- <follow-ups or future work>
+
+## Reflection & Lessons Learned
+- <what went wrong/right last time and how to avoid regressions>
 
 ---
 

--- a/docs/REFLECTIONS.md
+++ b/docs/REFLECTIONS.md
@@ -1,0 +1,3 @@
+# Reflections
+
+- _Add your lessons learned per PR here._

--- a/pages/post-job.tsx
+++ b/pages/post-job.tsx
@@ -7,13 +7,17 @@ import { useRequireUser } from "@/lib/useRequireUser";
 import { uploadPublicFile } from "@/lib/storage";
 import { hasApprovedOrder } from "@/utils/billing";
 import Link from "next/link";
-import LocationSelect from "@/components/LocationSelect";
+import LocationSelect, { LocationValue } from "@/components/location/LocationSelect";
 
 export default function PostJobPage() {
   const [title, setTitle] = useState("");
   const [description, setDesc] = useState("");
   const [budget, setBudget] = useState<number | "">("");
-  const [loc, setLoc] = useState<{ region_code: string; city_code: string }>({ region_code: "", city_code: "" });
+  const [loc, setLoc] = useState<LocationValue>({
+    regionCode: null,
+    provinceCode: null,
+    cityCode: null,
+  });
   const [imageUrl, setImageUrl] = useState("");
   const [msg, setMsg] = useState<string | null>(null);
   const router = useRouter();
@@ -47,8 +51,8 @@ export default function PostJobPage() {
           title,
           description,
           budget: budget === "" ? null : Number(budget),
-          region_code: loc.region_code || null,
-          city_code: loc.city_code || null,
+          region_code: loc.regionCode || null,
+          city_code: loc.cityCode || null,
           image_url: imageUrl,
         } satisfies Insert<"gigs">,
       ])

--- a/src/components/posts/CreatePostForm.tsx
+++ b/src/components/posts/CreatePostForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import * as React from "react";
-import LocationSelect from "@/components/LocationSelect";
+import LocationSelect, { LocationValue } from "@/components/location/LocationSelect";
 import { getBrowserSupabase } from "@/lib/supabase-browser";
 
 let supabase = getBrowserSupabase();
@@ -38,7 +38,14 @@ export async function submit(form: FormData) {
 }
 
 export default function CreatePostForm() {
-  const [form, setForm] = React.useState({ title:'', description:'', region_code:'', city_code:'', price_php:'' });
+  const [form, setForm] = React.useState({
+    title: '',
+    description: '',
+    region_code: '',
+    province_code: '',
+    city_code: '',
+    price_php: '',
+  });
   const [submitting, setSubmitting] = React.useState(false);
   const [err, setErr] = React.useState<string|null>(null);
 
@@ -49,7 +56,7 @@ export default function CreatePostForm() {
 
     try {
       await submit(new FormData(e.currentTarget));
-      setForm({ title:'', description:'', region_code:'', city_code:'', price_php:'' });
+      setForm({ title:'', description:'', region_code:'', province_code:'', city_code:'', price_php:'' });
       window.location.href = `/find`;
     } catch (e: any) {
       setErr(e.message || 'Create failed');
@@ -66,9 +73,23 @@ export default function CreatePostForm() {
                value={form.title} onChange={e=>setForm(f=>({...f, title:e.target.value}))} />
         <textarea name="description" className="border rounded-xl p-2 w-full" placeholder="Description"
                   value={form.description} onChange={e=>setForm(f=>({...f, description:e.target.value}))} />
-        <LocationSelect value={{ region_code: form.region_code, city_code: form.city_code }}
-                        onChange={(v)=>setForm(f=>({...f, ...v}))} />
+        <LocationSelect
+          value={{
+            regionCode: form.region_code || null,
+            provinceCode: form.province_code || null,
+            cityCode: form.city_code || null,
+          } as LocationValue}
+          onChange={(v) =>
+            setForm((f) => ({
+              ...f,
+              region_code: v.regionCode || '',
+              province_code: v.provinceCode || '',
+              city_code: v.cityCode || '',
+            }))
+          }
+        />
         <input type="hidden" name="region_code" value={form.region_code} />
+        <input type="hidden" name="province_code" value={form.province_code} />
         <input type="hidden" name="city_code" value={form.city_code} />
         <input name="price_php" className="border rounded-xl p-2 w-full" placeholder="Budget (optional)" inputMode="numeric"
                value={form.price_php} onChange={e=>setForm(f=>({...f, price_php:e.target.value}))} />

--- a/tests/smoke/location-select.spec.ts
+++ b/tests/smoke/location-select.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import LocationSelect from '../../components/location/LocationSelect';
+
+function countRegionOptions(html: string) {
+  const match = html.match(/data-testid="region-select"[^>]*>([\s\S]*?)<\/select>/);
+  if (!match) return 0;
+  const options = match[1].match(/<option/g) || [];
+  return Math.max(0, options.length - 1); // minus placeholder
+}
+
+test('LocationSelect renders full region list', async () => {
+  const html = renderToString(
+    React.createElement(LocationSelect, {
+      value: { regionCode: null, provinceCode: null, cityCode: null },
+      onChange: () => {},
+    }),
+  );
+  expect(countRegionOptions(html)).toBeGreaterThan(15);
+});


### PR DESCRIPTION
## Summary
- record lessons in docs/REFLECTIONS.md and PR template
- ensure job posting dropdown shows full PH regions and cities
- add smoke test for LocationSelect

## Changes
- add `/docs/REFLECTIONS.md`
- update PR template with reflection fields
- switch job post forms to canonical `LocationSelect`
- add Playwright smoke test for region list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL not set)*

## Smoke
- `npm run test:smoke` *(fails: Process from config.webServer was not able to start)*

## Acceptance
- job posting dropdown pulls from full static PH dataset

## Notes / Next Steps
- populate `docs/REFLECTIONS.md` on each PR
- ensure env vars in CI for build & smoke tests

## Reflection & Lessons Learned
- earlier dropdowns mirrored DB contents, hiding valid locations; using static canonical data prevents future gaps


------
https://chatgpt.com/codex/tasks/task_e_68b2ec781074832786adf5e498c528c4