### PR TITLE
feat: enforce canonical routes and responsive header

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,73 +1,70 @@
-diff --git a/agents.md b/agents.md
---- a/agents.md
-+++ b/agents.md
-@@
--<<<<<<<
--... (conflicted content removed)
--=======
--... (conflicted content removed)
-->>>>>>>
-+# Agents Contract
-+**Version:** 2025-09-04
-+
-+## Routes & CTAs (source of truth)
-+- Use `ROUTES` constants for all navigational links (no raw string paths).
-+- Header CTAs:
-+  - `data-testid="nav-post-job"` → `/gigs/create`
-+  - `data-testid="nav-my-applications"` → `/applications`
-+
-+## Auth behavior
-+- If signed out, clicking either CTA MUST 302 to `/login?next=<dest>`.
-+
-+## Legacy redirects (middleware)
-+- `/find`      → `/browse-jobs`
-+- `/post-job`  → `/gigs/create`
-+- Unauthenticated users MAY be redirected to `/login?next=/gigs/create`.
-+
-+## Test hooks (smoke/e2e)
-+- Stable header test IDs: `nav-post-job`, `nav-my-applications`.
-+- Post Job skeleton test id: `post-job-skeleton`.
-+- The landing page must not render duplicate CTAs with identical accessible names.
-+
-+## CI guardrails
-+- `scripts/check-cta-links.mjs` forbids legacy targets in UI (e.g., `/browse-jobs`) for header/landing CTAs.
-+- Whenever `app/**/routes.ts`, `middleware/**`, or `tests/smoke/**` change, update this document and bump the **Version** date above.
-+
-+<!-- AGENT CONTRACT v2025-09-04 -->
-+
-+---
-+
-+# QuickGig Agent Playbook (READ ME FIRST)
-+
-+## DO FIRST (hard rules)
-+- Use the canonical routes from `app/lib/routes.ts`. **Never** hardcode paths.
-+- Treat auth-gated flows as **auth-aware**: redirects to `/login?next=` are a *success* condition in PR smoke.
-+- Prefer stable selectors: `data-testid` over headings/text.
-+- Do not introduce or resurrect legacy paths in UI (e.g., `/find`, `/browse-jobs`, `/post-job`) except where explicitly redirected by middleware.
-+- If you modify routes, middleware, or smoke tests, update **this file** and `BACKFILL.md` with rationale.
-+
-+## Repository invariants
-+- **Routes:** `app/lib/routes.ts` is the single source of truth. CTAs import from there.
-+- **Redirects:** legacy paths normalize in `middleware.ts` and `next.config` `redirects()`.
-+- **Auth-aware smoke:** specs accept `/login` for gated flows; otherwise assert the form (or skeleton) renders.
-+- **Error handling:** global `app/error.tsx` + page-level boundaries (e.g., Post Job) prevent white screens.
-+
-+## When you change these, you must also update this file
-+- `app/lib/routes.ts`, `middleware/**`, `next.config.*`
-+- `tests/smoke/**`
-+- Components that alter Post Job skeleton or header CTAs (ensure test IDs stay stable)
-+- Any docs that alter smoke expectations
-+
-+## PR acceptance (agent checklist)
-+- [ ] No legacy anchors in the UI (run `bash scripts/no-legacy.sh`).
-+- [ ] Smoke passes locally: `npx playwright test -c playwright.smoke.ts`.
-+- [ ] If unauthenticated flows were touched, smoke specs are **auth-aware** (accept `/login?next=`).
-+- [ ] `BACKFILL.md` updated with changes + rationale.
-+- [ ] This file’s header **Version** bumped when contracts change.
-+
-+See [docs/smoke.md](docs/smoke.md) for smoke test instructions.
-+
-+```ts
-+// Unauth flows in smoke:
-+// Treat /login?next=… as success; do not assert privileged content.
-+```
+# Agents Contract
+**Version:** 2025-09-05
+
+## Routes & CTAs (source of truth)
+- Use `ROUTES` constants for all navigational links (no raw string paths).
+- Header CTAs:
+  - `data-testid="nav-browse-jobs"` → `/browse-jobs`
+  - `data-testid="nav-post-job"` → `/gigs/create`
+  - `data-testid="nav-my-applications"` → `/applications`
+  - `data-testid="nav-login"` → `/login`
+
+## Auth behavior
+- If signed out, clicking either CTA MUST 302 to `/login?next=<dest>`.
+- Auth-gated routes: `/applications`, `/gigs/create`.
+
+## Legacy redirects (middleware)
+- `/find`      → `/browse-jobs`
+- `/post-job`  → `/gigs/create`
+- Unauthenticated users MAY be redirected to `/login?next=/gigs/create`.
+
+## Test hooks (smoke/e2e)
+- Stable header test IDs: `nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`.
+- Mobile menu IDs: `navm-browse-jobs`, `navm-post-job`, `navm-my-applications`, `navm-login`.
+- Landing hero IDs: `hero-browse-jobs`, `hero-post-job`.
+- Post Job skeleton test id: `post-job-skeleton`.
+- The landing page must not render duplicate CTAs with identical accessible names.
+
+## CI guardrails
+- `scripts/no-legacy.sh` forbids raw legacy paths (e.g., `/find`, `/post-job`).
+- `scripts/check-cta-links.mjs` ensures CTAs point only to canonical routes.
+- Whenever `app/**/routes.ts`, `middleware/**`, or `tests/smoke/**` change, update this document and bump the **Version** date above.
+
+<!-- AGENT CONTRACT v2025-09-04 -->
+
+---
+
+# QuickGig Agent Playbook (READ ME FIRST)
+
+## DO FIRST (hard rules)
+- Use the canonical routes from `app/lib/routes.ts`. **Never** hardcode paths.
+- Treat auth-gated flows as **auth-aware**: redirects to `/login?next=` are a *success* condition in PR smoke.
+- Prefer stable selectors: `data-testid` over headings/text.
+- Do not introduce or resurrect legacy paths in UI (e.g., `/find`, `/browse-jobs`, `/post-job`) except where explicitly redirected by middleware.
+- If you modify routes, middleware, or smoke tests, update **this file** and `BACKFILL.md` with rationale.
+
+## Repository invariants
+- **Routes:** `app/lib/routes.ts` is the single source of truth. CTAs import from there.
+- **Redirects:** legacy paths normalize in `middleware.ts` and `next.config` `redirects()`.
+- **Auth-aware smoke:** specs accept `/login` for gated flows; otherwise assert the form (or skeleton) renders.
+- **Error handling:** global `app/error.tsx` + page-level boundaries (e.g., Post Job) prevent white screens.
+
+## When you change these, you must also update this file
+- `app/lib/routes.ts`, `middleware/**`, `next.config.*`
+- `tests/smoke/**`
+- Components that alter Post Job skeleton or header CTAs (ensure test IDs stay stable)
+- Any docs that alter smoke expectations
+
+## PR acceptance (agent checklist)
+- [ ] No legacy anchors in the UI (run `bash scripts/no-legacy.sh`).
+- [ ] Smoke passes locally: `npx playwright test -c playwright.smoke.ts`.
+- [ ] If unauthenticated flows were touched, smoke specs are **auth-aware** (accept `/login?next=`).
+- [ ] `BACKFILL.md` updated with changes + rationale.
+- [ ] This file’s header **Version** bumped when contracts change.
+
+See [docs/smoke.md](docs/smoke.md) for smoke test instructions.
+
+```ts
+// Unauth flows in smoke:
+// Treat /login?next=… as success; do not assert privileged content.
+```

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -76,3 +76,47 @@
 
 **Rollback**
 - Revert the PR(s) that introduced the contract & guardrails if a critical issue appears; routes fall back to previous behavior.
