### PR TITLE
feat(tickets): RLS + signup bonus + spend RPCs; balance API & UI

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,5 +1,5 @@
 # Agents Contract
-**Version:** 2025-09-09
+**Version:** 2025-10-15
 
 ## Routes & CTAs (source of truth)
 - Use `ROUTES` constants for all navigational links (no raw string paths).

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -224,3 +224,11 @@
 - Created `tickets_burn_on_agreement(employer, jobseeker, agreement_id)` RPC to atomically debit both parties and log transactions.
 - Enabled RLS for read-your-own on both tables; writes occur via service-role RPC only.
 - Backfilled existing users with an account and a one-time signup bonus if missing.
+
+## 2025-10-15 — Tickets: RLS + RPC + Balance UI
+- Enable RLS for ticket_ledger; owners can read their rows.
+- Block direct writes; expose SECURITY DEFINER RPCs:
+  - award_signup_bonus() — idempotent, grants 3 on first call
+  - spend_one_ticket(reason text, meta jsonb) — debits 1 if balance > 0
+  - ticket_balance(user_id uuid = auth.uid()) — returns int
+- Added /api/tickets/balance and a TicketBadge used in header + /account/tickets page.

--- a/src/app/account/tickets/page.tsx
+++ b/src/app/account/tickets/page.tsx
@@ -1,0 +1,13 @@
+import TicketBadge from "@/components/TicketBadge";
+
+export default function TicketsPage() {
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Your Tickets</h1>
+      <TicketBadge />
+      <p className="text-sm text-neutral-500">
+        You receive 3 free tickets on signup. One ticket is spent when an agreement is reached.
+      </p>
+    </main>
+  );
+}

