### PR TITLE
ci: manual “Run Smoke” workflow (on demand; keeps PRs fast)

### DIFF
--- a/.github/workflows/smoke-manual.yml
+++ b/.github/workflows/smoke-manual.yml
@@ -1,0 +1,56 @@
+name: Run Smoke (manual)
+on:
+  workflow_dispatch:
+    inputs:
+      baseUrl:
+        description: 'App base URL'
+        required: false
+        default: 'http://localhost:3000'
+permissions:
+  contents: read
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install deps
+        run: |
+          corepack enable
+          pnpm i --frozen-lockfile || npm ci || yarn install --frozen-lockfile
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: Build
+        run: |
+          if [ -f pnpm-lock.yaml ]; then pnpm build; elif [ -f yarn.lock ]; then yarn build; else npm run build; fi
+
+      - name: Start app (background)
+        run: |
+          (nohup npx next start -p 3000 > .next/serve.log 2>&1 &)
+          echo "Started Next on :3000"
+
+      - name: Wait for app
+        run: |
+          for i in {1..60}; do
+            if curl -fsSL "${{ github.event.inputs.baseUrl }}" >/dev/null 2>&1; then echo "App is up"; exit 0; fi
+            sleep 2
+          done
+          echo "App did not become healthy in time"; cat .next/serve.log || true; exit 1
+
+      - name: Run smoke
+        env:
+          RUN_SMOKE: "true"
+          BASE_URL: ${{ github.event.inputs.baseUrl }}
+        run: |
+          npx playwright test tests/smoke.* --reporter=line || npx playwright show-report


### PR DESCRIPTION
## Summary
- add manual "Run Smoke" GitHub Actions workflow to run smoke tests on demand

## Changes
- create `.github/workflows/smoke-manual.yml` with build/start/wait steps and Playwright smoke run

## Testing
- `npm test`

## Acceptance
- Actions → Run Smoke triggers Playwright smoke; PR smoke + clickmap unchanged

## Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b55afe0b70832790df1cb1f4b26a45