+
+## 2025-09-04 — Canonical routes & responsive header
+
+**Summary**
+- Root `/` and legacy paths normalize to `/browse-jobs`.
+- `LinkApp` + `toAppPath` ensure CTAs hit the app host in prod.
+- Single source header drives desktop and mobile menus with stable IDs:
+  - `nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`
+  - `navm-browse-jobs`, `navm-post-job`, `navm-my-applications`, `navm-login`
+
+**Rationale**
+- Prevent link drift and keep auth-aware flows consistent across devices.
+
+**Impact / Migrations**
+- Use `LinkApp` with `ROUTES` constants for new CTAs.
+- Tests must treat `/login?next=<dest>` redirects as success for gated links.
+
+**How to verify**
+- `npm run no-legacy`
+- `node scripts/check-cta-links.mjs`
+- `npx playwright test -c playwright.smoke.ts`
+
+**Rollback**
+- Revert the PR if navigation or auth flows break.
+
+## 2025-09-05 — Append `next` query for auth-gated redirects
+
+**Summary**
+- Middleware now redirects unsigned users from `/applications` and `/gigs/create` to `/login?next=<dest>`.
+
+**Rationale**
+- Preserve the intended destination after sign-in and satisfy smoke tests expecting `?next=`.
+
+**Impact / Migrations**
+- None; auth gating handled centrally in `middleware.ts`.
+
+**How to verify**
+- Visit `/applications` or `/gigs/create` while signed out → `/login?next=<dest>`.
+- `npm run no-legacy`
+- `node scripts/check-cta-links.mjs`
+- `npx playwright test -c playwright.smoke.ts`
+
+**Rollback**
+- Revert this commit to restore previous middleware behavior.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { LEGACY_MAP } from "@/app/lib/legacy-redirects";
+import { ROUTES } from "@/lib/routes";
+
+const AUTH_GATED = new Set([ROUTES.applications, ROUTES.gigsCreate]);
 
 // Normalize: case-insensitive, trim trailing slash (except root)
 function normalize(pathname: string) {
@@ -10,7 +13,7 @@ function normalize(pathname: string) {
 }
 
 export function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+  const { pathname, search } = req.nextUrl;
 
   // Allow smoke pages (and Next/static) through untouched
   if (
@@ -22,12 +25,27 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // Root redirect → browse jobs
+  if (pathname === "/" || pathname === "") {
+    const url = new URL(ROUTES.browseJobs, req.nextUrl);
+    return NextResponse.redirect(url, 308);
+  }
+
   // Legacy → modern redirects (belt & suspenders with next.config redirects)
   const key = normalize(pathname);
   const target = LEGACY_MAP[key];
   if (target) {
     const url = new URL(target, req.nextUrl);
     return NextResponse.redirect(url, 308);
+  }
+
+  // Auth-gated routes → /login?next=<dest>
+  const dest = pathname + (search || "");
+  if (AUTH_GATED.has(pathname) && !req.cookies.get("sb-access-token")) {
+    const url = req.nextUrl.clone();
+    url.pathname = ROUTES.login;
+    url.search = `?next=${encodeURIComponent(dest)}`;
+    return NextResponse.redirect(url, 302);
   }
 
   return NextResponse.next();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "smoke:prod": "BASE_URL=https://app.quickgig.ph npx playwright test -c playwright.smoke.ts",
     "e2e:prod": "BASE_URL=https://app.quickgig.ph npx playwright test",
     "test": "echo \"E2E disabled while product is WIP\" && exit 0",
-    "no-legacy": "node scripts/no-legacy.mjs"
+    "no-legacy": "bash scripts/no-legacy.sh"
   },
   "dependencies": {
     "@jobuntux/psgc": "^0.2.1",

--- a/scripts/check-cta-links.mjs
+++ b/scripts/check-cta-links.mjs
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CTA_MAP = {
+  'nav-browse-jobs': 'ROUTES.browseJobs',
+  'nav-post-job': 'ROUTES.gigsCreate',
+  'nav-my-applications': 'ROUTES.applications',
+  'nav-login': 'ROUTES.login',
+  'navm-browse-jobs': 'ROUTES.browseJobs',
+  'navm-post-job': 'ROUTES.gigsCreate',
+  'navm-my-applications': 'ROUTES.applications',
+  'navm-login': 'ROUTES.login',
+  'hero-browse-jobs': 'ROUTES.browseJobs',
+  'hero-post-job': 'ROUTES.gigsCreate'
+};
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) yield* walk(p);
+    else if (s.isFile()) yield p;
+  }
+}
+
+let errors = [];
+for (const file of walk('src')) {
+  const txt = readFileSync(file, 'utf8');
+  for (const [id, route] of Object.entries(CTA_MAP)) {
+    const marker = `data-testid="${id}"`;
+    const idx = txt.indexOf(marker);
+    if (idx !== -1) {
+      const snippet = txt.slice(Math.max(0, idx - 100), idx + 200);
+      if (!snippet.includes(route)) {
+        errors.push(`${file} → ${id}`);
+      }
+    }
+  }
+}
+
+if (errors.length) {
+  console.error('CTA link mismatches:\n' + errors.map(e => ' - ' + e).join('\n'));
+  process.exit(1);
+} else {
+  console.log('✔ CTA links use canonical routes');
+}

