### PR TITLE
feat(mvp): employer dashboard — manage gigs & applicants (no SSG; mock fallback)

### DIFF
--- a/docs/product-first.md
+++ b/docs/product-first.md
@@ -23,3 +23,9 @@ in-memory mock store so the flow still works.
 
 `/applications` is dynamic (no SSG) to avoid preview build failures. It falls
 back to mock data when secrets are absent; replace by real DB later.
+
+## Employer dashboard
+
+The `/owner/gigs` pages and APIs are dynamic and fall back to in-memory mocks
+when Supabase secrets are absent. Preview builds can list gigs, view applicants,
+and update statuses without hitting the database.

--- a/src/app/api/applications/[id]/status/route.ts
+++ b/src/app/api/applications/[id]/status/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { adminSupabase } from '@/lib/supabase/server';
+import { setApplicationStatus } from '@/lib/mock/owner';
+import type { AppStatus } from '@/types/owner';
+
+export const runtime = 'nodejs';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const status = body?.status as AppStatus;
+  if (status !== 'accepted' && status !== 'rejected') {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+  }
+  const appId = params.id;
+  const supa = await adminSupabase();
+  if (!supa) {
+    const ok = setApplicationStatus(appId, status);
+    if (!ok) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ ok: true, status });
+  }
+  try {
+    const { error } = await supa
+      .from('gig_applications')
+      .update({ status })
+      .eq('id', appId);
+    if (error) throw error;
+    return NextResponse.json({ ok: true, status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message || 'Unexpected error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/owner/gigs/[id]/applicants/route.ts
+++ b/src/app/api/owner/gigs/[id]/applicants/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { publicSupabase } from '@/lib/supabase/server';
+import { listApplicants } from '@/lib/mock/owner';
+import type { ApplicantRow } from '@/types/owner';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const gigId = params.id;
+  const supa = await publicSupabase();
+  if (!supa) {
+    const items = listApplicants(gigId);
+    return NextResponse.json({ items });
+  }
+  try {
+    const { data, error } = await supa
+      .from('gig_applications')
+      .select('id,applicant,created_at,status')
+      .eq('gig_id', gigId);
+    if (error) throw error;
+    return NextResponse.json({ items: (data as ApplicantRow[]) ?? [] });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message || 'Unexpected error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/owner/gigs/[id]/status/route.ts
+++ b/src/app/api/owner/gigs/[id]/status/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { adminSupabase } from '@/lib/supabase/server';
+import { setGigStatus } from '@/lib/mock/owner';
+
+export const runtime = 'nodejs';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const status = body?.status;
+  if (status !== 'open' && status !== 'closed') {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+  }
+  const gigId = params.id;
+  const uid = 'stub-owner';
+  const supa = await adminSupabase();
+  if (!supa) {
+    const ok = setGigStatus(gigId, status);
+    if (!ok) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ ok: true, status });
+  }
+  try {
+    const { error } = await supa
+      .from('gigs')
+      .update({ status })
+      .eq('id', gigId)
+      .eq('owner', uid);
+    if (error) throw error;
+    return NextResponse.json({ ok: true, status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message || 'Unexpected error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/owner/gigs/route.ts
+++ b/src/app/api/owner/gigs/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { publicSupabase } from '@/lib/supabase/server';
+import { listGigs } from '@/lib/mock/owner';
+import type { OwnerGigRow } from '@/types/owner';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const uid = 'stub-owner';
+  const supa = await publicSupabase();
+  if (!supa) {
+    const items = listGigs(uid);
+    return NextResponse.json({ items });
+  }
+  try {
+    const { data, error } = await supa
+      .from('gigs')
+      .select('id,title,city,budget,status,created_at')
+      .eq('owner', uid);
+    if (error) throw error;
+    return NextResponse.json({ items: (data as OwnerGigRow[]) ?? [] });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message || 'Unexpected error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/owner/gigs/[id]/applicants/page.tsx
+++ b/src/app/owner/gigs/[id]/applicants/page.tsx
@@ -1,0 +1,24 @@
+import ApplicantsTable from '@/components/owner/ApplicantsTable';
+import { getOrigin } from '@/lib/origin';
+import type { ApplicantRow } from '@/types/owner';
+
+export const dynamic = 'force-dynamic';
+
+export default async function GigApplicantsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const res = await fetch(
+    `${getOrigin()}/api/owner/gigs/${params.id}/applicants`,
+    { cache: 'no-store' },
+  );
+  const data = await res.json().catch(() => ({ items: [] }));
+  const items = (data.items as ApplicantRow[]) || [];
+  return (
+    <main className="mx-auto max-w-3xl p-6 space-y-4">
+      <h1 className="text-xl font-semibold">Applicants</h1>
+      <ApplicantsTable items={items} />
+    </main>
+  );
+}

--- a/src/app/owner/gigs/page.tsx
+++ b/src/app/owner/gigs/page.tsx
@@ -1,0 +1,27 @@
+import GigRow from '@/components/owner/GigRow';
+import { getOrigin } from '@/lib/origin';
+import type { OwnerGigRow } from '@/types/owner';
+
+export const dynamic = 'force-dynamic';
+
+export default async function OwnerGigsPage() {
+  const res = await fetch(`${getOrigin()}/api/owner/gigs`, {
+    cache: 'no-store',
+  });
+  const data = await res.json().catch(() => ({ items: [] }));
+  const items = (data.items as OwnerGigRow[]) || [];
+  return (
+    <main className="mx-auto max-w-3xl p-6 space-y-4">
+      <h1 className="text-xl font-semibold">My Gigs</h1>
+      {items.length === 0 ? (
+        <p>No gigs found.</p>
+      ) : (
+        <ul className="divide-y border rounded">
+          {items.map((g) => (
+            <GigRow key={g.id} gig={g} />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/components/nav/MainNav.tsx
+++ b/src/components/nav/MainNav.tsx
@@ -9,6 +9,9 @@ export default function MainNav() {
       <Link href="/gigs/create" className="hover:underline">
         Post a Gig
       </Link>
+      <Link href="/owner/gigs" className="hover:underline">
+        My Gigs
+      </Link>
     </nav>
   );
 }

--- a/src/components/owner/ApplicantsTable.tsx
+++ b/src/components/owner/ApplicantsTable.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import type { ApplicantRow } from '@/types/owner';
+
+export default function ApplicantsTable({ items }: { items: ApplicantRow[] }) {
+  const [rows, setRows] = useState(items);
+
+  const updateStatus = async (
+    id: string,
+    status: 'accepted' | 'rejected',
+  ) => {
+    setRows((r) => r.map((a) => (a.id === id ? { ...a, status } : a)));
+    try {
+      await fetch(`/api/applications/${id}/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+    } catch {
+      // ignore
+    }
+  };
+
+  if (rows.length === 0) return <p>No applicants yet.</p>;
+
+  return (
+    <table className="w-full text-sm border">
+      <thead>
+        <tr className="bg-gray-50">
+          <th className="p-2 text-left">Applicant</th>
+          <th className="p-2 text-left">Submitted</th>
+          <th className="p-2">Status</th>
+          <th className="p-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((a) => (
+          <tr key={a.id} className="border-t">
+            <td className="p-2">{a.applicant}</td>
+            <td className="p-2">
+              {new Date(a.created_at).toLocaleDateString()}
+            </td>
+            <td className="p-2 capitalize">{a.status}</td>
+            <td className="p-2 flex gap-2 justify-center">
+              <button
+                className="px-2 py-1 border rounded"
+                disabled={a.status !== 'submitted'}
+                onClick={() => updateStatus(a.id, 'accepted')}
+              >
+                Accept
+              </button>
+              <button
+                className="px-2 py-1 border rounded"
+                disabled={a.status !== 'submitted'}
+                onClick={() => updateStatus(a.id, 'rejected')}
+              >
+                Reject
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/owner/GigRow.tsx
+++ b/src/components/owner/GigRow.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { OwnerGigRow } from '@/types/owner';
+
+export default function GigRow({ gig }: { gig: OwnerGigRow }) {
+  const [status, setStatus] = useState(gig.status);
+
+  const toggle = async () => {
+    const next = status === 'open' ? 'closed' : 'open';
+    setStatus(next);
+    try {
+      await fetch(`/api/owner/gigs/${gig.id}/status`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: next }),
+      });
+    } catch {
+      setStatus(status);
+    }
+  };
+
+  return (
+    <li className="p-4 flex items-center justify-between gap-4">
+      <div>
+        <p className="font-medium">{gig.title}</p>
+        <p className="text-sm text-gray-600">
+          {gig.city} · ₱{gig.budget} ·{' '}
+          {new Date(gig.created_at).toLocaleDateString()}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <span
+          className={`px-2 py-1 text-xs rounded-full ${
+            status === 'open'
+              ? 'bg-green-200 text-green-800'
+              : 'bg-gray-200 text-gray-800'
+          }`}
+        >
+          {status}
+        </span>
+        <Link
+          href={`/owner/gigs/${gig.id}/applicants`}
+          className="text-blue-600 underline text-sm"
+        >
+          View applicants
+        </Link>
+        <button
+          className="text-sm border rounded px-2 py-1"
+          onClick={toggle}
+        >
+          {status === 'open' ? 'Close' : 'Open'}
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/src/lib/mock/owner.ts
+++ b/src/lib/mock/owner.ts
@@ -1,0 +1,84 @@
+import type { OwnerGigRow, ApplicantRow, AppStatus } from '@/types/owner';
+
+type MockGig = OwnerGigRow & { owner: string };
+type MockApplication = ApplicantRow & { gig_id: string };
+
+const gigs: MockGig[] = [
+  {
+    id: 'g1',
+    owner: 'stub-owner',
+    title: 'Sample Gig One',
+    city: 'Manila',
+    budget: 5000,
+    status: 'open',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 'g2',
+    owner: 'stub-owner',
+    title: 'Sample Gig Two',
+    city: 'Quezon City',
+    budget: 7000,
+    status: 'closed',
+    created_at: new Date().toISOString(),
+  },
+];
+
+const applications: MockApplication[] = [
+  {
+    id: 'a1',
+    gig_id: 'g1',
+    applicant: 'worker-1',
+    created_at: new Date().toISOString(),
+    status: 'submitted',
+  },
+  {
+    id: 'a2',
+    gig_id: 'g1',
+    applicant: 'worker-2',
+    created_at: new Date().toISOString(),
+    status: 'accepted',
+  },
+  {
+    id: 'a3',
+    gig_id: 'g2',
+    applicant: 'worker-3',
+    created_at: new Date().toISOString(),
+    status: 'submitted',
+  },
+];
+
+export function listGigs(uid: string): OwnerGigRow[] {
+  return gigs.filter((g) => g.owner === uid);
+}
+
+export function listApplicants(gigId: string): ApplicantRow[] {
+  return applications
+    .filter((a) => a.gig_id === gigId)
+    .map(({ id, applicant, created_at, status }) => ({
+      id,
+      applicant,
+      created_at,
+      status,
+    }));
+}
+
+export function setGigStatus(
+  gigId: string,
+  status: 'open' | 'closed',
+): boolean {
+  const gig = gigs.find((g) => g.id === gigId);
+  if (!gig) return false;
+  gig.status = status;
+  return true;
+}
+
+export function setApplicationStatus(
+  appId: string,
+  status: AppStatus,
+): boolean {
+  const app = applications.find((a) => a.id === appId);
+  if (!app) return false;
+  app.status = status;
+  return true;
+}

--- a/src/types/owner.ts
+++ b/src/types/owner.ts
@@ -1,0 +1,17 @@
+export type AppStatus = 'submitted' | 'accepted' | 'rejected';
+
+export interface OwnerGigRow {
+  id: string;
+  title: string;
+  city: string;
+  budget: number;
+  status: 'open' | 'closed';
+  created_at: string;
+}
+
+export interface ApplicantRow {
+  id: string;
+  applicant: string;
+  created_at: string;
+  status: AppStatus;
+}


### PR DESCRIPTION
## Summary
- add employer dashboard pages for managing gigs and applicants
- provide mock-backed API routes for gigs, applicants, and status updates
- document mock fallback for owner dashboard

## Changes
- add `/owner/gigs` and `/owner/gigs/[id]/applicants` pages
- extend main nav and owner types, components, and mocks
- implement dynamic API routes with Supabase or mock fallback

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find package 'globby')*

## Acceptance
- Preview builds show employer dashboard with mock data
- Status updates and applicant actions work via mock APIs when secrets are missing

## CI
- PR smoke + clickmap

## Rollback
- Revert this PR

## Notes
- Build failure due to missing npm deps (`globby` 403 during install)


------
https://chatgpt.com/codex/tasks/task_e_68b4e878ab008327b96a49fb301f183f