### PR TITLE
chore: reuse server in Playwright

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,13 @@ jobs:
 
       # Seed/Cleanup intentionally skipped in CI; tests don’t require preseeded data.
 
+      - name: Ensure port 3000 is free
+        run: |
+          if lsof -i :3000 -sTCP:LISTEN -t >/dev/null 2>&1; then
+            echo "Port 3000 busy. Killing existing process..."
+            kill -9 $(lsof -i :3000 -sTCP:LISTEN -t) || true
+          fi
+
       - name: Start server (background, local only)
         if: ${{ env.BASE_URL == '' }}
         run: |

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,9 +28,9 @@ export default defineConfig({
   webServer: process.env.BASE_URL
     ? undefined
     : {
-        command: 'npm run start:prod',
-        url: 'http://localhost:3000',
+        command: process.env.PLAYWRIGHT_WEBSERVER_CMD || 'npm run start:prod',
+        url: base(),
+        reuseExistingServer: true,
         timeout: 120_000,
-        reuseExistingServer: false,
       },
 });


### PR DESCRIPTION
## Summary
- allow Playwright tests to reuse an existing server and avoid port collisions
- free port 3000 in the E2E workflow before starting the server

## Changes
- update Playwright webServer config to reuse an existing server
- kill orphan process on port 3000 in e2e workflow

## Testing
- `npm test`
- `npm run lint -- playwright.config.ts` *(fails: next not found; dependency install blocked)*

## Acceptance
- Playwright attaches to an existing server instead of starting a new one
- Port 3000 is freed before launching the app in CI

## Notes
- none


------
https://chatgpt.com/codex/tasks/task_e_68b64f48f988832781f5f8527656818f