### PR TITLE
chore: enforce agents contract

### DIFF
--- a/.github/workflows/agents-contract.yml
+++ b/.github/workflows/agents-contract.yml
@@ -1,0 +1,20 @@
+name: agents-contract
+on:
+  pull_request:
+    paths:
+      - "agents.md"
+      - "scripts/verify-agents-md.mjs"
+      - "app/lib/routes.ts"
+      - "middleware.ts"
+      - "next.config.*"
+      - "tests/smoke/**"
+      - "components/**/PostJobSkeleton.tsx"
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify agents.md contract
+        run: node scripts/verify-agents-md.mjs

--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,41 @@
+<!-- AGENT CONTRACT v2025-09-04 -->
+
+# QuickGig Agent Playbook (READ ME FIRST)
+
+## DO FIRST (hard rules)
+- Use the canonical routes from **app/lib/routes.ts**. **Never** hardcode paths.
+- Treat auth-gated flows as **auth-aware**: redirects to `/login?next=…` are success in PR smoke.
+- Use stable selectors: prefer `data-testid` over headings/text.
+- Do not introduce or resurrect legacy paths (`/find`, `/gigs` (except `/gigs/create`), `/browsejobs`, `/post-job`, `/my-apps`).
+- If you modify routes, middleware, or smoke tests, update this file **and** `BACKFILL.md`.
+
+## Repository invariants
+- **Routes:** **app/lib/routes.ts** is the single source of truth. CTAs import from there.
+- **Redirects:** legacy paths normalize in `middleware.ts` and `next.config` `redirects()`.
+- **Auth-aware smoke:** specs accept `/login` for gated flows; otherwise assert form or skeleton.
+- **Error handling:** Global `app/error.tsx` + page-level boundaries (e.g., Post Job) prevent white screens.
+
+## When you change these, you must also update this file
+- `app/lib/routes.ts`, `middleware.ts`, `next.config.*`
+- any `tests/smoke/**`
+- `components/**/PostJobSkeleton.tsx` (test id)
+- docs that alter test expectations
+
+## PR acceptance (agent checklist)
+- [ ] No legacy anchors (run `bash scripts/no-legacy.sh`).
+- [ ] Smoke passes locally: `npx playwright test -c playwright.smoke.ts`.
+- [ ] If unauthenticated flows are touched, smoke specs are **auth-aware**.
+- [ ] `BACKFILL.md` updated with changes + rationale.
+- [ ] This file’s header version bumped when contracts change.
+
+<!-- /AGENT CONTRACT -->
+
+See [docs/smoke.md](docs/smoke.md) for smoke test instructions.
+
+```ts
+// When unauthenticated, treat /login?next=… as success; do not assert privileged content.
+```
+
 ## Repo + Stack
 - App: quickgig-frontend (Next.js Pages Router, TypeScript). Deploy: Vercel.
 - Backend: Supabase (RLS). No secrets in code. Stripe is **stub only** (don’t add live Stripe deps).

--- a/scripts/verify-agents-md.mjs
+++ b/scripts/verify-agents-md.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const baseRef = process.env.GITHUB_BASE_REF || "main";
+
+const changed = execSync(`git diff --name-only origin/${baseRef}...HEAD`, { stdio: "pipe" })
+  .toString()
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+const mustTouchAgents = changed.some(p =>
+  /^(app\/lib\/routes\.ts|middleware\.ts|next\.config\.\w+|tests\/smoke\/|components\/.*PostJobSkeleton\.tsx)/.test(p)
+);
+
+const agents = readFileSync("agents.md", "utf8");
+const hasContract = agents.includes("AGENT CONTRACT");
+const hasVersion = /AGENT CONTRACT v\d{4}-\d{2}-\d{2}/.test(agents);
+
+let failed = false;
+
+if (!hasContract || !hasVersion) {
+  console.error("❌ `agents.md` is missing the AGENT CONTRACT header with a version stamp.");
+  failed = true;
+}
+
+if (mustTouchAgents && !changed.includes("agents.md")) {
+  console.error("❌ You changed routes/middleware/smoke but didn’t update `agents.md`.");
+  console.error("   Please reflect the new contract at the top of `agents.md` and bump the version date.");
+  failed = true;
+}
+
+if (failed) process.exit(1);
+console.log("✅ agents.md contract present and consistent.");


### PR DESCRIPTION
## Summary
- codify agent contract at the top of `agents.md`
- add `scripts/verify-agents-md.mjs` and CI workflow to ensure the contract is kept current

## Changes
- prepend AGENT CONTRACT block with routing and auth rules
- create verifier script and `agents-contract` GitHub workflow

## Testing Steps
- `bash scripts/no-legacy.sh` *(fails: No such file or directory)*
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 Forbidden from npm)*
- `GITHUB_BASE_REF=work node scripts/verify-agents-md.mjs`

## Acceptance
- `agents.md` includes AGENT CONTRACT header with version
- CI fails if routes/middleware/smoke change without updating `agents.md`

## CI
- `agents-contract` workflow runs verifier script

## Rollback
- revert this PR

## Notes
- none


------
https://chatgpt.com/codex/tasks/task_e_68b936ad42c883278b08256b8205f1ec