--- a/src/app/api/tickets/balance/route.ts
+++ b/src/app/api/tickets/balance/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { ensureSignupBonus, getTicketBalance } from "@/lib/tickets";
+
+export async function GET() {
+  try {
+    // Award free tickets once per user (idempotent), then return balance
+    await ensureSignupBonus();
+    const balance = await getTicketBalance();
+    return NextResponse.json({ balance });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "error" }, { status: 400 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,16 @@
 import '@/styles/globals.css';
 import type { Metadata } from 'next';
 import AppHeader from '@/components/AppHeader';
-import { ensureTicketsRow, getTicketBalance } from '@/lib/tickets';
-import { userIdFromCookie } from '@/lib/supabase/server';
 
 export const metadata: Metadata = {
   title: 'QuickGig App',
 };
 
-export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const uid = await userIdFromCookie();
-  if (uid) await ensureTicketsRow(uid);
-  const balance = uid ? await getTicketBalance(uid) : 0;
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <AppHeader balance={balance} />
+        <AppHeader />
         {children}
       </body>
     </html>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,12 +4,9 @@ import { useState } from 'react';
 import { useUser } from '@/hooks/useUser';
 import LinkApp from '@/components/LinkApp';
 import { NAV_ITEMS, ROUTES } from '@/lib/routes';
+import TicketBadge from '@/components/TicketBadge';
 
-type Props = {
-  balance: number;
-};
-
-export default function AppHeader({ balance }: Props) {
+export default function AppHeader() {
   const { user, signOut } = useUser();
   const [open, setOpen] = useState(false);
 
@@ -71,11 +68,9 @@ export default function AppHeader({ balance }: Props) {
           </button>
         </div>
         <div className="flex items-center gap-2">
-          <span className="rounded-xl border px-2 py-1 text-sm" title="Tickets">
-            🎟️ {balance}
-          </span>
+          <TicketBadge />
           <LinkApp
-            href="/billing/tickets?next=/gigs/create"
+            href={`${ROUTES.billingTickets}?next=${encodeURIComponent(ROUTES.postJob)}`}
             className="border rounded-xl px-3 py-1 text-sm"
           >
             Buy ticket

--- a/src/components/TicketBadge.tsx
+++ b/src/components/TicketBadge.tsx
@@ -1,0 +1,15 @@
+"use client";
+import useSWR from "swr";
+
+const fetcher = (u: string) => fetch(u).then(r => r.json());
+
+export default function TicketBadge() {
+  const { data } = useSWR<{ balance?: number }>("/api/tickets/balance", fetcher, { refreshInterval: 30000 });
+  const balance = data?.balance ?? "—";
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-sm">
+      <span className="font-medium">Tickets</span>
+      <span className="rounded-full bg-neutral-800 text-white px-2 py-[1px]">{balance}</span>
+    </span>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,6 +3,8 @@ export const ROUTES = {
   postJob: '/gigs/create',
   applications: '/applications',
   login: '/login',
+  billingTickets: '/billing/tickets',
+  accountTickets: '/account/tickets',
 } as const;
 export type AppPath = (typeof ROUTES)[keyof typeof ROUTES];
 

--- a/supabase/migrations/20251015000000_tickets_rls_and_rpcs.sql
+++ b/supabase/migrations/20251015000000_tickets_rls_and_rpcs.sql
@@ -1,0 +1,88 @@
+-- Enable RLS
+alter table public.ticket_ledger enable row level security;
+
+-- Only owners can read their rows
+drop policy if exists "ticket_ledger: read own" on public.ticket_ledger;
+drop policy if exists "ticket_ledger: admin read all" on public.ticket_ledger;
+drop policy if exists "owner_can_select_tickets" on public.ticket_ledger;
+create policy "owner_can_select_tickets"
+on public.ticket_ledger
+for select
+to authenticated
+using (user_id = auth.uid());
+
+-- Block direct inserts/updates/deletes from clients; we’ll use SECURITY DEFINER funcs
+revoke insert, update, delete on public.ticket_ledger from anon, authenticated;
+
+-- Helpful index
+create index if not exists ticket_ledger_user_created_idx
+  on public.ticket_ledger (user_id, created_at desc);
+
+-- Balance function
+create or replace function public.ticket_balance(p_user uuid default auth.uid())
+returns integer
+language sql
+stable
+as $$
+  select coalesce(sum(delta), 0)::int
+  from public.ticket_ledger
+  where user_id = p_user
+$$;
+
+grant execute on function public.ticket_balance(uuid) to anon, authenticated;
+
+-- One-time signup bonus (3 tickets) if not already granted
+create or replace function public.award_signup_bonus()
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  has_bonus boolean;
+begin
+  select exists (
+    select 1 from public.ticket_ledger
+    where user_id = auth.uid()
+      and reason = 'signup_bonus'
+  ) into has_bonus;
+
+  if not has_bonus then
+    insert into public.ticket_ledger(user_id, delta, reason, ref_type, ref_id)
+    values (auth.uid(), 3, 'signup_bonus', 'system', null);
+  end if;
+
+  return public.ticket_balance(auth.uid());
+end;
+$$;
+
+grant execute on function public.award_signup_bonus() to authenticated;
+
+-- Spend exactly 1 ticket with a reason
+create or replace function public.spend_one_ticket(p_reason text, p_meta jsonb default '{}'::jsonb)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  bal int;
+  v_ref_type text;
+  v_ref_id uuid;
+begin
+  bal := public.ticket_balance(auth.uid());
+  if bal < 1 then
+    raise exception 'INSUFFICIENT_TICKETS';
+  end if;
+
+  v_ref_type := coalesce(p_meta->>'ref_type', null);
+  v_ref_id := (p_meta->>'ref_id')::uuid;
+
+  insert into public.ticket_ledger(user_id, delta, reason, ref_type, ref_id)
+  values (auth.uid(), -1, coalesce(p_reason, 'spend'), v_ref_type, v_ref_id);
+
+  return public.ticket_balance(auth.uid());
+end;
+$$;
+
+grant execute on function public.spend_one_ticket(text, jsonb) to authenticated;


### PR DESCRIPTION
## Summary
- secure ticket_ledger with RLS and security definer RPCs for balance, signup bonus and spending
- server helpers + `/api/tickets/balance` to award signup bonus and expose balance
- TicketBadge in header and /account/tickets page to surface current balance

## Testing
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs`
- `npx playwright test -c playwright.smoke.ts` *(fails: browser download 403)*

## Acceptance Checklist
- [ ] Migration filename matches `^[0-9]{14}_.+\.sql$`
- [ ] `select ticket_balance(auth.uid())` works in SQL editor when logged in
- [ ] Calling `/api/tickets/balance` returns `{ balance: 3 }` on first load for a fresh user
- [ ] TicketBadge renders and shows a number
- [ ] RLS prevents reading others’ ledger rows
- [ ] No secrets in client bundles (server RPCs only)


------
https://chatgpt.com/codex/tasks/task_e_68bb85e2b434832785212b2ca254a629