### PR TITLE
docs: mark MVP complete + refresh baseline after freebies

### DIFF
--- a/docs/product/BASELINE.md
+++ b/docs/product/BASELINE.md
@@ -93,6 +93,8 @@
 #### FEAT-TICKETS-GATE — Tickets gating (3 free, ₱20 after)
 | Date | Ref | Subject |
 |------|-----|---------|
+| 2025-09-01 | #544 | Merge pull request #544 from MarlonManabat/codex/add-free-starter-tickets-for-new-users |
+| 2025-09-01 | daf6b23 | feat(tickets): seed free starter tickets on first login and ensure user_tickets row exists |
 | 2025-09-01 | #541 | Merge pull request #541 from MarlonManabat/codex/add-ticket-balance-badge-and-link |
 | 2025-09-01 | c73464d | feat(ui): header tickets badge and quick Buy link to /billing/tickets |
 | 2025-09-01 | #539 | Merge pull request #539 from MarlonManabat/codex/add-gcash-upload-and-polling-to-tickets-page |

--- a/docs/product/MVP_CHECKLIST.md
+++ b/docs/product/MVP_CHECKLIST.md
@@ -4,9 +4,12 @@
 - [x] Canonical routes: /gigs/create, /gigs (Landing CTAs unified)
 - [x] Applications thread: no spinner, polling, optimistic send
 - [x] Tickets gate + atomic deduct on create
+- [x] Starter ticket freebies (3 on first login)
 - [x] Tickets page: GCash upload, polling, auto-redirect
 - [x] Safe `next` redirects; header ticket badge+link
 - [x] RSC guard (no hooks in server components)
+
+> New users receive 3 free tickets on first login (`FREE_TICKETS_ON_FIRST_LOGIN=3`).
 
 ## Ops ✅
 - [x] PR title guard (non-blocking)


### PR DESCRIPTION
## Summary
- Mark free starter tickets as completed in MVP checklist
- Document FREE_TICKETS_ON_FIRST_LOGIN=3 policy
- Backfill product baseline history after starter ticket rollout

## Changes
- update MVP checklist with starter ticket freebies and note
- refresh baseline backfilled history for ticket freebies

## Testing
- `node scripts/baseline/backfill.js`

## Acceptance
- MVP checklist notes free starter tickets
- baseline includes free starter ticket history

## CI
- PR smoke + clickmap green; full QA unaffected

## Rollback
- revert PR; no data migration required

## Notes
- none

------
https://chatgpt.com/codex/tasks/task_e_68b564378dc88327ad907100affc7719