### PR TITLE
feat(tickets): burn 1 per party on agreement; balance chip; action guards

### DIFF
--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -247,3 +247,8 @@
 ### 2025-09-06
 - Fix preview build by making ticket API routes dynamic and deferring Supabase env reads to runtime.
 - Added `getAdminClient()` helper that never throws at import-time; routes return 503 when server env is missing.
+### 2025-09-06
+- Atomic ticket burn: added `tickets_agreement_spend(employer, seeker, agreement)` RPC.
+- New `/api/agreements/[id]/confirm` calls the atomic burn and returns updated balances.
+- UI: balance chip in header + guards on Apply/Confirm when balance < 1.
+

--- a/src/app/api/agreements/[id]/confirm/route.ts
+++ b/src/app/api/agreements/[id]/confirm/route.ts
@@ -1,57 +1,70 @@
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
-import { spendOneTicket, getTicketBalance } from '@/lib/tickets';
-import { userIdFromCookie } from '@/lib/supabase/server';
-import {
-  assertUserCanConfirmAgreement,
-  confirmAgreementSide,
-} from '@/lib/agreements';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { getAdminClient } from '@/lib/supabase/admin';
 
-const Params = z.object({ id: z.string().uuid().or(z.string().min(1)) });
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
 
-export async function POST(
-  _req: Request,
-  { params }: { params: { id: string } },
-) {
-  const parse = Params.safeParse(params);
-  if (!parse.success)
-    return NextResponse.json({ error: 'Invalid ID' }, { status: 400 });
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const agreementId = params.id;
 
-  const userId = await userIdFromCookie();
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  // 1) Identify requester (must be one of the parties)
+  const cookieStore = cookies();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const supa = createServerClient(url, anon, { cookies: () => cookieStore });
 
-  const agreementId = parse.data.id;
-
-  try {
-    const { agreement, role, already } = await assertUserCanConfirmAgreement(
-      agreementId,
-      userId,
-    );
-    if (already) {
-      const bal = await getTicketBalance();
-      return NextResponse.json({ ok: true, balance: bal, agreement });
-    }
-
-    const bal = await getTicketBalance();
-    if (bal < 1) {
-      return NextResponse.json(
-        { error: 'INSUFFICIENT_TICKETS' },
-        { status: 402 },
-      );
-    }
-
-    const newBal = await spendOneTicket('agreement_burn', {
-      agreementId,
-      role,
-    });
-
-    const updated = await confirmAgreementSide(agreementId, role);
-
-    return NextResponse.json({ ok: true, balance: newBal, agreement: updated });
-  } catch (e: any) {
-    return NextResponse.json(
-      { error: e?.message ?? 'Failed to confirm' },
-      { status: 409 },
-    );
+  const { data: session } = await supa.auth.getUser();
+  const me = session?.user?.id;
+  if (!me) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
   }
+
+  // 2) Load agreement and participants (adjust table/columns if needed)
+  const { data: ag, error: agErr } = await supa
+    .from('agreements')
+    .select('id, employer_id, seeker_id, status')
+    .eq('id', agreementId)
+    .single();
+
+  if (agErr || !ag) {
+    return NextResponse.json({ ok: false, error: 'agreement_not_found' }, { status: 404 });
+  }
+
+  if (ag.status === 'agreed') {
+    return NextResponse.json({ ok: true, already: true }, { status: 200 });
+  }
+
+  if (me !== ag.employer_id && me !== ag.seeker_id) {
+    return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 });
+  }
+
+  // 3) Mark agreement agreed (domain logic)
+  const { error: upErr } = await supa.from('agreements').update({ status: 'agreed' }).eq('id', ag.id);
+  if (upErr) {
+    return NextResponse.json({ ok: false, error: 'update_failed', detail: upErr.message }, { status: 500 });
+  }
+
+  // 4) Atomic ticket burn for both sides (admin RPC)
+  const admin = getAdminClient();
+  if (!admin) {
+    return NextResponse.json({ ok: false, error: 'server_not_configured' }, { status: 503 });
+  }
+
+  const { data: burn, error: burnErr } = await admin.rpc('tickets_agreement_spend', {
+    p_employer: ag.employer_id,
+    p_seeker: ag.seeker_id,
+    p_agreement: ag.id,
+  });
+
+  if (burnErr) {
+    // Best-effort rollback of status if burn fails
+    await admin.from('agreements').update({ status: 'pending' }).eq('id', ag.id);
+    return NextResponse.json({ ok: false, error: 'burn_failed', detail: burnErr.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true, burn }, { status: 200 });
 }

