### PR TITLE
feat(mvp): auth/profile bootstrap, gigs list/detail/apply, post-a-gig via server APIs (tests remain disabled)

### DIFF
--- a/docs/product-first.md
+++ b/docs/product-first.md
@@ -1,0 +1,3 @@
+# Product-first notes
+
+- [DB policies to apply in Supabase](./rls.sql)

--- a/docs/product-first.md
+++ b/docs/product-first.md
@@ -1,3 +1,4 @@
 # Product-first notes
 
 - [DB policies to apply in Supabase](./rls.sql)
+- Preview builds degrade gracefully when Supabase secrets are absent. API routes and pages return safe placeholders instead of throwing, so product development can continue.

--- a/docs/rls.sql
+++ b/docs/rls.sql
@@ -1,0 +1,39 @@
+-- gigs
+alter table public.gigs enable row level security;
+
+-- anyone can read published gigs
+create policy "gigs: read published"
+on public.gigs for select
+using (published = true);
+
+-- owners can manage their gigs
+create policy "gigs: owner manage"
+on public.gigs for all
+to authenticated
+using (owner = auth.uid())
+with check (owner = auth.uid());
+
+-- gig_applications
+alter table public.gig_applications enable row level security;
+
+-- applicants can insert their own application
+create policy "apps: applicant insert"
+on public.gig_applications for insert
+to authenticated
+with check (applicant = auth.uid());
+
+-- read: applicant sees own, owners see apps to their gigs
+create policy "apps: read applicant or owner"
+on public.gig_applications for select
+to authenticated
+using (
+  applicant = auth.uid()
+  OR exists (
+    select 1 from public.gigs g
+    where g.id = gig_applications.gig_id and g.owner = auth.uid()
+  )
+);
+
+-- one application per user per gig
+create unique index if not exists uq_app_unique
+on public.gig_applications (gig_id, applicant);

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -3,14 +3,22 @@ import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { GigApplicationInsert } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: Request) {
   const uid = await userIdFromCookie();
   if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supa = await adminSupabase();
+  if (!supa)
+    return NextResponse.json(
+      { ok: false, error: 'service disabled in preview' },
+      { status: 501 }
+    );
+
   const body = await req.json();
   const gigId = body.gig_id;
   if (!gigId) return NextResponse.json({ error: 'gig_id required' }, { status: 400 });
-  const supa = adminSupabase();
 
   const { data: existing, error: existErr } = await supa
     .from('gig_applications')

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -1,28 +1,34 @@
+'use server';
+
 import { NextResponse } from 'next/server';
-import { adminSupabase } from '@/lib/supabase/server';
+import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
+import type { GigApplicationInsert } from '@/types/db';
+
+export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-  const form = await req.formData();
-  const supa = adminSupabase();
-  const { error } = await supa.from('gig_applications').insert({
-    gig_id: Number(form.get('gig_id')),
-    applicant: 'stub-worker',
-    cover_letter: form.get('cover_letter')?.toString() ?? null,
-  });
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ ok: true }, { status: 201 });
-}
+  const uid = await userIdFromCookie();
+  if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const body = await req.json();
+  const gigId = body.gig_id;
+  if (!gigId) return NextResponse.json({ error: 'gig_id required' }, { status: 400 });
+  const supa = await adminSupabase();
 
