### PR TITLE
ci(eslint): fix warnings and restore --max-warnings=0; backfill

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci --ignore-scripts --no-audit --fund=false --loglevel=error
-      - run: npx eslint .
+      - run: npx eslint . --max-warnings=0

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -205,3 +205,10 @@
 - Softened ESLint (allow warnings) to prevent non-actionable failures.
 - Made Type Check informational (non-blocking) while type errors are triaged.
 - Check names preserved: `Lint / eslint (pull_request)`, `Type Check / tsc (pull_request)`, `Smoke (PR) / pr (pull_request)`.
+
+## 2025-09-05 — Harden ESLint warnings and restore strict gate
+
+- Fixed React hook deps warnings (`supabase.auth`, `ready`).
+- Replaced legacy `<img>` tags with Next.js `<Image>`.
+- Lint workflow now runs `npx eslint . --max-warnings=0`.
+- Check name preserved: `Lint / eslint (pull_request)`.

--- a/src/components/AppHeaderTickets.tsx
+++ b/src/components/AppHeaderTickets.tsx
@@ -15,7 +15,7 @@ export default function AppHeaderTickets() {
       } = await supabase.auth.getUser();
       setUid(user?.id ?? null);
     })();
-  }, []);
+  }, [supabase.auth]);
 
   const { data } = useSWR(uid ? ["tickets", uid] : null, async () => {
     const { data } = await supabase

--- a/src/components/PaymentProofModal.tsx
+++ b/src/components/PaymentProofModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import Image from 'next/image';
 import { supabaseBrowser } from '@/lib/supabase/browser';
 import { nanoid } from 'nanoid';
 
@@ -60,7 +61,13 @@ export default function PaymentProofModal({
         <h2 className="text-xl font-semibold">Buy posting credits</h2>
         <p>Send <b>₱{pricePHP}</b> via GCash and upload the receipt.</p>
         {process.env.NEXT_PUBLIC_GCASH_QR_URL && (
-          <img src={process.env.NEXT_PUBLIC_GCASH_QR_URL} alt="GCash QR" className="w-48 h-48 mx-auto rounded" />
+          <Image
+            src={process.env.NEXT_PUBLIC_GCASH_QR_URL}
+            alt="GCash QR"
+            width={192}
+            height={192}
+            className="w-48 h-48 mx-auto rounded"
+          />
         )}
         <input type="file" accept="image/*" onChange={(e)=>setFile(e.target.files?.[0] || null)} />
         {error && <p className="text-sm text-red-600">{error}</p>}

--- a/src/components/billing/ProofCard.tsx
+++ b/src/components/billing/ProofCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { supabaseBrowser } from '@/lib/supabase/browser';
 
 interface Proof {
@@ -29,7 +30,7 @@ export default function ProofCard({ proof, children }: { proof: Proof; children?
     <div className="border rounded p-4 space-y-2">
       {url && (
         isImage ? (
-          <img src={url} alt="proof" className="h-32 object-contain" />
+          <Image src={url} alt="proof" width={128} height={128} className="h-32 object-contain" />
         ) : (
           <a href={url} target="_blank" rel="noreferrer" className="underline">
             View file

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -19,7 +19,7 @@ export function useUser() {
       setUser(u);
     });
     return () => { mounted = false; sub?.subscription.unsubscribe(); };
-  }, []);
+  }, [supabase.auth]);
 
   return { user, loading, signOut: () => supabase.auth.signOut() };
 }

--- a/src/lib/useRequireUser.ts
+++ b/src/lib/useRequireUser.ts
@@ -31,7 +31,7 @@ export function useRequireUser() {
       active = false;
       clearTimeout(timer);
     };
-  }, [router]);
+  }, [router, ready]);
 
   return { ready, userId, timedOut };
 }


### PR DESCRIPTION
## Summary
- enforce zero-warn lint gate in CI
- satisfy React hook dep warnings and use Next.js Image
- document lint hardening in backfill

## Testing
- `bash scripts/no-legacy.sh`
- `node scripts/check-cta-links.mjs`
- `npx eslint . --max-warnings=0` *(fails: ESLint v9 requires new config format)*
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 fetching playwright)*

## Checklist
- [ ] Lint / eslint (pull_request) is green with 0 warnings
- [ ] Smoke (PR) / pr (pull_request) remains green
- [ ] Type Check / tsc (pull_request) unaffected


------
https://chatgpt.com/codex/tasks/task_e_68bacfeae9d0832789bd442b36760a5f