### PR TITLE
chore(stability): unify CTAs & auth-aware smokes; remove flaky selectors; add docs + no-legacy check

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,28 @@
+# Agents Contract
+**Version:** 2025-09-04
+
+## Routes & CTAs (source of truth)
+- Use `ROUTES` constants for all navigational links (no raw string paths).
+- Header CTAs:
+  - `data-testid="nav-post-job"` → `/gigs/create`
+  - `data-testid="nav-my-applications"` → `/applications`
+- Auth behavior:
+  - If signed out, clicking either CTA must 302 to `/login?next=<dest>`
+
+## Legacy redirects (middleware)
+- `/find` → `/browse-jobs`
+- `/post-job` → `/gigs/create`
+  - May 302 to `/login?next=/gigs/create` when unauthenticated
+
+## Test hooks (smoke/e2e)
+- Stable header test IDs: `nav-post-job`, `nav-my-applications`
+- Post Job skeleton test id: `post-job-skeleton`
+- Landing page must not render duplicate CTAs with identical accessible names
+
+## CI guardrails
+- `scripts/check-cta-links.mjs` forbids legacy targets in UI (e.g., `/browse-jobs`) for header/landing CTAs
+- Whenever `routes/**`, `middleware/**`, or `tests/smoke/**` change, update this document and bump the **Version** date above
+
 ## Repo + Stack
 - App: quickgig-frontend (Next.js Pages Router, TypeScript). Deploy: Vercel.
 - Backend: Supabase (RLS). No secrets in code. Stripe is **stub only** (don’t add live Stripe deps).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,8 @@
+## PR Smoke Guardrails (read me first)
+- Do **not** use `cta-post-job` / `cta-my-applications` testIds. Use `nav-post-job` / `nav-my-applications`.
+- For auth-gated routes, accept `/login?next=…` as valid using `expectAuthAwareRedirect`.
+- Ensure `post-job-skeleton` remains available for client-side checks.
+- Before opening a PR, run:
+  ```bash
+  npm run no-legacy
+  ```

--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -1,0 +1,21 @@
+# Smoke Tests
+
+## Run all smokes locally
+```bash
+npx playwright test -c playwright.smoke.ts
+```
+
+## Run a specific spec
+
+```bash
+npx playwright test -c playwright.smoke.ts tests/smoke/post-job-form-render.spec.ts
+```
+
+## Rules (important)
+
+* **Selectors**: Smokes must target **header CTAs only** via stable IDs:
+
+  * `data-testid="nav-post-job"`, `data-testid="nav-my-applications"`
+  * Hero CTAs use `hero-*` and are for landing-only tests, not smokes.
+* **Auth-aware**: For auth-gated pages, treat either the destination **or** `/login?next=…` as passing. Use `expectAuthAwareRedirect(page, /<dest-path>$/)`.
+* **Post Job form**: The smoke test passes if the form renders, the `post-job-skeleton` renders, or the request is redirected to login.

--- a/landing_public_html/index.html
+++ b/landing_public_html/index.html
@@ -87,7 +87,7 @@
           <a
             class="btn btn-ghost"
             href="/gigs/create"
-            data-testid="cta-post-job"
+            data-testid="hero-post-job"
             aria-label="Post job on QuickGig app"
             data-app-root
             >Post a Job</a

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "e2e:cleanup:local": "tsx scripts/e2e/cleanup.ts",
     "smoke:prod": "BASE_URL=https://app.quickgig.ph npx playwright test -c playwright.smoke.ts",
     "e2e:prod": "BASE_URL=https://app.quickgig.ph npx playwright test",