--- a/scripts/no-legacy.sh
+++ b/scripts/no-legacy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find raw legacy paths
+bad=$(rg -l '/find|/post-job' src tests || true)
+bad=$(echo "$bad" | grep -v 'src/app/lib/legacy-redirects.ts' | grep -v 'tests/smoke/legacy-redirects.spec.ts' || true)
+if [[ -n "$bad" ]]; then
+  echo 'Legacy path strings found in:'
+  echo "$bad"
+  exit 1
+fi
+
+# Check for legacy testIds
+node "$(dirname "$0")/no-legacy.mjs"

--- a/src/app/applications/page.tsx
+++ b/src/app/applications/page.tsx
@@ -4,6 +4,7 @@ export const revalidate = 0;
 
 import { redirect } from "next/navigation";
 import { supabaseServer } from "@/lib/supabase/server";
+import { ROUTES } from "@/lib/routes";
 
 export default async function ApplicationsPage() {
   const supabase = supabaseServer();
@@ -11,7 +12,7 @@ export default async function ApplicationsPage() {
   const user = userRes?.user;
 
   if (userErr || !user) {
-    redirect("/login");
+    redirect(`${ROUTES.login}?next=${ROUTES.applications}`);
   }
 
   const { data: applications, error } = await supabase

--- a/src/app/gigs/create/error.tsx
+++ b/src/app/gigs/create/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import PostJobSkeleton from '@/features/gigs/PostJobSkeleton';
+
+export default function GigsCreateError() {
+  return <PostJobSkeleton data-testid="post-job-skeleton" />;
+}

--- a/src/app/gigs/create/page.tsx
+++ b/src/app/gigs/create/page.tsx
@@ -3,12 +3,13 @@ import { redirect } from 'next/navigation';
 import PostJobFormClient from '@/features/gigs/PostJobFormClient';
 import { userIdFromCookie } from '@/lib/supabase/server';
 import { ensureTicketsRow, getTicketBalance } from '@/lib/tickets';
+import { ROUTES } from '@/lib/routes';
 
 export const dynamic = 'force-dynamic';
 
 export default async function GigsCreatePage() {
   const uid = await userIdFromCookie();
-  if (!uid) redirect('/login?next=/gigs/create');
+  if (!uid) redirect(`${ROUTES.login}?next=${ROUTES.gigsCreate}`);
   await ensureTicketsRow(uid);
   const balance = await getTicketBalance(uid);
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 // Server component: redirect "/" to the working product shell at "/browse-jobs".
-import { redirect } from 'next/navigation';
+import { permanentRedirect } from 'next/navigation';
+import { ROUTES } from '@/lib/routes';
 
 export default function Root() {
-  redirect('/browse-jobs');
+  permanentRedirect(ROUTES.browseJobs);
 }

--- a/src/app/smoke/landing-ctas/page.tsx
+++ b/src/app/smoke/landing-ctas/page.tsx
@@ -12,10 +12,12 @@ export default function SmokeLandingCTAs() {
     <main className="p-8 space-y-4">
       <h1 className="text-xl font-semibold">Smoke: Landing CTAs</h1>
       <div className="flex flex-col gap-3">
-        <LinkApp data-testid="cta-find-work" href={ROUTES.browseJobs}>Find Work</LinkApp>
-        <LinkApp data-testid="cta-browse-jobs" href={ROUTES.browseJobs}>Browse Jobs</LinkApp>
-        <LinkApp data-testid="nav-post-job" href={ROUTES.gigsCreate}>Post a job</LinkApp>
-        <LinkApp data-testid="nav-my-applications" href={ROUTES.applications}>My Applications</LinkApp>
+        <LinkApp data-testid="hero-browse-jobs" href={ROUTES.browseJobs}>
+          Browse Jobs
+        </LinkApp>
+        <LinkApp data-testid="hero-post-job" href={ROUTES.gigsCreate}>
+          Post a job
+        </LinkApp>
       </div>
     </main>
   );

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { useState } from 'react';
 import { useUser } from '@/hooks/useUser';
 import LinkApp from '@/components/LinkApp';
 import { ROUTES } from '@/lib/routes';
@@ -11,50 +11,126 @@ type Props = {
 
 export default function AppHeader({ balance }: Props) {
   const { user, signOut } = useUser();
+  const [open, setOpen] = useState(false);
+
+  const baseLinks = [
+    {
+      href: ROUTES.browseJobs,
+      label: 'Browse jobs',
+      testId: 'nav-browse-jobs',
+      mobileId: 'navm-browse-jobs',
+    },
+    {
+      href: ROUTES.gigsCreate,
+      label: 'Post a job',
+      testId: 'nav-post-job',
+      mobileId: 'navm-post-job',
+    },
+    {
+      href: ROUTES.applications,
+      label: 'My Applications',
+      testId: 'nav-my-applications',
+      mobileId: 'navm-my-applications',
+    },
+  ];
+  const authLinks = user
+    ? [
+        {
+          label: 'Sign out',
+          onClick: () => signOut(),
+          testId: 'nav-logout',
+          mobileId: 'navm-logout',
+        },
+      ]
+    : [
+        {
+          href: ROUTES.login,
+          label: 'Sign in',
+          testId: 'nav-login',
+          mobileId: 'navm-login',
+        },
+      ];
+  const links = [...baseLinks, ...authLinks];
+
   return (
     <header data-testid="app-header" className="border-b bg-white/60 backdrop-blur">
       <div className="mx-auto max-w-5xl flex items-center justify-between p-4">
         <div className="flex items-center gap-4">
-          <Link href="/" className="font-semibold">
+          <LinkApp href={ROUTES.browseJobs} className="font-semibold">
             QuickGig
-          </Link>
-          <nav className="flex items-center gap-4">
-            <LinkApp data-testid="nav-browse-jobs" href={ROUTES.browseJobs} prefetch={false}>
-              Browse jobs
-            </LinkApp>
-            <LinkApp href={ROUTES.gigsCreate} data-testid="nav-post-job" prefetch={false}>
-              Post a job
-            </LinkApp>
-            <LinkApp
-              href={ROUTES.applications}
-              data-testid="nav-my-applications"
-              prefetch={false}
-            >
-              My Applications
-            </LinkApp>
-            {user ? (
-              <button onClick={() => signOut()} className="underline">
-                Sign out
-              </button>
-            ) : (
-              <Link href="/login" className="underline">
-                Sign in
-              </Link>
+          </LinkApp>
+          <nav className="hidden md:flex items-center gap-4">
+            {links.map(link =>
+              link.href ? (
+                <LinkApp
+                  key={link.testId}
+                  data-testid={link.testId}
+                  href={link.href}
+                  prefetch={false}
+                >
+                  {link.label}
+                </LinkApp>
+              ) : (
+                <button
+                  key={link.testId}
+                  data-testid={link.testId}
+                  onClick={link.onClick}
+                  className="underline"
+                >
+                  {link.label}
+                </button>
+              ),
             )}
           </nav>
+          <button
+            data-testid="navm-toggle"
+            className="md:hidden"
+            onClick={() => setOpen(o => !o)}
+          >
+            Menu
+          </button>
         </div>
         <div className="flex items-center gap-2">
           <span className="rounded-xl border px-2 py-1 text-sm" title="Tickets">
             🎟️ {balance}
           </span>
-          <Link
+          <LinkApp
             href="/billing/tickets?next=/gigs/create"
             className="border rounded-xl px-3 py-1 text-sm"
           >
             Buy ticket
-          </Link>
+          </LinkApp>
         </div>
       </div>
+      {open && (
+        <nav className="md:hidden flex flex-col gap-2 p-4 border-t">
+          {links.map(link =>
+            link.href ? (
+              <LinkApp
+                key={link.mobileId}
+                data-testid={link.mobileId}
+                href={link.href}
+                prefetch={false}
+                onClick={() => setOpen(false)}
+              >
+                {link.label}
+              </LinkApp>
+            ) : (
+              <button
+                key={link.mobileId}
+                data-testid={link.mobileId}
+                onClick={() => {
+                  setOpen(false);
+                  link.onClick();
+                }}
+                className="underline text-left"
+              >
+                {link.label}
+              </button>
+            ),
+          )}
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import LinkApp from "@/components/LinkApp";
+import { ROUTES } from "@/lib/routes";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import Banner from "@/components/ui/Banner";
@@ -139,9 +141,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 Profile
               </Link>
             ) : (
-              <Link href="/login" data-testid="nav-login" app-nav="/login">
+              <LinkApp href={ROUTES.login} data-testid="nav-login">
                 {copy.nav.auth}
-              </Link>
+              </LinkApp>
             )}
           </nav>
           {user && <AppHeaderTickets />}

--- a/src/components/LinkApp.tsx
+++ b/src/components/LinkApp.tsx
@@ -1,8 +1,9 @@
 'use client';
 import Link from 'next/link';
 import type { ComponentProps } from 'react';
+import { toAppPath } from '@/lib/urls';
 
-export default function LinkApp(props: ComponentProps<typeof Link>) {
-  // Simple passthrough; any cross-host logic stays centralized here if needed later.
-  return <Link {...props} />;
+export default function LinkApp({ href, ...props }: ComponentProps<typeof Link>) {
+  const dest = typeof href === 'string' ? toAppPath(href) : href;
+  return <Link {...props} href={dest} />;
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import LinkApp from "@/components/LinkApp";
+import { ROUTES } from "@/lib/routes";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { supabase } from "@/utils/supabaseClient";
@@ -32,15 +34,15 @@ export default function Nav() {
         <Link href="/gigs" data-testid="nav-find">
           {copy.nav.findWork}
         </Link>
-        <Link href="/gigs/create" data-testid="nav-post">
+        <LinkApp href={ROUTES.gigsCreate} data-testid="nav-post-job">
           {copy.nav.postJob}
-        </Link>
+        </LinkApp>
       {session ? (
         <button onClick={logout}>Logout</button>
       ) : (
-        <Link href="/login" data-testid="nav-login">
+        <LinkApp href={ROUTES.login} data-testid="nav-login">
           {copy.nav.auth}
-        </Link>
+        </LinkApp>
       )}
     </nav>
   );

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import LinkApp from "@/components/LinkApp";
+import { ROUTES } from "@/lib/routes";
 import { useEffect, useState } from "react";
 import { supabase } from "@/utils/supabaseClient";
 import AppHeaderNotifications from "@/components/AppHeaderNotifications";
@@ -61,9 +63,9 @@ export default function TopNav() {
             >
               {copy.nav.postJob}
             </Link>
-          <Link href="/login" data-testid="nav-login">
+          <LinkApp href={ROUTES.login} data-testid="nav-login">
             {copy.nav.auth}
-          </Link>
+          </LinkApp>
         </div>
       </div>
     </nav>

--- a/src/components/home/HomeSeeker.tsx
+++ b/src/components/home/HomeSeeker.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import LinkApp from "@/components/LinkApp";
+import { ROUTES } from "@/lib/routes";
 import { useEffect, useMemo, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -50,12 +52,12 @@ export default function HomeSeeker() {
             online.
           </p>
           <div className="flex flex-wrap gap-2">
-            <Link
-              href="/find?focus=search"
+            <LinkApp
+              href={`${ROUTES.browseJobs}?focus=search`}
               className="qg-btn qg-btn--primary px-4 py-2 rounded-xl"
             >
               Browse jobs
-            </Link>
+            </LinkApp>
             <Link
               href="/profile"
               className="qg-btn qg-btn--outline px-4 py-2 rounded-xl"
@@ -97,9 +99,12 @@ export default function HomeSeeker() {
       <section>
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-lg font-medium">Suggested jobs for you</h2>
-          <Link href="/find?focus=search" className="text-sm text-blue-600 underline">
+          <LinkApp
+            href={`${ROUTES.browseJobs}?focus=search`}
+            className="text-sm text-blue-600 underline"
+          >
             See all
-          </Link>
+          </LinkApp>
         </div>
         {loadingJobs ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -137,9 +142,12 @@ export default function HomeSeeker() {
       <section>
         <h2 className="text-lg font-medium mb-3">Quick actions</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          <Link href="/find?focus=search" className="border rounded-xl p-4 hover:shadow-sm">
+          <LinkApp
+            href={`${ROUTES.browseJobs}?focus=search`}
+            className="border rounded-xl p-4 hover:shadow-sm"
+          >
             Browse jobs
-          </Link>
+          </LinkApp>
           <Link
             href="/messages"
             className="border rounded-xl p-4 hover:shadow-sm"

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -25,7 +25,7 @@ export default function LandingHeader() {
       >
         My Applications
       </LinkApp>
-      <LinkApp href={ROUTES.login} className="...">
+      <LinkApp data-testid="nav-login" href={ROUTES.login} className="...">
         Sign in
       </LinkApp>
     </nav>

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -7,7 +7,7 @@ export default function LandingHero() {
       <div className="flex gap-3">
         <LinkApp
           href={ROUTES.browseJobs}
-          data-testid="cta-browse-jobs"
+          data-testid="hero-browse-jobs"
           className="px-4 py-2 rounded-md bg-gray-100"
         >
           Browse jobs

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -19,7 +19,7 @@ export default function LandingCTAs({
       <div className="flex gap-3">
         {showFind && (
           <LinkApp
-            data-testid="cta-browse-jobs"
+            data-testid="hero-browse-jobs"
             href={ROUTES.browseJobs}
             className={findClassName}
           >
@@ -27,7 +27,7 @@ export default function LandingCTAs({
           </LinkApp>
         )}
         {showPost && (
-          <LinkApp href={ROUTES.gigsCreate} className={postClassName}>
+          <LinkApp data-testid="hero-post-job" href={ROUTES.gigsCreate} className={postClassName}>
             Post a job
           </LinkApp>
         )}

--- a/src/components/posts/CreatePostForm.tsx
+++ b/src/components/posts/CreatePostForm.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import GeoSelect, { GeoValue } from "@/components/location/GeoSelect";
 import { getBrowserSupabase } from "@/lib/supabase-browser";
+import { ROUTES } from "@/lib/routes";
 
 let supabase = getBrowserSupabase();
 export function __setSupabaseClient(client: any) {
@@ -58,7 +59,7 @@ export default function CreatePostForm() {
     try {
       await submit(new FormData(e.currentTarget));
       setForm({ title:'', description:'', region_code:'', province_code:'', city_code:'', price_php:'' });
-      window.location.href = `/find`;
+      window.location.href = ROUTES.browseJobs;
     } catch (e: any) {
       setErr(e.message || 'Create failed');
     } finally {

--- a/tests/e2e/core.nav.spec.ts
+++ b/tests/e2e/core.nav.spec.ts
@@ -13,9 +13,9 @@ test('Home → Browse Jobs renders', async ({ page }) => {
 
 test('Home → My Applications renders (signed out ok)', async ({ page }) => {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await page.getByTestId('my-applications').click();
+  await page.getByTestId('nav-my-applications').click();
   await expect(page).toHaveURL(
-    new RegExp(`${APP_HOST.source}\\/(applications\\/login|login)\\/?$`)
+    new RegExp(`${APP_HOST.source}\\/(applications|login)\\/?$`)
   );
   if ((await page.url()).includes('/login')) {
     await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible();

--- a/tests/smoke/hero.spec.ts
+++ b/tests/smoke/hero.spec.ts
@@ -1,53 +1,16 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { expectAuthAwareRedirect } from '../e2e/helpers';
 
-const PATHS = {
-  browse: ['/browse-jobs', '/jobs'],
-  post: ['/gigs/create'],
-};
-
-async function gotoHome(page: Page) {
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('networkidle');
-}
-
-async function tryClick(page: Page, nameRegex: RegExp) {
-  const candidates = [
-    page.getByRole('link', { name: nameRegex }),
-    page.getByRole('button', { name: nameRegex }),
-    page.getByText(nameRegex).filter({ hasNot: page.locator('[aria-hidden="true"]') }),
-  ];
-  for (const loc of candidates) {
-    if (await loc.count()) {
-      await loc.first().click();
-      return true;
-    }
-  }
-  return false;
-}
-
-test.describe('Hero', () => {
-  test('Browse jobs works', async ({ page }) => {
-    await gotoHome(page);
-    const clicked = await tryClick(page, /browse jobs/i);
-    if (!clicked) {
-      // Navigate directly; smoke’s job is route-health, not UX fidelity
-      await page.goto(PATHS.browse[0], { waitUntil: 'domcontentloaded' });
-    }
-    // Accept either /browse-jobs or /jobs
-    await expect(page).toHaveURL(/\/(browse-jobs|jobs)\b/i, { timeout: 10_000 });
-    // Heading assertion is best-effort (don’t fail smoke if copy differs)
-    await expect(page.getByRole('heading', { name: /browse jobs/i }))
-      .toBeVisible({ timeout: 5_000 })
-      .catch(() => {});
+test.describe('landing hero CTAs', () => {
+  test('Browse Jobs', async ({ page }) => {
+    await page.goto('/smoke/landing-ctas');
+    await page.getByTestId('hero-browse-jobs').click();
+    await expect(page).toHaveURL(/\/browse-jobs/);
   });
 
-  test('Post a job works (shell)', async ({ page }) => {
-    await gotoHome(page);
-    const clicked = await tryClick(page, /post a job/i);
-    if (!clicked) {
-      await page.goto(PATHS.post[0], { waitUntil: 'domcontentloaded' });
-    }
-    await expect(page).toHaveURL(/\/gigs\/create\/?$/i, { timeout: 10_000 });
+  test('Post a Job (auth-aware)', async ({ page }) => {
+    await page.goto('/smoke/landing-ctas');
+    await page.getByTestId('hero-post-job').click();
+    await expectAuthAwareRedirect(page, /\/gigs\/create$/);
   });
 });
-

--- a/tests/smoke/nav-mobile.spec.ts
+++ b/tests/smoke/nav-mobile.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { expectAuthAwareRedirect } from '../e2e/helpers';
+
+async function openMenu(page) {
+  await page.getByTestId('navm-toggle').click();
+}
+
+test.use({ viewport: { width: 360, height: 740 } });
+
+test.describe('mobile header CTAs', () => {
+  test('Browse Jobs', async ({ page }) => {
+    await page.goto('/');
+    await openMenu(page);
+    await page.getByTestId('navm-browse-jobs').click();
+    await expect(page).toHaveURL(/\/browse-jobs/);
+  });
+
+  test('Post a Job (auth-aware)', async ({ page }) => {
+    await page.goto('/');
+    await openMenu(page);
+    await page.getByTestId('navm-post-job').click();
+    await expectAuthAwareRedirect(page, /\/gigs\/create$/);
+  });
+
+  test('My Applications (auth-aware)', async ({ page }) => {
+    await page.goto('/');
+    await openMenu(page);
+    await page.getByTestId('navm-my-applications').click();
+    await expectAuthAwareRedirect(page, /\/applications$/);
+  });
+
+  test('Login', async ({ page }) => {
+    await page.goto('/');
+    await openMenu(page);
+    await page.getByTestId('navm-login').click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/tests/smoke/nav.spec.ts
+++ b/tests/smoke/nav.spec.ts
@@ -1,30 +1,33 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { expectAuthAwareRedirect } from '../e2e/helpers';
 
-async function gotoHome(page: Page) {
+async function gotoHome(page) {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('networkidle');
 }
 
-async function clickNavOrGo(page: Page, opts: { name: RegExp, fallbackPath: string }) {
-  const link = page.getByRole('link', { name: opts.name });
-  if (await link.count()) {
-    await link.first().click();
-  } else {
-    await page.goto(opts.fallbackPath, { waitUntil: 'domcontentloaded' });
-  }
-}
-
-test.describe('nav links work', () => {
-  test('Home ▸ Browse Jobs', async ({ page }) => {
+test.describe('desktop header CTAs', () => {
+  test('Browse Jobs', async ({ page }) => {
     await gotoHome(page);
-    await clickNavOrGo(page, { name: /browse jobs/i, fallbackPath: '/browse-jobs' });
-    await expect(page).toHaveURL(/\/(browse-jobs|jobs)\b/i, { timeout: 10_000 });
+    await page.getByTestId('nav-browse-jobs').click();
+    await expect(page).toHaveURL(/\/browse-jobs/);
   });
 
-  test('Home ▸ My Applications (signed out ok)', async ({ page }) => {
+  test('Post a Job (auth-aware)', async ({ page }) => {
     await gotoHome(page);
-    await clickNavOrGo(page, { name: /my applications/i, fallbackPath: '/applications' });
-    await expect(page).toHaveURL(/\/(applications|login)\b/i, { timeout: 10_000 });
+    await page.getByTestId('nav-post-job').click();
+    await expectAuthAwareRedirect(page, /\/gigs\/create$/);
+  });
+
+  test('My Applications (auth-aware)', async ({ page }) => {
+    await gotoHome(page);
+    await page.getByTestId('nav-my-applications').click();
+    await expectAuthAwareRedirect(page, /\/applications$/);
+  });
+
+  test('Login', async ({ page }) => {
+    await gotoHome(page);
+    await page.getByTestId('nav-login').click();
+    await expect(page).toHaveURL(/\/login/);
   });
 });
-


### PR DESCRIPTION
## Summary
- append `next` query for auth-gated redirects in middleware
- bump agents contract and document auth-aware middleware behavior
- log the redirect change in backfill docs

## CTA IDs
nav-browse-jobs, nav-post-job, nav-my-applications, nav-login, navm-browse-jobs, navm-post-job, navm-my-applications, navm-login, hero-browse-jobs, hero-post-job

## Testing
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs`
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 Forbidden fetching Playwright package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9683de98c83278bd458e3da429bee