### PR TITLE
feat: add application moderation API

### DIFF
--- a/src/app/api/applications/[id]/moderate/route.ts
+++ b/src/app/api/applications/[id]/moderate/route.ts
@@ -1,8 +1,10 @@
-'use server';
-
-import { NextResponse } from 'next/server';
 import { userIdFromCookie } from '@/lib/supabase/server';
-import { moderateApplication, ForbiddenError, NotFoundError, BadRequestError } from '@/lib/applications/moderation';
+import {
+  moderateApplication,
+  ForbiddenError,
+  NotFoundError,
+  BadRequestError,
+} from '@/lib/applications/moderation';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -10,43 +12,29 @@ export const dynamic = 'force-dynamic';
 type Body = { action?: 'approve' | 'reject' };
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const uid = await userIdFromCookie();
+  if (!uid) return new Response('Unauthorized', { status: 401 });
+
+  let body: Body = {};
   try {
-    const uid = await userIdFromCookie();
-    if (!uid) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
+    body = await req.json();
+  } catch {
+    /* keep default empty body */
+  }
 
-    const id = params?.id?.trim();
-    if (!id) {
-      return NextResponse.json({ error: 'invalid_id' }, { status: 400 });
-    }
+  const action = body.action;
+  if (action !== 'approve' && action !== 'reject') {
+    return new Response('Invalid action', { status: 400 });
+  }
 
-    let body: Body;
-    try {
-      body = await req.json();
-    } catch {
-      body = {};
-    }
-
-    const action = body?.action;
-    if (action !== 'approve' && action !== 'reject') {
-      return NextResponse.json({ error: 'invalid_action' }, { status: 400 });
-    }
-
-    await moderateApplication(uid, id, action);
-    return NextResponse.json({ ok: true });
-  } catch (err) {
-    if (err instanceof ForbiddenError) {
-      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
-    }
-    if (err instanceof NotFoundError) {
-      return NextResponse.json({ error: 'application_not_found' }, { status: 404 });
-    }
-    if (err instanceof BadRequestError) {
-      return NextResponse.json({ error: err.message }, { status: 400 });
-    }
-    console.error('[applications/moderate] unexpected', err);
-    return NextResponse.json({ error: 'unexpected' }, { status: 500 });
+  try {
+    const result = await moderateApplication({ id: params.id, action, by: uid });
+    return Response.json(result);
+  } catch (e) {
+    if (e instanceof ForbiddenError) return new Response('Forbidden', { status: 403 });
+    if (e instanceof NotFoundError) return new Response('Not Found', { status: 404 });
+    if (e instanceof BadRequestError) return new Response(e.message, { status: 400 });
+    console.error(e);
+    return new Response('Internal Server Error', { status: 500 });
   }
 }
-

--- a/src/app/api/applications/[id]/moderate/route.ts
+++ b/src/app/api/applications/[id]/moderate/route.ts
@@ -1,0 +1,52 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+import { userIdFromCookie } from '@/lib/supabase/server';
+import { moderateApplication, ForbiddenError, NotFoundError, BadRequestError } from '@/lib/applications/moderation';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Body = { action?: 'approve' | 'reject' };
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const uid = await userIdFromCookie();
+    if (!uid) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const id = params?.id?.trim();
+    if (!id) {
+      return NextResponse.json({ error: 'invalid_id' }, { status: 400 });
+    }
+
+    let body: Body;
+    try {
+      body = await req.json();
+    } catch {
+      body = {};
+    }
+
+    const action = body?.action;
+    if (action !== 'approve' && action !== 'reject') {
+      return NextResponse.json({ error: 'invalid_action' }, { status: 400 });
+    }
+
+    await moderateApplication(uid, id, action);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+    if (err instanceof NotFoundError) {
+      return NextResponse.json({ error: 'application_not_found' }, { status: 404 });
+    }
+    if (err instanceof BadRequestError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    console.error('[applications/moderate] unexpected', err);
+    return NextResponse.json({ error: 'unexpected' }, { status: 500 });
+  }
+}
+

