### PR TITLE
feat: support remote base url for e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,25 @@
-name: E2E (manual or nightly)
+name: E2E (manual)
+
 on:
   workflow_dispatch:
     inputs:
       base_url:
-        description: 'Base URL (leave empty to run local)'
+        description: "Target base URL (leave blank to test local build)"
         required: false
-  schedule:
-    - cron: '0 9 * * *' # optional
+        type: string
+      run_auth:
+        description: "Run @auth tests (requires test login path/secrets)"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
     env:
-      E2E_BASIC: '1'
+      BASE_URL: ${{ inputs.base_url }}
+      E2E_BASIC: ${{ inputs.run_auth == 'true' && '0' || '1' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -25,27 +32,47 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Build app
+      # LOCAL PATH (no base_url or localhost-ish base_url)
+      - name: Build app (local)
+        if: ${{ inputs.base_url == '' || contains(inputs.base_url, 'localhost') || contains(inputs.base_url, '127.0.0.1') || contains(inputs.base_url, '0.0.0.0') }}
         run: npm run build
 
-      - name: Ensure port 3000 is free
+      - name: Ensure port 3000 is free (local)
+        if: ${{ inputs.base_url == '' || contains(inputs.base_url, 'localhost') || contains(inputs.base_url, '127.0.0.1') || contains(inputs.base_url, '0.0.0.0') }}
         run: |
           if lsof -i :3000 -sTCP:LISTEN -t >/dev/null 2>&1; then
             kill -9 $(lsof -i :3000 -sTCP:LISTEN -t) || true
           fi
 
       - name: Start server (background, local only)
+        if: ${{ inputs.base_url == '' || contains(inputs.base_url, 'localhost') || contains(inputs.base_url, '127.0.0.1') || contains(inputs.base_url, '0.0.0.0') }}
         run: |
           npm run start & echo $! > .pidfile
 
-      - name: Wait for app/health or homepage (90s)
+      - name: Wait for app/health or homepage (local, 90s)
+        if: ${{ inputs.base_url == '' || contains(inputs.base_url, 'localhost') || contains(inputs.base_url, '127.0.0.1') || contains(inputs.base_url, '0.0.0.0') }}
         run: |
           URL="${BASE_URL:-http://localhost:3000}"
           for i in {1..90}; do
-            curl -fsS "$URL/health" || curl -fsS "$URL" >/dev/null && { echo UP; exit 0; }
+            curl -fsS "$URL/health" || curl -fsS "$URL" >/dev/null && { echo "UP (local)"; exit 0; }
             sleep 1
           done
-          echo "App not up"; exit 1
+          echo "Local app not up"; exit 1
+
+      # REMOTE PATH (non-local base_url)
+      - name: Probe remote (90s)
+        if: ${{ inputs.base_url != '' && !contains(inputs.base_url, 'localhost') && !contains(inputs.base_url, '127.0.0.1') && !contains(inputs.base_url, '0.0.0.0') }}
+        run: |
+          URL="${BASE_URL}"
+          for i in {1..90}; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+            if [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then
+              echo "UP (remote, $code)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Remote not reachable: $URL"; exit 1
 
       - name: Run E2E
         run: npx playwright test --reporter=html
@@ -59,6 +86,6 @@ jobs:
           if-no-files-found: ignore
 
       - name: Stop server
-        if: always()
-        run: if [ -f .pidfile ]; then kill $(cat .pidfile) || true; fi
-
+        if: always() && (inputs.base_url == '' || contains(inputs.base_url, 'localhost') || contains(inputs.base_url, '127.0.0.1') || contains(inputs.base_url, '0.0.0.0'))
+        run: |
+          if [ -f .pidfile ]; then kill $(cat .pidfile) || true; fi

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,27 +1,46 @@
 import { defineConfig, devices } from '@playwright/test';
 
 function base() {
-  const raw = process.env.BASE_URL || process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_URL;
+  const raw =
+    process.env.BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.VERCEL_URL;
   if (!raw) return 'http://localhost:3000';
   return raw.startsWith('http') ? raw : `https://${raw}`;
 }
-const basic = process.env.E2E_BASIC === '1';
+
+const resolved = base();
+const isRemote = (() => {
+  try {
+    const u = new URL(resolved);
+    return !['localhost', '127.0.0.1', '0.0.0.0'].includes(u.hostname);
+  } catch {
+    return false;
+  }
+})();
+
+const basicMode = process.env.E2E_BASIC === '1';
 
 export default defineConfig({
   testDir: 'tests/e2e',
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: base(),
+    baseURL: resolved,
     navigationTimeout: 30_000,
     actionTimeout: 15_000,
   },
-  ...(basic ? { grepInvert: /@auth/ } : {}),
+  ...(basicMode ? { grepInvert: /@auth/ } : {}),
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
-  webServer: {
-    command: process.env.PLAYWRIGHT_WEBSERVER_CMD || 'npm run start',
-    url: base(),
-    reuseExistingServer: true,
-    timeout: 120_000,
-  },
+  // Only start a local server when target is local
+  ...(isRemote
+    ? {}
+    : {
+        webServer: {
+          command: process.env.PLAYWRIGHT_WEBSERVER_CMD || 'npm run start',
+          url: resolved,
+          reuseExistingServer: true,
+          timeout: 120_000,
+        },
+      }),
 });


### PR DESCRIPTION
## Summary
- allow running Playwright tests against remote base URLs
- make manual E2E workflow skip local server when a remote base_url is provided

## Changes
- conditionally start Playwright webServer only for localhost targets
- revamp `.github/workflows/e2e.yml` to accept `base_url` and `run_auth` inputs and branch for local vs remote targets

## Testing Steps
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: 403 Forbidden fetching @supabase/ssr)*

## Acceptance
- PR smoke + clickmap green
- Full QA unaffected

## Notes
- Linting and dependency install blocked by registry access; ensure environment can reach npm registry.


------
https://chatgpt.com/codex/tasks/task_e_68b65b2c697c832796a83e24cbdba4a3