### PR TITLE
fix(e2e): unstick Full E2E by using `npm install` (lockfile drift safe)

### DIFF
--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -44,8 +44,10 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      # Note: Use npm install here because E2E runs may coincide with lockfile drift.
+      # Release workflows can stay strict with `npm ci`.
       - name: Install deps
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Install Playwright browsers
         run: |


### PR DESCRIPTION
## Summary
* Switch Full E2E workflow from `npm ci` to `npm install --no-audit --no-fund` to tolerate lockfile drift.
* Leaves other workflows (release, smoke, etc.) unchanged.

## Why
* `npm ci` requires perfect lockfile sync; current failures show mismatched globby/slash versions during CI.
* We want the E2E pipeline to validate product behavior rather than fail early on lockfile churn.

## Scope
* Only `.github/workflows/full-e2e.yml`.

## Testing
* `npm install --no-audit --no-fund` *(failed: 403 Forbidden fetching globby)*
* `npm run build` *(failed: Named export 'globby' not found)*
* `npm run test:e2e` *(failed: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fc809da4832788a15f2ab1c10cf2