--- a/src/lib/applications/moderation.ts
+++ b/src/lib/applications/moderation.ts
@@ -1,0 +1,95 @@
+import 'server-only';
+
+type Status = 'applied' | 'withdrawn' | 'rejected' | 'hired';
+
+export class ForbiddenError extends Error {}
+export class NotFoundError extends Error {}
+export class BadRequestError extends Error {}
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+type AppRow = { id: string; candidate_id: string; gig_id: string; status: Status };
+type GigRow = { id: string; owner_id: string };
+
+// Minimal in-memory fallback so Preview works with no secrets.
+// (Isolated here to avoid touching other mock files.)
+const mock = (() => {
+  let inited = false;
+  const store = new Map<string, { ownerId: string; candidateId: string; status: Status }>();
+  return {
+    ensure() {
+      if (!inited) {
+        inited = true;
+        console.log('[applications/moderation] using in-memory mock store');
+      }
+    },
+    setSeed(id: string, ownerId: string, candidateId: string, status: Status) {
+      store.set(id, { ownerId, candidateId, status });
+    },
+    get(id: string) { return store.get(id); },
+    set(id: string, next: Status) {
+      const cur = store.get(id);
+      if (!cur) throw new NotFoundError('not found');
+      cur.status = next;
+      store.set(id, cur);
+    }
+  };
+})();
+
+export async function moderateApplication(
+  employerUid: string,
+  applicationId: string,
+  action: 'approve' | 'reject'
+): Promise<void> {
+  const nextStatus: Status = action === 'approve' ? 'hired' : 'rejected';
+
+  // If we have service credentials, do a real update with owner check.
+  if (SUPABASE_URL && SUPABASE_SERVICE_ROLE) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const supa = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    // 1) fetch application to learn gig_id
+    const { data: app, error: appErr } = await supa
+      .from<AppRow>('applications')
+      .select('id,candidate_id,gig_id,status')
+      .eq('id', applicationId)
+      .single();
+
+    if (appErr || !app) throw new NotFoundError('application');
+
+    // 2) fetch gig to verify owner
+    const { data: gig, error: gigErr } = await supa
+      .from<GigRow>('gigs')
+      .select('id,owner_id')
+      .eq('id', app.gig_id)
+      .single();
+
+    if (gigErr || !gig) throw new NotFoundError('gig');
+    if (gig.owner_id !== employerUid) throw new ForbiddenError('not owner');
+
+    // 3) update status
+    const { error: updErr, count } = await supa
+      .from('applications')
+      .update({ status: nextStatus })
+      .eq('id', applicationId)
+      .eq('gig_id', app.gig_id)
+      .select('id', { count: 'exact', head: true });
+
+    if (updErr) throw updErr;
+    if (!count) throw new NotFoundError('application');
+    return;
+  }
+
+  // Fallback mock (Preview / local without secrets)
+  mock.ensure();
+  const row = mock.get(applicationId);
+  if (!row) throw new NotFoundError('application');
+  // In mock, we also enforce ownership.
+  // (Seeded rows should set ownerId to the employer who posted the gig.)
+  if (row && employerUid !== row.ownerId) throw new ForbiddenError('not owner');
+  mock.set(applicationId, nextStatus);
+}
+


### PR DESCRIPTION
## Summary
- add employer-only API endpoint to approve or reject applications
- support moderation via Supabase or in-memory mock when secrets missing

## Changes
- new route `/api/applications/[id]/moderate`
- moderation helper verifying gig ownership and updating status

## Testing Steps
- `npm test`
- `npm run lint` *(fails: next/eslint not installed; npm ci forbidden)*
- `npm run typecheck` *(fails: tsc not installed)*

## Acceptance
- POST `/api/applications/:id/moderate` accepts `{action:"approve"|"reject"}`
- returns `{ok:true}` for authorized owner; `forbidden` or `application_not_found` otherwise
- works in preview without Supabase secrets via in-memory mock

## Notes
- Could not install dependencies to run lint/typecheck due to 403 from npm registry

------
https://chatgpt.com/codex/tasks/task_e_68b4fdda68fc8327a266fb9bade7b4f3