### PR TITLE
ci(harden): strict Smoke via npm ci, stable check names, and backfill entry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,12 @@
 name: Lint
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   eslint:
@@ -10,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - run: npm install --ignore-scripts --no-audit --fund=false --loglevel=error
-      - run: npx eslint .
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci --ignore-scripts --no-audit --fund=false --loglevel=error
+      - run: npx eslint . --max-warnings=0

--- a/.github/workflows/smoke-pr.yml
+++ b/.github/workflows/smoke-pr.yml
@@ -22,9 +22,8 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      # Tolerant install for smoke to avoid lockfile strictness (EUSAGE)
-      - name: Install dependencies (tolerant)
-        run: npm install --no-audit --fund=false --loglevel=error
+      - name: Install dependencies (strict)
+        run: npm ci --ignore-scripts --no-audit --fund=false --loglevel=error
 
       - name: Build
         env:
@@ -32,22 +31,8 @@ jobs:
           NEXT_TELEMETRY_DISABLED: '1'
         run: npm run build
 
-      - name: Start Next server
+      - name: Start server & verify /api/healthz
         env:
           NODE_ENV: production
           NEXT_TELEMETRY_DISABLED: '1'
-          PORT: 3000
-        run: |
-          nohup npm run start >/dev/null 2>&1 &
-
-      - name: Wait for /api/healthz
-        run: |
-          for i in {1..30}; do
-            if curl -fsS http://localhost:3000/api/healthz >/dev/null; then
-              echo "healthz is up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::healthz endpoint did not become ready"
-          exit 1
+        run: npx --yes start-server-and-test "next start -p 3000" http://localhost:3000/api/healthz "node -e \"process.exit(0)\"

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,7 +1,12 @@
 name: Type Check
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tsc:
@@ -10,8 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-      - run: npm install --ignore-scripts --no-audit --fund=false --loglevel=error
-      - run: npx tsc --noEmit --skipLibCheck
-        continue-on-error: true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci --ignore-scripts --no-audit --fund=false --loglevel=error
+      - run: npm run typecheck

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,12 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2025-09-05 — CI harden: strict Smoke, stable checks
+
+- Switched **Smoke (PR)** to `npm ci` (strict) now that **Lock Guard** syncs `package-lock.json` on PRs.
+- Smoke builds Next, boots on port 3000, and verifies readiness via **/api/healthz**.
+- Kept check names stable: **Lint**, **Type Check**, **Smoke (PR)** (recognized by branch protection).
+- Leaves `.nvmrc` (Node 20) and `.npmrc` (`audit=false`, `fund=false`) as-is.
+
 ## 2025-09-03
 - Added `NEXT_PUBLIC_APP_ORIGIN` and `src/lib/urls.ts` utility to centralize the app host.
 - Converted all landing CTAs (hero, nav, footer, and cards) to absolute links to the app:


### PR DESCRIPTION
## Summary
- Make Smoke (PR) strict with `npm ci`, build Next, and verify `/api/healthz`
- Keep check names stable by ensuring Lint and Type Check workflows use strict installs
- Document the CI hardening in backfill

## Testing
- `bash scripts/no-legacy.sh`
- `node scripts/check-cta-links.mjs`
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: missing module `globby`)*
- `npx --yes start-server-and-test "next start -p 3000" http://localhost:3000/api/healthz "node -e \"process.exit(0)\""` *(fails: 403 Forbidden from registry)*


------
https://chatgpt.com/codex/tasks/task_e_68bac644101c83279e0f6f243d5b0b1e