### PR TITLE
feat(mvp): candidate dashboard — my applications (no SSG; mock-safe)

### DIFF
--- a/docs/product-first.md
+++ b/docs/product-first.md
@@ -29,3 +29,11 @@ back to mock data when secrets are absent; replace by real DB later.
 The `/owner/gigs` pages and APIs are dynamic and fall back to in-memory mocks
 when Supabase secrets are absent. Preview builds can list gigs, view applicants,
 and update statuses without hitting the database.
+
+## Candidate dashboard
+
+`/me/applications` lists a worker's own gig applications. It is dynamic and uses mock data when Supabase secrets are absent or policies block reads. Withdraw buttons are disabled in preview when writes aren't allowed.
+
+## Withdraw API
+
+`POST /api/applications/:id/withdraw` sets an application's status to `withdrawn`. When Supabase write access is missing, the endpoint responds with `501` and performs no update.

--- a/src/app/api/applications/[id]/withdraw/route.ts
+++ b/src/app/api/applications/[id]/withdraw/route.ts
@@ -1,0 +1,33 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { userIdFromCookie, adminSupabase } from '@/lib/supabase/server';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const uid = await userIdFromCookie();
+  if (!uid) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+
+  const admin = await adminSupabase?.();
+  if (!admin) {
+    // still “successful” UX-wise, just no-op in preview without secrets
+    return NextResponse.json(
+      { ok: false, error: 'write not available in this environment' },
+      { status: 501 }
+    );
+  }
+
+  // Only allow withdrawing user’s own application
+  const { error } = await admin
+    .from('applications')
+    .update({ status: 'withdrawn' })
+    .eq('id', params.id)
+    .eq('user_id', uid)
+    .in('status', ['submitted', 'viewed', 'interviewing']);
+
+  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/me/applications/loading.tsx
+++ b/src/app/me/applications/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-3xl p-6 animate-pulse">
+      <div className="h-8 w-64 bg-slate-200 rounded mb-4" />
+      <div className="space-y-3">
+        <div className="h-24 bg-slate-200 rounded" />
+        <div className="h-24 bg-slate-200 rounded" />
+        <div className="h-24 bg-slate-200 rounded" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/me/applications/page.tsx
+++ b/src/app/me/applications/page.tsx
@@ -1,0 +1,74 @@
+export const dynamic = 'force-dynamic';
+
+import { Suspense } from 'react';
+import { applicationsForUser } from './server';
+import Link from 'next/link';
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    submitted: 'bg-blue-100 text-blue-800',
+    viewed: 'bg-violet-100 text-violet-800',
+    interviewing: 'bg-amber-100 text-amber-800',
+    rejected: 'bg-rose-100 text-rose-800',
+    withdrawn: 'bg-slate-200 text-slate-700',
+    hired: 'bg-emerald-100 text-emerald-800',
+  };
+  return <span className={`px-2 py-0.5 rounded text-xs ${map[status] ?? 'bg-slate-100 text-slate-800'}`}>{status}</span>;
+}
+
+async function List() {
+  const { items, canMutate, issue } = await applicationsForUser();
+  return (
+    <div className="space-y-4">
+      {issue && (
+        <div className="text-xs text-slate-600 bg-slate-50 border rounded p-2">
+          Running in mock/read-only mode: {issue}
+        </div>
+      )}
+      {items.length === 0 ? (
+        <p className="text-slate-600">No applications yet.</p>
+      ) : (
+        <ul className="grid gap-3">
+          {items.map((a) => (
+            <li key={a.id} className="border rounded p-4 flex items-start justify-between">
+              <div>
+                <div className="font-medium">
+                  <Link href={`/gigs/${a.gig_id}`} className="underline">
+                    {a.gig_title ?? `Gig ${a.gig_id}`}
+                  </Link>
+                </div>
+                <div className="text-sm text-slate-600">
+                  Applied {new Date(a.created_at).toLocaleString()}
+                </div>
+                <div className="mt-2">
+                  <StatusBadge status={a.status} />
+                </div>
+              </div>
+              <form action={`/api/applications/${a.id}/withdraw`} method="post">
+                <button
+                  className="text-sm border rounded px-3 py-1 disabled:opacity-50"
+                  disabled={!canMutate || a.status === 'withdrawn' || a.status === 'rejected' || a.status === 'hired'}
+                >
+                  Withdraw
+                </button>
+              </form>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl font-semibold mb-4">My Applications</h1>
+      <Suspense fallback={<div className="animate-pulse h-28 bg-slate-200 rounded" />}>
+        {/* @ts-expect-error Async Server Component */}
+        <List />
+      </Suspense>
+    </main>
+  );
+}
+

--- a/src/app/me/applications/server.ts
+++ b/src/app/me/applications/server.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+import { userIdFromCookie, publicSupabase } from '@/lib/supabase/server';
+
+type Row = {
+  id: string;
+  gig_id: string;
+  gig_title?: string | null;
+  status: string;
+  created_at: string;
+};
+
+export async function applicationsForUser(): Promise<{ items: Row[]; canMutate: boolean; issue?: string }> {
+  try {
+    const uid = await userIdFromCookie();
+    if (!uid) return { items: [], canMutate: false, issue: 'no user session' };
+
+    const supa = await publicSupabase?.();
+    if (!supa) return { items: mock(uid), canMutate: false, issue: 'supabase env not configured' };
+
+    // Expect RLS to allow selecting own applications
+    const { data, error } = await supa
+      .from('applications_view') // prefer a view joining gigs for title; fallback handled below
+      .select('id, gig_id, gig_title, status, created_at')
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    if (error || !data) {
+      return { items: mock(uid), canMutate: false, issue: 'query failed or view missing' };
+    }
+    return { items: data as Row[], canMutate: true };
+  } catch (e: any) {
+    return { items: [], canMutate: false, issue: e?.message ?? 'unknown' };
+  }
+}
+
+function mock(uid: string): Row[] {
+  const now = new Date().toISOString();
+  return [
+    { id: 'm1', gig_id: 'g1', gig_title: 'Sample Gig', status: 'submitted', created_at: now },
+  ];
+}


### PR DESCRIPTION
### Summary
- add candidate dashboard to list and withdraw applications with mock-friendly fallback

### Changes
- dynamic `/me/applications` page with read-only mock mode and withdraw stub
- withdraw API route returning `501` when write access missing
- document candidate dashboard and withdraw API behavior

### Testing Steps
- `npm test`
- `npm run lint` *(fails: ESLint config/deps missing)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

### Acceptance
- candidate can view their applications and attempt to withdraw
- preview builds degrade gracefully without Supabase secrets

### Notes
- write operations disabled when Supabase admin client not configured

### CI
- PR smoke + clickmap green; full QA unaffected.

### Rollback
- revert PR; no data migration required.

------
https://chatgpt.com/codex/tasks/task_e_68b4ea7df9c88327bc32e10638c8fcf9