### PR TITLE
feat(agreements): spend 1 ticket on agreement confirmation (atomic); UI guard with balance

### DIFF
--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -232,3 +232,8 @@
   - spend_one_ticket(reason text, meta jsonb) — debits 1 if balance > 0
   - ticket_balance(user_id uuid = auth.uid()) — returns int
 - Added /api/tickets/balance and a TicketBadge used in header + /account/tickets page.
+
+## 2025-09-06 — Ticket spend on agreement
+- Added server endpoint to confirm agreements and atomically spend 1 ticket via spend_one_ticket('agreement_burn').
+- Blocks confirmation with 402 when balance is 0; client shows a disabled button with tooltip.
+- Balance shown near CTA; auto-updates on success.

--- a/src/app/api/agreements/[id]/confirm/route.ts
+++ b/src/app/api/agreements/[id]/confirm/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { spendOneTicket, getTicketBalance } from '@/lib/tickets';
+import { userIdFromCookie } from '@/lib/supabase/server';
+import {
+  assertUserCanConfirmAgreement,
+  confirmAgreementSide,
+} from '@/lib/agreements';
+
+const Params = z.object({ id: z.string().uuid().or(z.string().min(1)) });
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const parse = Params.safeParse(params);
+  if (!parse.success)
+    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 });
+
+  const userId = await userIdFromCookie();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const agreementId = parse.data.id;
+
+  try {
+    const { agreement, role, already } = await assertUserCanConfirmAgreement(
+      agreementId,
+      userId,
+    );
+    if (already) {
+      const bal = await getTicketBalance();
+      return NextResponse.json({ ok: true, balance: bal, agreement });
+    }
+
+    const bal = await getTicketBalance();
+    if (bal < 1) {
+      return NextResponse.json(
+        { error: 'INSUFFICIENT_TICKETS' },
+        { status: 402 },
+      );
+    }
+
+    const newBal = await spendOneTicket('agreement_burn', {
+      agreementId,
+      role,
+    });
+
+    const updated = await confirmAgreementSide(agreementId, role);
+
+    return NextResponse.json({ ok: true, balance: newBal, agreement: updated });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message ?? 'Failed to confirm' },
+      { status: 409 },
+    );
+  }
+}

--- a/src/components/ConfirmAgreementButton.tsx
+++ b/src/components/ConfirmAgreementButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useState } from "react";
+import useSWR from "swr";
+
+export function ConfirmAgreementButton({ agreementId }: { agreementId: string }) {
+  const { data, mutate } = useSWR<{ balance?: number }>(
+    "/api/tickets/balance",
+    u => fetch(u).then(r => r.json()),
+  );
+  const bal = data?.balance ?? 0;
+  const [loading, setLoading] = useState(false);
+
+  async function onConfirm() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/agreements/${agreementId}/confirm`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || "Failed");
+      mutate({ balance: json.balance }, false);
+    } catch (e: any) {
+      alert(
+        e.message === "INSUFFICIENT_TICKETS"
+          ? "You need at least 1 ticket."
+          : e.message,
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        className="rounded-md px-4 py-2 border disabled:opacity-50"
+        onClick={onConfirm}
+        disabled={loading || bal <= 0}
+        title={bal <= 0 ? "No tickets remaining" : ""}
+      >
+        {loading ? "Confirming..." : "Confirm agreement"}
+      </button>
+      <span className="text-sm text-slate-600">Balance: {bal}</span>
+    </div>
+  );
+}

--- a/src/lib/agreements.ts
+++ b/src/lib/agreements.ts
@@ -1,0 +1,73 @@
+import 'server-only';
+
+import supabaseServer from '@/lib/supabase/server';
+
+export type AgreementRole = 'employer' | 'worker';
+
+export async function assertUserCanConfirmAgreement(
+  agreementId: string,
+  userId: string,
+) {
+  const supa = supabaseServer();
+  if (!supa) throw new Error('Server not configured');
+
+  const { data, error } = await supa
+    .from('agreements')
+    .select(
+      'id, employer_id, worker_id, status, employer_confirmed_at, worker_confirmed_at, reached_at'
+    )
+    .eq('id', agreementId)
+    .single();
+
+  if (error || !data) throw new Error('Agreement not found');
+
+  let role: AgreementRole | null = null;
+  if (data.employer_id === userId) role = 'employer';
+  else if (data.worker_id === userId) role = 'worker';
+  if (!role) throw new Error('Forbidden');
+
+  const already =
+    role === 'employer'
+      ? data.employer_confirmed_at != null
+      : data.worker_confirmed_at != null;
+
+  return { agreement: data, role, already } as const;
+}
+
+export async function confirmAgreementSide(
+  agreementId: string,
+  role: AgreementRole,
+) {
+  const supa = supabaseServer();
+  if (!supa) throw new Error('Server not configured');
+
+  const field = role === 'employer' ? 'employer_confirmed_at' : 'worker_confirmed_at';
+  const other = role === 'employer' ? 'worker_confirmed_at' : 'employer_confirmed_at';
+
+  const now = new Date().toISOString();
+
+  const { data, error } = await supa
+    .from('agreements')
+    .update({ [field]: now } as any)
+    .eq('id', agreementId)
+    .is(field, null)
+    .select('id, status, employer_confirmed_at, worker_confirmed_at, reached_at, employer_id, worker_id')
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('Failed to confirm');
+
+  if (data[field] && data[other] && data.status !== 'reached') {
+    const { data: reached, error: err2 } = await supa
+      .from('agreements')
+      .update({ status: 'reached', reached_at: now } as any)
+      .eq('id', agreementId)
+      .select('id, status, employer_confirmed_at, worker_confirmed_at, reached_at, employer_id, worker_id')
+      .single();
+    if (err2) throw new Error(err2.message);
+    return reached;
+  }
+
+  return data;
+}
+


### PR DESCRIPTION
## Summary
- add agreements confirmation API that spends a ticket atomically and blocks when balance is 0
- expose ConfirmAgreementButton component to show balance and disable when tickets empty
- document ticket spend for agreements

## Testing
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs`
- `npm run lint`
- `npm test`
- `npx playwright test -c playwright.smoke.ts` *(fails: 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb883b9768832797d9081ffab24d5b