--- a/src/app/api/tickets/spend/route.ts
+++ b/src/app/api/tickets/spend/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { spendOneTicket, getTicketBalance } from '@/lib/tickets';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+const Body = z.object({
+  amount: z.number().int().positive().default(1),
+  reason: z.string().max(100).default('spend'),
+});
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const parsed = Body.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'bad_request' }, { status: 400 });
+    }
+    const { amount, reason } = parsed.data;
+    for (let i = 0; i < amount; i++) {
+      await spendOneTicket(reason, { i });
+    }
+    const balance = await getTicketBalance();
+    return NextResponse.json({ ok: true, balance });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message ?? 'error' }, { status: 400 });
+  }
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,8 +4,10 @@ import { useState } from 'react';
 import { useUser } from '@/hooks/useUser';
 import LinkApp from '@/components/LinkApp';
 import { NAV_ITEMS, ROUTES } from '@/lib/routes';
-import TicketBadge from '@/components/TicketBadge';
+import dynamic from 'next/dynamic';
 import { isAdmin } from '@/lib/admin';
+
+const TicketBalanceChip = dynamic(() => import('@/components/TicketBalanceChip'), { ssr: false });
 
 export default function AppHeader() {
   const { user, signOut } = useUser();
@@ -77,7 +79,7 @@ export default function AppHeader() {
           </button>
         </div>
         <div className="flex items-center gap-2">
-          <TicketBadge />
+          <TicketBalanceChip />
           <LinkApp
             href={`${ROUTES.billingTickets}?next=${encodeURIComponent(ROUTES.postJob)}`}
             className="border rounded-xl px-3 py-1 text-sm"

--- a/src/components/ConfirmAgreementButton.tsx
+++ b/src/components/ConfirmAgreementButton.tsx
@@ -1,46 +1,31 @@
 "use client";
-import { useState } from "react";
-import useSWR from "swr";
+import { RequireTickets } from '@/components/RequireTickets';
 
 export function ConfirmAgreementButton({ agreementId }: { agreementId: string }) {
-  const { data, mutate } = useSWR<{ balance?: number }>(
-    "/api/tickets/balance",
-    u => fetch(u).then(r => r.json()),
-  );
-  const bal = data?.balance ?? 0;
-  const [loading, setLoading] = useState(false);
-
-  async function onConfirm() {
-    setLoading(true);
-    try {
-      const res = await fetch(`/api/agreements/${agreementId}/confirm`, {
-        method: "POST",
-      });
-      const json = await res.json();
-      if (!res.ok) throw new Error(json?.error || "Failed");
-      mutate({ balance: json.balance }, false);
-    } catch (e: any) {
-      alert(
-        e.message === "INSUFFICIENT_TICKETS"
-          ? "You need at least 1 ticket."
-          : e.message,
-      );
-    } finally {
-      setLoading(false);
-    }
+  async function confirmAgreement(id: string) {
+    const r = await fetch(`/api/agreements/${id}/confirm`, { method: 'POST' });
+    const j = await r.json();
+    if (!r.ok || !j?.ok) throw new Error(j?.error || 'Failed');
+    alert('Agreement confirmed. 1 ticket was spent from both parties.');
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <button
-        className="rounded-md px-4 py-2 border disabled:opacity-50"
-        onClick={onConfirm}
-        disabled={loading || bal <= 0}
-        title={bal <= 0 ? "No tickets remaining" : ""}
-      >
-        {loading ? "Confirming..." : "Confirm agreement"}
-      </button>
-      <span className="text-sm text-slate-600">Balance: {bal}</span>
-    </div>
+    <RequireTickets need={1}>
+      {(ok) => (
+        <button
+          className="rounded-md px-4 py-2 border disabled:opacity-50"
+          disabled={!ok}
+          onClick={() =>
+            ok
+              ? confirmAgreement(agreementId).catch(e =>
+                  alert(e?.message || 'Failed'),
+                )
+              : alert('You need 1 ticket to confirm an agreement.')
+          }
+        >
+          Confirm agreement
+        </button>
+      )}
+    </RequireTickets>
   );
 }

--- a/src/components/RequireTickets.tsx
+++ b/src/components/RequireTickets.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ReactNode, useState, useEffect } from 'react';
+
+export function RequireTickets({ need = 1, children }: { need?: number; children: (ok: boolean, spend: () => Promise<boolean>) => ReactNode }) {
+  const [balance, setBalance] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/tickets/balance', { cache: 'no-store' })
+      .then(r => r.json())
+      .then(j => setBalance(Number(j?.balance ?? 0)))
+      .catch(() => setBalance(0));
+  }, []);
+
+  async function spend() {
+    setBusy(true);
+    try {
+      const r = await fetch('/api/tickets/spend', { method: 'POST', body: JSON.stringify({ amount: need, reason: 'action' }) });
+      if (!r.ok) return false;
+      const j = await r.json();
+      setBalance(Number(j?.balance ?? 0));
+      return true;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const ok = (balance ?? 0) >= need && !busy;
+  return <>{children(ok, spend)}</>;
+}

--- a/src/components/TicketBalanceChip.tsx
+++ b/src/components/TicketBalanceChip.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url, { cache: 'no-store' }).then(r => r.json());
+
+export default function TicketBalanceChip() {
+  const { data } = useSWR<{ balance?: number; ok?: boolean }>('/api/tickets/balance', fetcher, { refreshInterval: 30_000 });
+
+  const b = typeof data?.balance === 'number' ? data.balance : undefined;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs">
+      🎟️ <strong>{b ?? '—'}</strong>
+    </span>
+  );
+}