-    "test": "echo \"E2E disabled while product is WIP\" && exit 0"
+    "test": "echo \"E2E disabled while product is WIP\" && exit 0",
+    "no-legacy": "node scripts/no-legacy.mjs"
   },
   "dependencies": {
     "@jobuntux/psgc": "^0.2.1",

--- a/scripts/no-legacy.mjs
+++ b/scripts/no-legacy.mjs
@@ -1,0 +1,31 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FORBIDDEN = ['data-testid="cta-post-job"', 'data-testid="cta-my-applications"'];
+const ROOTS = ['src', 'tests'];
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) yield* walk(p);
+    else if (s.isFile()) yield p;
+  }
+}
+
+let bad = [];
+for (const root of ROOTS) {
+  try {
+    for (const file of walk(root)) {
+      const txt = readFileSync(file, 'utf8');
+      if (FORBIDDEN.some(f => txt.includes(f))) bad.push(file);
+    }
+  } catch {}
+}
+
+if (bad.length) {
+  console.error('Forbidden legacy testIds found in:\n' + bad.map(b => ' - ' + b).join('\n'));
+  process.exit(1);
+} else {
+  console.log('✔ No legacy CTA testIds found.');
+}

--- a/src/app/gigs/create/loading.tsx
+++ b/src/app/gigs/create/loading.tsx
@@ -1,12 +1,5 @@
+import PostJobSkeleton from '@/features/gigs/PostJobSkeleton';
+
 export default function Loading() {
-  return (
-    <main className="mx-auto max-w-5xl p-6 animate-pulse">
-      <div className="h-8 w-64 bg-slate-200 rounded mb-6" />
-      <div className="space-y-3">
-        <div className="h-24 bg-slate-200 rounded" />
-        <div className="h-24 bg-slate-200 rounded" />
-        <div className="h-24 bg-slate-200 rounded" />
-      </div>
-    </main>
-  );
+  return <PostJobSkeleton data-testid="post-job-skeleton" />;
 }

--- a/src/app/smoke/landing-ctas/page.tsx
+++ b/src/app/smoke/landing-ctas/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
+import LinkApp from "@/components/LinkApp";
 import type { Metadata } from "next";
-import { ROUTES } from "@/app/lib/routes";
+import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -12,10 +12,10 @@ export default function SmokeLandingCTAs() {
     <main className="p-8 space-y-4">
       <h1 className="text-xl font-semibold">Smoke: Landing CTAs</h1>
       <div className="flex flex-col gap-3">
-        <Link data-testid="cta-find-work" href={ROUTES.GIGS_BROWSE}>Find Work</Link>
-        <Link data-testid="cta-browse-jobs" href={ROUTES.GIGS_BROWSE}>Browse Jobs</Link>
-        <Link data-testid="cta-post-job" href={ROUTES.GIGS_CREATE}>Post a job</Link>
-        <Link data-testid="cta-my-applications" href={ROUTES.APPLICATIONS}>My Applications</Link>
+        <LinkApp data-testid="cta-find-work" href={ROUTES.browseJobs}>Find Work</LinkApp>
+        <LinkApp data-testid="cta-browse-jobs" href={ROUTES.browseJobs}>Browse Jobs</LinkApp>
+        <LinkApp data-testid="nav-post-job" href={ROUTES.gigsCreate}>Post a job</LinkApp>
+        <LinkApp data-testid="nav-my-applications" href={ROUTES.applications}>My Applications</LinkApp>
       </div>
     </main>
   );

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link';
 import { useUser } from '@/hooks/useUser';