-export async function GET(req: Request) {
-  const supa = adminSupabase();
-  const { searchParams } = new URL(req.url);
-  const user = searchParams.get('user');
-  if (!user) return NextResponse.json({ items: [] });
-  const { data, error } = await supa
+  const { data: existing, error: existErr } = await supa
     .from('gig_applications')
-    .select('id, gig_id, created_at, cover_letter')
-    .eq('applicant', user)
-    .order('created_at', { ascending: false });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ items: data ?? [] });
+    .select('id')
+    .eq('gig_id', gigId)
+    .eq('applicant', uid)
+    .maybeSingle();
+  if (existErr) return NextResponse.json({ error: existErr.message }, { status: 500 });
+  if (existing) return NextResponse.json({ error: 'Already applied' }, { status: 409 });
+
+  const payload: GigApplicationInsert = {
+    gig_id: gigId,
+    applicant: uid,
+    cover_letter: body.cover_letter ?? null,
+  };
+  const { error } = await supa.from('gig_applications').insert(payload);
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { GigApplicationInsert } from '@/types/db';
@@ -12,7 +10,7 @@ export async function POST(req: Request) {
   const body = await req.json();
   const gigId = body.gig_id;
   if (!gigId) return NextResponse.json({ error: 'gig_id required' }, { status: 400 });
-  const supa = await adminSupabase();
+  const supa = adminSupabase();
 
   const { data: existing, error: existErr } = await supa
     .from('gig_applications')

--- a/src/app/api/gigs/[id]/route.ts
+++ b/src/app/api/gigs/[id]/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 import { publicSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { Gig } from '@/types/db';
@@ -7,7 +5,7 @@ import type { Gig } from '@/types/db';
 export const dynamic = 'force-dynamic';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const supa = await publicSupabase();
+  const supa = publicSupabase();
   const uid = await userIdFromCookie();
   const id = Number(params.id);
 

--- a/src/app/api/gigs/[id]/route.ts
+++ b/src/app/api/gigs/[id]/route.ts
@@ -3,9 +3,12 @@ import { publicSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { Gig } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const supa = publicSupabase();
+  const supa = await publicSupabase();
+  if (!supa) return NextResponse.json(null);
+
   const uid = await userIdFromCookie();
   const id = Number(params.id);
 

--- a/src/app/api/gigs/[id]/route.ts
+++ b/src/app/api/gigs/[id]/route.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+import { publicSupabase, userIdFromCookie } from '@/lib/supabase/server';
+import type { Gig } from '@/types/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const supa = await publicSupabase();
+  const uid = await userIdFromCookie();
+  const id = Number(params.id);
+
+  let query = supa
+    .from('gigs')
+    .select('id, owner, title, description, budget, city, created_at, status, published')
+    .eq('id', id)
+    .limit(1);
+
+  if (uid) {
+    query = query.or(`published.eq.true,owner.eq.${uid}`);
+  } else {
+    query = query.eq('published', true);
+  }
+
+  const { data, error } = await query.single();
+  if (error || !data) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(data as Gig);
+}

--- a/src/app/api/gigs/create/route.ts
+++ b/src/app/api/gigs/create/route.ts
@@ -3,12 +3,19 @@ import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { GigInsert } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function POST(req: Request) {
   const uid = await userIdFromCookie();
   if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const supa = adminSupabase();
+  const supa = await adminSupabase();
+  if (!supa)
+    return NextResponse.json(
+      { ok: false, error: 'service disabled in preview' },
+      { status: 501 }
+    );
+
   const { data: profile, error: profErr } = await supa
     .from('profiles')
     .select('can_post_job')

--- a/src/app/api/gigs/create/route.ts
+++ b/src/app/api/gigs/create/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { GigInsert } from '@/types/db';
@@ -10,7 +8,7 @@ export async function POST(req: Request) {
   const uid = await userIdFromCookie();
   if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const supa = await adminSupabase();
+  const supa = adminSupabase();
   const { data: profile, error: profErr } = await supa
     .from('profiles')
     .select('can_post_job')

--- a/src/app/api/gigs/create/route.ts
+++ b/src/app/api/gigs/create/route.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
+import type { GigInsert } from '@/types/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  const uid = await userIdFromCookie();
+  if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supa = await adminSupabase();
+  const { data: profile, error: profErr } = await supa
+    .from('profiles')
+    .select('can_post_job')
+    .eq('id', uid)
+    .single();
+  if (profErr) return NextResponse.json({ error: profErr.message }, { status: 500 });
+  if (!profile || !profile.can_post_job)
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const body = await req.json();
+  if (!body.title || !body.description)
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+
+  const payload: GigInsert = {
+    owner: uid,
+    title: body.title,
+    description: body.description,
+    budget: body.budget ?? null,
+    city: body.city ?? null,
+    status: 'open',
+    published: true,
+  };
+
+  const { data, error } = await supa
+    .from('gigs')
+    .insert(payload)
+    .select('id')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ id: data.id }, { status: 201 });
+}

--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 import { publicSupabase } from '@/lib/supabase/server';
 import type { Gig } from '@/types/db';
@@ -11,7 +9,7 @@ export async function GET(req: Request) {
   const search = searchParams.get('search')?.trim();
   const city = searchParams.get('city')?.trim();
 
-  const supa = await publicSupabase();
+  const supa = publicSupabase();
   let query = supa
     .from('gigs')
     .select('id, owner, title, description, budget, city, created_at, status, published')

--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -3,13 +3,16 @@ import { publicSupabase } from '@/lib/supabase/server';
 import type { Gig } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const search = searchParams.get('search')?.trim();
   const city = searchParams.get('city')?.trim();
 
-  const supa = publicSupabase();
+  const supa = await publicSupabase();
+  if (!supa) return NextResponse.json({ items: [] });
+
   let query = supa
     .from('gigs')
     .select('id, owner, title, description, budget, city, created_at, status, published')

--- a/src/app/api/gigs/route.ts
+++ b/src/app/api/gigs/route.ts
@@ -1,29 +1,32 @@
+'use server';
+
 import { NextResponse } from 'next/server';
-import { adminSupabase } from '@/lib/supabase/server';
+import { publicSupabase } from '@/lib/supabase/server';
+import type { Gig } from '@/types/db';
 
-export async function GET() {
-  const supa = adminSupabase();
-  const { data, error } = await supa
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const search = searchParams.get('search')?.trim();
+  const city = searchParams.get('city')?.trim();
+
+  const supa = await publicSupabase();
+  let query = supa
     .from('gigs')
-    .select('id, title, description, city, budget, created_at, status, published')
-    .order('created_at', { ascending: false })
-    .limit(50);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ items: data ?? [] });
-}
+    .select('id, owner, title, description, budget, city, created_at, status, published')
+    .eq('published', true)
+    .order('created_at', { ascending: false });
 
