### PR TITLE
chore: stabilize e2e navigation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,10 +27,9 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
 
-      - name: Install deps (robust)
-        shell: bash
+      - name: Install deps
         run: |
-          if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --prefer-offline; fi
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npx playwright install --with-deps
 
       - name: Seed data

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,25 @@
 import { defineConfig, devices } from '@playwright/test';
 
+function base() {
+  // No new envs. Use what we already have, with safe fallbacks.
+  const raw = process.env.BASE_URL || process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_URL;
+  if (!raw) return 'http://localhost:3000';
+  return raw.startsWith('http') ? raw : `https://${raw}`;
+}
+
 export default defineConfig({
   testDir: 'tests/e2e',
   timeout: 60_000,
+  expect: { timeout: 10_000 },
   retries: 0,
   workers: 1,
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL: base(),
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
     headless: true,
+    // IMPORTANT: our app is client-side heavy; avoid waiting for network idle.
+    // Tests should use goto with domcontentloaded explicitly.
   },
   reporter: [['html', { open: 'never' }]],
   projects: [

--- a/tests/e2e/_utils/nav.ts
+++ b/tests/e2e/_utils/nav.ts
@@ -1,0 +1,4 @@
+import type { Page } from '@playwright/test';
+export async function goto(page: Page, path: string) {
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+}

--- a/tests/e2e/core.nav.spec.ts
+++ b/tests/e2e/core.nav.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { goto } from './_utils/nav';
+
+test('Home → Browse Jobs renders', async ({ page }) => {
+  await goto(page, '/');
+  await page.getByRole('link', { name: /browse jobs/i }).click();
+  await expect(page).toHaveURL(/\/browse-jobs/);
+  // assert shell, not data (DB can be empty)
+  await expect(page.getByRole('heading', { name: /browse jobs/i })).toBeVisible();
+  await expect(page.getByText(/no jobs yet/i).or(page.locator('li').first())).toBeVisible();
+});
+
+test('Home → My Applications renders (signed out ok)', async ({ page }) => {
+  await goto(page, '/');
+  await page.getByRole('link', { name: /my applications/i }).click();
+  await expect(page).toHaveURL(/\/applications/);
+  await expect(page.getByRole('heading', { name: /my applications/i })).toBeVisible();
+  // Signed-out view should not fail the test
+  await expect(page.getByText(/sign in/i).or(page.getByText(/no applications/i))).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- keep manual E2E workflow resilient by falling back to npm install
- streamline Playwright base URL and timeouts for faster, stable navigation
- standardize DOMContentLoaded waits and cover key navigation paths

## Changes
- fall back to `npm install` when `npm ci` fails in E2E workflow
- add env-aware base URL helper and shorter navigation/action timeouts
- introduce `goto` helper using `domcontentloaded`
- add navigation tests asserting page shells instead of data

## Testing
- `npm test`
- `npm run lint tests/e2e` *(fails: next not found)*
- `npm ci --no-audit --no-fund` *(fails: 403 forbidden)*
- `npm run typecheck` *(fails: cannot find type definition file for 'node')*

## Acceptance
- Full E2E remains manual; install step resilient to lockfile drift

## Notes
- none


------
https://chatgpt.com/codex/tasks/task_e_68b647d2d994832799bb038b283e4b21