--- a/src/components/gigs/ApplyPanel.tsx
+++ b/src/components/gigs/ApplyPanel.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useUser } from '@/hooks/useUser';
 import { useState } from 'react';
+import { RequireTickets } from '@/components/RequireTickets';
+import { ROUTES } from '@/lib/routes';
 
 export function ApplyPanel({ gigId }: { gigId: string }) {
   const { user } = useUser();
@@ -20,12 +22,35 @@ export function ApplyPanel({ gigId }: { gigId: string }) {
     setDone(true); setSubmitting(false);
   }
 
-  if (!user) return <p className="text-slate-600">Please <a className="underline" href="/login">sign in</a> to apply.</p>;
+  if (!user)
+    return (
+      <p className="text-slate-600">
+        Please{' '}
+        <a className="underline" href={ROUTES.login}>
+          sign in
+        </a>{' '}
+        to apply.
+      </p>
+    );
   if (done) return <p className="text-green-700">Application submitted.</p>;
   return (
     <div className="space-y-2">
       {err && <p className="text-red-600">{err}</p>}
-      <button disabled={submitting} onClick={onApply} className="rounded bg-black text-white px-4 py-2">Apply</button>
+      <RequireTickets need={1}>
+        {(ok) => (
+          <button
+            disabled={!ok || submitting}
+            onClick={() =>
+              ok
+                ? onApply()
+                : alert('You need 1 ticket to apply. Check your balance or earn more.')
+            }
+            className="rounded bg-black text-white px-4 py-2"
+          >
+            Apply
+          </button>
+        )}
+      </RequireTickets>
     </div>
   );
 }

--- a/supabase/migrations/20250906093000_tickets_agreement_spend.sql
+++ b/supabase/migrations/20250906093000_tickets_agreement_spend.sql
@@ -1,0 +1,40 @@
+-- Atomic burn: 1 ticket from employer and seeker when an agreement is finalized
+-- Uses existing ticket_ledger and tickets_balance() helpers.
+
+create or replace function public.tickets_agreement_spend(
+  p_employer uuid,
+  p_seeker   uuid,
+  p_agreement uuid
+) returns table (employer_balance int, seeker_balance int)
+language plpgsql
+security definer
+as $$
+declare
+  bal_e int;
+  bal_s int;
+begin
+  -- pre-checks
+  select public.tickets_balance(p_employer) into bal_e;
+  select public.tickets_balance(p_seeker)   into bal_s;
+  if coalesce(bal_e,0) < 1 then
+    raise exception 'employer_insufficient_tickets';
+  end if;
+  if coalesce(bal_s,0) < 1 then
+    raise exception 'seeker_insufficient_tickets';
+  end if;
+
+  -- burn
+  insert into public.ticket_ledger (user_id, delta, source, ref_id)
+  values
+    (p_employer, -1, 'agreement', p_agreement),
+    (p_seeker,   -1, 'agreement', p_agreement);
+
+  employer_balance := public.tickets_balance(p_employer);
+  seeker_balance   := public.tickets_balance(p_seeker);
+  return;
+end
+$$;
+
+-- Allow server and authenticated calls; function is security definer.
+revoke all on function public.tickets_agreement_spend(uuid, uuid, uuid) from public;
+grant execute on function public.tickets_agreement_spend(uuid, uuid, uuid) to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- add tickets_agreement_spend RPC for atomic burn on agreement
- confirm agreement API calls new RPC
- header shows live ticket balance; guard apply/confirm actions when balance low

## Testing
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs`
- `npx playwright test -c playwright.smoke.ts` *(fails: Applications page renders empty state when no applications, Apply flow, Browse list, Landing hero CTAs route to app host, Landing → App CTAs and more)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb44122188327a8fae9f8c0930138