-import { ROUTES } from '@/app/lib/routes';
+import LinkApp from '@/components/LinkApp';
+import { ROUTES } from '@/lib/routes';
 
 type Props = {
   balance: number;
@@ -18,19 +19,19 @@ export default function AppHeader({ balance }: Props) {
             QuickGig
           </Link>
           <nav className="flex items-center gap-4">
-            <Link data-testid="nav-browse-jobs" href={ROUTES.GIGS_BROWSE} prefetch={false}>
+            <LinkApp data-testid="nav-browse-jobs" href={ROUTES.browseJobs} prefetch={false}>
               Browse jobs
-            </Link>
-            <Link data-testid="post-job" href={ROUTES.GIGS_CREATE} prefetch={false}>
+            </LinkApp>
+            <LinkApp href={ROUTES.gigsCreate} data-testid="nav-post-job" prefetch={false}>
               Post a job
-            </Link>
-            <Link
-              data-testid="my-applications"
-              href={ROUTES.APPLICATIONS}
+            </LinkApp>
+            <LinkApp
+              href={ROUTES.applications}
+              data-testid="nav-my-applications"
               prefetch={false}
             >
               My Applications
-            </Link>
+            </LinkApp>
             {user ? (
               <button onClick={() => signOut()} className="underline">
                 Sign out

--- a/src/components/LinkApp.tsx
+++ b/src/components/LinkApp.tsx
@@ -1,0 +1,8 @@
+'use client';
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+
+export default function LinkApp(props: ComponentProps<typeof Link>) {
+  // Simple passthrough; any cross-host logic stays centralized here if needed later.
+  return <Link {...props} />;
+}

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -1,29 +1,33 @@
-import { toAppPath } from '@/lib/urls';
-import { ROUTES } from '@/app/lib/routes';
-import LandingCTAs from '@/components/landing/LandingCTAs';
+import LinkApp from '@/components/LinkApp';
+import { ROUTES } from '@/lib/routes';
 
 export default function LandingHeader() {
   return (
     <nav className="...">
-      <LandingCTAs
-        findClassName="hover:underline"
-        postClassName="btn btn-primary"
-      />
-      <a
-        data-testid="cta-my-applications"
-        href={toAppPath(ROUTES.APPLICATIONS)}
+      <LinkApp
+        data-testid="nav-browse-jobs"
+        href={ROUTES.browseJobs}
+        className="hover:underline"
+      >
+        Browse jobs
+      </LinkApp>
+      <LinkApp
+        data-testid="nav-post-job"
+        href={ROUTES.gigsCreate}
+        className="btn btn-primary"
+      >
+        Post a job
+      </LinkApp>
+      <LinkApp
+        data-testid="nav-my-applications"
+        href={ROUTES.applications}
         className="..."
-        rel="noopener noreferrer"
       >
         My Applications
-      </a>
-      <a
-        href={toAppPath('/login')}
-        className="..."
-        rel="noopener noreferrer"
-      >
+      </LinkApp>
+      <LinkApp href={ROUTES.login} className="...">
         Sign in
-      </a>
+      </LinkApp>
     </nav>
   );
 }

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,12 +1,25 @@
-import LandingCTAs from '@/components/landing/LandingCTAs';
+import LinkApp from '@/components/LinkApp';
+import { ROUTES } from '@/lib/routes';
 
 export default function LandingHero() {
   return (
     <section className="...">
-      <LandingCTAs
-        findClassName="px-4 py-2 rounded-md bg-gray-100"
-        postClassName="px-4 py-2 rounded-md bg-blue-600 text-white"
-      />
+      <div className="flex gap-3">
+        <LinkApp
+          href={ROUTES.browseJobs}
+          data-testid="cta-browse-jobs"
+          className="px-4 py-2 rounded-md bg-gray-100"
+        >
+          Browse jobs
+        </LinkApp>
+        <LinkApp
+          href={ROUTES.gigsCreate}
+          data-testid="hero-post-job"
+          className="px-4 py-2 rounded-md bg-blue-600 text-white"
+        >
+          Post a job
+        </LinkApp>
+      </div>
     </section>
   );
 }

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { toAppPath } from '@/lib/urls';
-import { ROUTES } from '@/app/lib/routes';
+import LinkApp from '@/components/LinkApp';
+import { ROUTES } from '@/lib/routes';
 
 type Props = {
   findClassName?: string;
@@ -16,26 +16,20 @@ export default function LandingCTAs({
   showPost = true,
 }: Props) {
   return (
-    <div className="flex gap-3">
+      <div className="flex gap-3">
         {showFind && (
-          <a
+          <LinkApp
             data-testid="cta-browse-jobs"
-            href={toAppPath(ROUTES.GIGS_BROWSE)}
+            href={ROUTES.browseJobs}
             className={findClassName}
-            rel="noopener noreferrer"
           >
             Browse jobs
-          </a>
+          </LinkApp>
         )}
         {showPost && (
-          <a
-            data-testid="cta-post-job"
-            href={toAppPath(ROUTES.GIGS_CREATE)}
-            className={postClassName}
-            rel="noopener noreferrer"
-          >
+          <LinkApp href={ROUTES.gigsCreate} className={postClassName}>
             Post a job
-          </a>
+          </LinkApp>
         )}
       </div>
     );

--- a/src/features/gigs/PostJobSkeleton.tsx
+++ b/src/features/gigs/PostJobSkeleton.tsx
@@ -1,0 +1,15 @@
+export default function PostJobSkeleton(props: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <main
+      {...props}
+      className={"mx-auto max-w-5xl p-6 animate-pulse " + (props.className ?? "")}
+    >
+      <div className="h-8 w-64 bg-slate-200 rounded mb-6" />
+      <div className="space-y-3">
+        <div className="h-24 bg-slate-200 rounded" />
+        <div className="h-24 bg-slate-200 rounded" />
+        <div className="h-24 bg-slate-200 rounded" />
+      </div>
+    </main>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,6 +1,6 @@
 export const ROUTES = {
-  home: '/',
+  gigsCreate: '/gigs/create',
+  applications: '/applications',
   browseJobs: '/browse-jobs',
-  myApplications: '/applications',
-  postJob: '/post-job', // adjust if your create page differs; keep current working path
+  login: '/login',
 } as const;

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -15,3 +15,19 @@ export const isProdBase = () => {
   const u = process.env.BASE_URL || '';
   return /app\.quickgig\.ph/i.test(u);
 };
+
+// Wait for either the intended destination OR a bounce to /login?next=...
+export async function expectAuthAwareRedirect(
+  page: Page,
+  destPathPattern: RegExp, // e.g. /\/gigs\/create\/?$/
+  timeout = 8000
+) {
+  const host = 'https?:\\/\\/[^/]+'; // match any host (localhost or preview)
+  const dest = new RegExp(`${host}${destPathPattern.source}`);
+  const login = new RegExp(`${host}\/login(\\?.*)?$`);
+
+  await Promise.race([
+    page.waitForURL(dest, { timeout }),
+    page.waitForURL(login, { timeout }),
+  ]);
+}

--- a/tests/smoke/landing-to-app.spec.ts
+++ b/tests/smoke/landing-to-app.spec.ts
@@ -1,37 +1,18 @@
 import { test, expect } from '@playwright/test';
+import { expectAuthAwareRedirect } from '../e2e/helpers';
 
-const APP_HOST = /(https?:\/\/(app\.quickgig\.ph|localhost:3000))/;
+test('Landing → App CTAs » "Post a job" opens on app host', async ({ page }) => {
+  await page.goto('/');
+  const link = page.getByTestId('nav-post-job');
+  await expect(link).toBeVisible();
+  await Promise.all([page.waitForLoadState('domcontentloaded'), link.click()]);
+  await expectAuthAwareRedirect(page, /\/gigs\/create\/?$/);
+});
 
-test.describe('Landing → App CTAs', () => {
-  test('“Post a job” opens on app host', async ({ page }) => {
-    await page.goto('/smoke/landing-ctas');
-    await expect(
-      page.getByRole('heading', { name: 'Smoke: Landing CTAs' })
-    ).toBeVisible();
-    const link = page.locator('[data-testid="cta-post-job"]');
-    await expect(link).toBeVisible();
-    await Promise.all([
-      page.waitForLoadState('domcontentloaded'),
-      link.click(),
-    ]);
-    await expect(page).toHaveURL(
-      new RegExp(`${APP_HOST.source}\/gigs\/create\/?$`)
-    );
-  });
-
-  test('“My Applications” opens on app host', async ({ page }) => {
-    await page.goto('/smoke/landing-ctas');
-    await expect(
-      page.getByRole('heading', { name: 'Smoke: Landing CTAs' })
-    ).toBeVisible();
-    const link = page.locator('[data-testid="cta-my-applications"]');
-    await expect(link).toBeVisible();
-    await Promise.all([
-      page.waitForLoadState('domcontentloaded'),
-      link.click(),
-    ]);
-    await expect(page).toHaveURL(
-      new RegExp(`${APP_HOST.source}\/(applications|login)\/?$`)
-    );
-  });
+test('Landing → App CTAs » "My Applications" opens on app host', async ({ page }) => {
+  await page.goto('/');
+  const link = page.getByTestId('nav-my-applications');
+  await expect(link).toBeVisible();
+  await Promise.all([page.waitForLoadState('domcontentloaded'), link.click()]);
+  await expectAuthAwareRedirect(page, /\/applications\/?$/);
 });

--- a/tests/smoke/legacy-redirects.spec.ts
+++ b/tests/smoke/legacy-redirects.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
-const APP_HOST = /(https?:\/\/(app\.quickgig\.ph|localhost:3000))/;
+import { expectAuthAwareRedirect } from '../e2e/helpers';
 
 test('legacy /find redirects to /browse-jobs', async ({ page }) => {
   await page.goto('/find');
-  await expect(page).toHaveURL(new RegExp(`${APP_HOST.source}\/browse-jobs\/?$`));
+  await expect(page).toHaveURL(/\/browse-jobs\/?$/);
 });
 
-test('legacy /post-job redirects to /gigs/create', async ({ page }) => {
+test('legacy /post-job redirects to create (auth-aware)', async ({ page }) => {
   await page.goto('/post-job');
-  await expect(page).toHaveURL(new RegExp(`${APP_HOST.source}\/gigs\/create\/?$`));
+  await expectAuthAwareRedirect(page, /\/gigs\/create\/?$/);
 });

--- a/tests/smoke/post-job-form-render.spec.ts
+++ b/tests/smoke/post-job-form-render.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { expectAuthAwareRedirect } from '../e2e/helpers';
+
+test('Post Job form › renders form, skeleton, or redirects', async ({ page }) => {
+  await page.goto('/gigs/create');
+
+  const heading = page.getByRole('heading', { name: /post a job/i });
+  const skeleton = page.getByTestId('post-job-skeleton');
+
+  await Promise.race([
+    heading.waitFor({ timeout: 10000 }),
+    skeleton.waitFor({ timeout: 10000 }),
+    expectAuthAwareRedirect(page, /\/gigs\/create\/?$/, 10000),
+  ]);
+
+  if (await heading.isVisible()) {
+    await expect(page.getByLabel('Title')).toBeVisible();
+    await expect(page.getByLabel('Description')).toBeVisible();
+    await expect(page.getByLabel('Location')).toBeVisible();
+  }
+});


### PR DESCRIPTION
## Summary
- unify nav CTAs and hero CTA IDs
- add auth-aware redirect helper and stable post-job skeleton
- document smoke guardrails and add no-legacy testId check

## Changes
- header CTAs → `nav-post-job` / `nav-my-applications`
- add `post-job-skeleton` id
- add `expectAuthAwareRedirect` helper and update smokes
- normalize legacy redirects expectations
- add `scripts/no-legacy.mjs` and `docs/smoke.md`; update `docs/agents.md`
- remove old `cta-*` selectors from tests

## Testing
- `npm run no-legacy`
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 Forbidden fetching Playwright)*

## Acceptance
- no legacy `cta-post-job`/`cta-my-applications` testIds
- smokes account for `/login?next=` redirects
- header and hero CTAs have stable IDs

## Notes
- Playwright package unavailable from registry, so smoke tests could not run locally.


------
https://chatgpt.com/codex/tasks/task_e_68b93e02f3e883279cb3b1d65901d112