### PR TITLE
chore: configure e2e modes

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,16 +1,13 @@
-name: Full E2E
+name: PR Smoke + Slices
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 18 * * *"
-  push:
-    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
-  e2e:
+  pr:
     runs-on: ubuntu-latest
     env:
-      E2E_MODE: FULL
+      E2E_MODE: PR
       NEXT_PUBLIC_SUPABASE_URL: http://example.com
       NEXT_PUBLIC_SUPABASE_ANON_KEY: anon
       NEXT_PUBLIC_APP_ORIGIN: http://localhost:3000
@@ -57,7 +54,7 @@ jobs:
           done
           echo "App not ready"; exit 1
 
-      - name: Run Full tests
+      - name: Run PR tests (smoke + slices, no @wip)
         run: npx playwright test --reporter=line
 
       # ---- Artifacts ----

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Test conventions
+- **@smoke** — very fast checks; live in `tests/smoke/**`.
+- **@slice** — finished vertical slice tests; put `@slice` in the test title *or* name the file `*slice*.spec.ts`.
+- **@wip** — work-in-progress; excluded from PR.
+
+**PR runs**: `@smoke` + `@slice` (and anything with `slice`/`finished` in filename)
+
+**Full E2E**: everything (no filters)


### PR DESCRIPTION
## Summary
- run Playwright in PR or full mode via new `E2E_MODE`
- document tagging conventions and smoke workflow

## Changes
- gate Playwright tests with `E2E_MODE` and add PR filters
- add PR smoke workflow and retune full E2E schedule
- document test tags under `tests/`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*

## Acceptance
- PR workflow runs smoke and slice tests only
- Full E2E workflow runs nightly or via manual dispatch

## Notes
- Dependencies missing in container prevented local typecheck


------
https://chatgpt.com/codex/tasks/task_e_68b4395246c483279c21a2a4e812e761