### PR TITLE
docs(psgc): note missing dataset

### DIFF
--- a/src/data/psgc/README.md
+++ b/src/data/psgc/README.md
@@ -1,0 +1,13 @@
+Static PSGC dataset not found.
+
+Searched paths and counts:
+- public/data/ph/regions.json (2 regions)
+- public/data/ph/provinces.json (2 provinces)
+- public/data/ph/cities.json (40 entries)
+- public/data/ph_locations.json (17 regions, 149 cities, no provinces)
+- src/data/ph/regions.json (2 regions)
+- src/data/ph/provinces.json (2 provinces)
+- src/data/ph/cities.json (40 entries)
+- supabase/migrations/20250901010001_seed_ph_minimal.sql (NCR + CALABARZON only)
+
+Full PSGC dataset could not be recovered from repo or history.


### PR DESCRIPTION
## Summary
- document PSGC dataset absence and list searched paths

## Changes
- add `src/data/psgc/README.md` with search results

## Testing
- `npm test`

## Acceptance
- build stays green; PSGC dataset still missing


------
https://chatgpt.com/codex/tasks/task_e_68b51bd190348327a5763a1389e3282f