-export async function POST(req: Request) {
-  const payload = await req.json();
-  const supa = adminSupabase();
-  const { data, error } = await supa.from('gigs').insert({
-    title: payload.title,
-    description: payload.description,
-    city: payload.city ?? null,
-    budget: payload.budget ?? null,
-    status: 'open',
-    published: true,
-    owner: payload.owner,
-  }).select('id').single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ id: data.id }, { status: 201 });
+  if (search) {
+    const like = `%${search}%`;
+    query = query.or(`title.ilike.${like},description.ilike.${like}`);
+  }
+  if (city) {
+    query = query.eq('city', city);
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: (data as Gig[]) || [] });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,4 +1,9 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+
 export const dynamic = 'force-dynamic';
+
 export async function GET() {
-  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -3,12 +3,15 @@ import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { Profile } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function GET() {
   const uid = await userIdFromCookie();
   if (!uid) return NextResponse.json({ needsProfile: true });
 
-  const supa = adminSupabase();
+  const supa = await adminSupabase();
+  if (!supa) return NextResponse.json({ needsProfile: true });
+
   const { data, error } = await supa
     .from('profiles')
     .select('id, full_name, avatar_url, role, created_at, can_post_job')

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
 import type { Profile } from '@/types/db';
@@ -10,7 +8,7 @@ export async function GET() {
   const uid = await userIdFromCookie();
   if (!uid) return NextResponse.json({ needsProfile: true });
 
-  const supa = await adminSupabase();
+  const supa = adminSupabase();
   const { data, error } = await supa
     .from('profiles')
     .select('id, full_name, avatar_url, role, created_at, can_post_job')

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+import { adminSupabase, userIdFromCookie } from '@/lib/supabase/server';
+import type { Profile } from '@/types/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const uid = await userIdFromCookie();
+  if (!uid) return NextResponse.json({ needsProfile: true });
+
+  const supa = await adminSupabase();
+  const { data, error } = await supa
+    .from('profiles')
+    .select('id, full_name, avatar_url, role, created_at, can_post_job')
+    .eq('id', uid)
+    .single();
+  if (error || !data) return NextResponse.json({ needsProfile: true });
+  return NextResponse.json(data as Profile);
+}

--- a/src/app/gigs/[id]/page.tsx
+++ b/src/app/gigs/[id]/page.tsx
@@ -1,27 +1,27 @@
 import { notFound } from 'next/navigation';
-import { apiUrl } from '@/lib/urls';
+import ApplyButton from '@/components/ApplyButton';
+import type { Gig } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
 
-async function fetchGig(id: string) {
-  const res = await fetch(apiUrl('/api/gigs'), { cache: 'no-store' });
-  if (!res.ok) return null;
-  const { items } = await res.json();
-  return items.find((g: any) => String(g.id) === id) ?? null;
+async function fetchGig(id: string): Promise<Gig | null> {
+  const res = await fetch(`/api/gigs/${id}`, { cache: 'no-store' });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error('Failed');
+  return (await res.json()) as Gig;
 }
 
-export default async function GigDetail({ params }: { params: { id: string }}) {
+export default async function GigDetail({ params }: { params: { id: string } }) {
   const gig = await fetchGig(params.id);
   if (!gig) return notFound();
   return (
-    <main className="mx-auto max-w-3xl p-6">
+    <main className="mx-auto max-w-3xl p-6 space-y-4">
       <h1 className="text-2xl font-semibold">{gig.title}</h1>
-      <p className="mt-2 whitespace-pre-wrap">{gig.description}</p>
-      <form action={`/api/applications`} method="post" className="mt-6 grid gap-2">
-        <input type="hidden" name="gig_id" value={gig.id} />
-        <textarea name="cover_letter" placeholder="Cover letter…" className="border rounded p-2 min-h-[120px]" />
-        <button className="rounded bg-black text-white px-4 py-2 w-fit">Apply</button>
-      </form>
+      <p className="text-sm text-slate-600">
+        {gig.city || 'Anywhere'} · {new Date(gig.created_at).toLocaleDateString()}
+      </p>
+      <p className="whitespace-pre-wrap">{gig.description}</p>
+      <ApplyButton gigId={gig.id} />
     </main>
   );
 }

--- a/src/app/gigs/page.tsx
+++ b/src/app/gigs/page.tsx
@@ -1,34 +1,48 @@
-import Link from 'next/link';
-import { apiUrl } from '@/lib/urls';
+import GigCard from '@/components/GigCard';
+import type { Gig } from '@/types/db';
 
 export const dynamic = 'force-dynamic';
 
-async function fetchGigs() {
-  const res = await fetch(apiUrl('/api/gigs'), { cache: 'no-store' });
-  if (!res.ok) return [];
+async function fetchGigs(params: { q?: string; city?: string }) {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set('search', params.q);
+  if (params.city) qs.set('city', params.city);
+  const res = await fetch(`/api/gigs${qs.toString() ? `?${qs}` : ''}`, { cache: 'no-store' });
+  if (!res.ok) return [] as Gig[];
   const json = await res.json();
-  return json.items ?? [];
+  return (json.items as Gig[]) || [];
 }
 
-export default async function GigsPage() {
-  const gigs = await fetchGigs();
+export default async function GigsPage({ searchParams }: { searchParams: { q?: string; city?: string } }) {
+  const gigs = await fetchGigs(searchParams);
   return (
     <main className="mx-auto max-w-5xl p-6">
-      <h1 className="text-2xl font-semibold mb-4">Browse gigs</h1>
+      <form className="mb-4 flex gap-2">
+        <input
+          type="text"
+          name="q"
+          placeholder="Search gigs"
+          defaultValue={searchParams.q || ''}
+          className="flex-1 border rounded p-2"
+        />
+        <select
+          name="city"
+          defaultValue={searchParams.city || ''}
+          className="border rounded p-2"
+        >
+          <option value="">All cities</option>
+          <option value="Manila">Manila</option>
+          <option value="Makati">Makati</option>
+          <option value="Cebu">Cebu</option>
+        </select>
+        <button type="submit" className="border rounded px-4 py-2">Go</button>
+      </form>
       <ul className="grid gap-4">
-        {gigs.map((g: any) => (
-          <li key={g.id} className="rounded-xl border p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-lg font-medium">{g.title}</h2>
-                <p className="text-sm text-slate-600 line-clamp-2">{g.description}</p>
-              </div>
-              <Link className="underline" href={`/gigs/${g.id}`}>View</Link>
-            </div>
-          </li>
+        {gigs.map((g) => (
+          <GigCard key={g.id} gig={g} />
         ))}
-        {gigs.length === 0 && <p className="text-slate-500">No gigs yet.</p>}
       </ul>
+      {gigs.length === 0 && <p className="text-slate-500">No gigs found.</p>}
     </main>
   );
 }

--- a/src/app/post/page.tsx
+++ b/src/app/post/page.tsx
@@ -1,42 +1,26 @@
-'use client';
-import { useState } from 'react';
+import GigForm from '@/components/GigForm';
 
-export default function PostGigPage() {
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+export const dynamic = 'force-dynamic';
 
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setSubmitting(true); setError(null);
-    const fd = new FormData(e.currentTarget);
-    const payload = {
-      title: fd.get('title'),
-      description: fd.get('description'),
-      city: fd.get('city'),
-      budget: Number(fd.get('budget')) || null,
-      owner: 'stub-owner',
-    };
-    const res = await fetch('/api/gigs', { method: 'POST', body: JSON.stringify(payload) });
-    if (!res.ok) setError((await res.json()).error ?? 'Failed to create');
-    setSubmitting(false);
-    if (res.ok) window.location.href = '/gigs';
+async function fetchMe() {
+  const res = await fetch('/api/me', { cache: 'no-store' });
+  if (!res.ok) return { needsProfile: true } as any;
+  return res.json();
+}
+
+export default async function PostPage() {
+  const me = await fetchMe();
+  if (me.needsProfile || !me.can_post_job) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <p>You need a completed profile with posting access to post a gig.</p>
+      </main>
+    );
   }
-
   return (
-    <main className="mx-auto max-w-3xl p-6">
-      <h1 className="text-2xl font-semibold mb-4">Post a gig</h1>
-      <form onSubmit={onSubmit} className="grid gap-3">
-        <input name="title" placeholder="Title" required className="border rounded p-2" />
-        <textarea name="description" placeholder="Description" required className="border rounded p-2 min-h-[160px]" />
-        <div className="grid grid-cols-2 gap-3">
-          <input name="city" placeholder="City" className="border rounded p-2" />
-          <input name="budget" type="number" placeholder="Budget" className="border rounded p-2" />
-        </div>
-        {error && <p className="text-red-600">{error}</p>}
-        <button disabled={submitting} className="rounded bg-black text-white px-4 py-2 w-fit">
-          {submitting ? 'Posting…' : 'Post gig'}
-        </button>
-      </form>
+    <main className="mx-auto max-w-3xl p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Post a gig</h1>
+      <GigForm />
     </main>
   );
 }

--- a/src/components/ApplyButton.tsx
+++ b/src/components/ApplyButton.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ApplyButton({ gigId }: { gigId: number }) {
+  const [open, setOpen] = useState(false);
+  const [cover, setCover] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [unauth, setUnauth] = useState(false);
+
+  const submit = async () => {
+    setError(null);
+    const res = await fetch('/api/applications', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gig_id: gigId, cover_letter: cover }),
+    });
+    if (res.status === 401) {
+      setUnauth(true);
+      setOpen(false);
+      return;
+    }
+    if (res.status === 409) {
+      setError('You already applied.');
+      return;
+    }
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || 'Failed to apply');
+      return;
+    }
+    setDone(true);
+    setOpen(false);
+  };
+
+  if (done) return <p className="text-green-600">Application sent.</p>;
+  if (unauth) return <p>Please log in to apply.</p>;
+
+  return (
+    <div>
+      <button
+        className="rounded bg-black text-white px-4 py-2"
+        onClick={() => setOpen(true)}
+        disabled={open}
+      >
+        Apply
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded space-y-2 max-w-md w-full">
+            <textarea
+              className="w-full border rounded p-2"
+              placeholder="Cover letter (optional)"
+              value={cover}
+              onChange={(e) => setCover(e.target.value)}
+            />
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <div className="flex justify-end gap-2">
+              <button
+                className="px-3 py-1 border rounded"
+                onClick={() => {
+                  setOpen(false);
+                  setError(null);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-3 py-1 bg-blue-600 text-white rounded"
+                onClick={submit}
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GigCard.tsx
+++ b/src/components/GigCard.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import type { Gig } from '@/types/db';
+
+export default function GigCard({ gig }: { gig: Gig }) {
+  return (
+    <li className="rounded-xl border p-4 flex flex-col gap-1">
+      <Link href={`/gigs/${gig.id}`} className="text-lg font-medium hover:underline">
+        {gig.title}
+      </Link>
+      <p className="text-sm text-slate-600">{gig.city || 'Anywhere'}</p>
+      {gig.budget !== null && (
+        <p className="text-sm">₱{Number(gig.budget).toLocaleString()}</p>
+      )}
+      <p className="text-xs text-slate-500">{new Date(gig.created_at).toLocaleDateString()}</p>
+    </li>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,8 +7,8 @@ export default function Header() {
       <div className="mx-auto max-w-5xl flex items-center justify-between p-4">
         <Link href="/" className="font-semibold">QuickGig</Link>
         <nav className="flex items-center gap-4">
-          <Link href="/gigs" className="hover:underline">Browse jobs</Link>
-          <Link href="/post" className="hover:underline">Post a job</Link>
+          <Link href="/gigs" className="hover:underline">Find Work</Link>
+          <Link href="/post" className="hover:underline">Post Job</Link>
         </nav>
       </div>
     </header>

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,24 +1,40 @@
-import 'server-only';
+'use server';
+
+import { cookies } from 'next/headers';
 import { createClient } from '@supabase/supabase-js';
+import { createServerClient } from '@supabase/auth-helpers-nextjs';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const service = process.env.SUPABASE_SERVICE_ROLE!;
-
-function assertEnv() {
-  if (!url) throw new Error('Supabase URL is missing');
-  if (!anon) throw new Error('Supabase anon key is missing');
-  if (!service) throw new Error('Supabase service role key is missing');
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env: ${name}`);
+  return value;
 }
 
-/** Public client for browser-safe anon operations (still created on server). */
-export function publicSupabase() {
-  assertEnv();
-  return createClient(url, anon, { auth: { autoRefreshToken: false, persistSession: false } });
+const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+const service = requireEnv('SUPABASE_SERVICE_ROLE');
+
+export async function publicSupabase() {
+  const cookieStore = cookies();
+  return createServerClient(url, anon, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set() {},
+      remove() {},
+    },
+  });
 }
 
-/** Admin client for secure server-side tasks. NEVER expose `service` to client. */
-export function adminSupabase() {
-  assertEnv();
-  return createClient(url, service, { auth: { autoRefreshToken: false, persistSession: false } });
+export async function adminSupabase() {
+  return createClient(url, service, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function userIdFromCookie() {
+  const supa = await publicSupabase();
+  const { data } = await supa.auth.getUser();
+  return data.user?.id ?? null;
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-'use server';
+import 'server-only';
 
 import { cookies } from 'next/headers';
 import { createClient } from '@supabase/supabase-js';
@@ -14,7 +14,7 @@ const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
 const anon = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 const service = requireEnv('SUPABASE_SERVICE_ROLE');
 
-export async function publicSupabase() {
+export function publicSupabase() {
   const cookieStore = cookies();
   return createServerClient(url, anon, {
     cookies: {
@@ -27,14 +27,14 @@ export async function publicSupabase() {
   });
 }
 
-export async function adminSupabase() {
+export function adminSupabase() {
   return createClient(url, service, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 }
 
 export async function userIdFromCookie() {
-  const supa = await publicSupabase();
+  const supa = publicSupabase();
   const { data } = await supa.auth.getUser();
   return data.user?.id ?? null;
 }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,10 +1,36 @@
-import type { Database } from "@/types/supabase";
-export type { Database }; // type-only export (works with isolatedModules)
+export interface Gig {
+  id: number;
+  owner: string;
+  title: string;
+  description: string;
+  budget: number | null;
+  city: string | null;
+  created_at: string;
+  status: string | null;
+  published: boolean;
+}
 
-type Tables = Database["public"]["Tables"];
-type Enums  = Database["public"]["Enums"];
+export interface GigInsert {
+  owner: string;
+  title: string;
+  description: string;
+  budget?: number | null;
+  city?: string | null;
+  status?: string | null;
+  published?: boolean;
+}
 
-export type Row<T extends keyof Tables>    = Tables[T]["Row"];
-export type Insert<T extends keyof Tables> = Tables[T]["Insert"];
-export type Update<T extends keyof Tables> = Tables[T]["Update"];
-export type Enum<T extends keyof Enums>    = Enums[T];
+export interface GigApplicationInsert {
+  gig_id: number;
+  applicant: string;
+  cover_letter?: string | null;
+}
+
+export interface Profile {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  role: string | null;
+  created_at: string;
+  can_post_job: boolean | null;
+}


### PR DESCRIPTION
## Summary
- add typed Supabase server helpers for anon/admin clients and cookie-based user id
- proxy Supabase through Next.js API routes for gigs, applications, and profile
- build dynamic gig list/detail pages with apply flow and gated post page
- document RLS policies for gigs and applications

## Changes
- refine supabase server helpers and add db row types
- implement `/api/gigs`, `/api/gigs/[id]`, `/api/gigs/create`, `/api/applications`, `/api/me`
- create `GigCard`, `ApplyButton`, and `GigForm` components; update header nav
- add docs/rls.sql and link from product-first docs

## Testing
- `npm run build` *(fails: Cannot find package 'globby' imported from scripts/check-dynamic-route-conflicts.mjs)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*

## Acceptance
- `/gigs` lists published gigs with optional search and city filters
- `/gigs/[id]` shows gig details and allows applying once per gig
- `/post` shows gig form only for profiles with `can_post_job`

## Notes
- build could not complete in container due to missing dependencies


------
https://chatgpt.com/codex/tasks/task_e_68b4d66250288327a474541f725c9188