### PR TITLE
chore: redeploy to pick up env changes + add health and prod env guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev",
     "ci:verify": "node scripts/ci-verify.mjs",
     "prebuild": "node ./scripts/check-dynamic-route-conflicts.mjs && node ./scripts/assert-valid-revalidate.mjs",
-    "build": "next build",
+    "build": "node scripts/check-required-env.mjs && next build",
     "start": "next start -p 3000",
     "start:e2e": "next build && next start -p 3000",
     "start:preview": "next start -p 3000",

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ ok: true });
+}

--- a/scripts/check-required-env.mjs
+++ b/scripts/check-required-env.mjs
@@ -1,0 +1,20 @@
+/* Production-only env guard to avoid cryptic "Digest" 500s. */
+const PROD = process.env.VERCEL_ENV === 'production' || process.env.NODE_ENV === 'production';
+
+const REQUIRED = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  // We use NextAuth in prod; enforce these only in prod:
+  'NEXTAUTH_URL',
+  'NEXTAUTH_SECRET',
+];
+
+if (PROD) {
+  const missing = REQUIRED.filter((k) => !process.env[k] || String(process.env[k]).trim() === '');
+  if (missing.length) {
+    console.error('❌ Missing required production env vars:', missing.join(', '));
+    process.exit(1);
+  }
+}
+
+console.log('✅ Env check passed', PROD ? '(production)' : '(non-production)');


### PR DESCRIPTION
## Summary
- redeploy to pick up env updates
- add health endpoint and production env guard

## Changes
- add `/api/health` endpoint
- check required env vars before building in production

## Testing
- `node scripts/check-required-env.mjs`
- `npm test`

## Acceptance
- `https://app.quickgig.ph/api/health` returns `{ ok: true }`
- Landing CTAs load the app without the white "Digest" error

## CI
- PR smoke + clickmap green
- Full QA unaffected

## Rollback
- Revert PR; no data migration required

------
https://chatgpt.com/codex/tasks/task_e_68b665ec96b883278f1d36f766c446a0