### PR TITLE
feat(agreements): cancel → refund 1 ticket to both parties; UI & RPC

### DIFF
--- a/.github/workflows/smoke-pr.yml
+++ b/.github/workflows/smoke-pr.yml
@@ -36,3 +36,9 @@ jobs:
           NODE_ENV: production
         run: |
           npx --yes start-server-and-test "next start -p 3000" "http://localhost:3000/api/healthz" "node -e 'process.exit(0)'"
+
+      - name: Smoke - confirm & cancel agreement (API quick sanity)
+        env:
+          NODE_ENV: production
+        run: |
+          npx --yes start-server-and-test "next start -p 3000" "http://localhost:3000/api/healthz" "node -e \"(async () => { const id='00000000-0000-0000-0000-000000000001'; const confirm = await fetch('http://localhost:3000/api/agreements/'+id+'/confirm', {method:'POST'}); console.log('confirm', confirm.status); const cancel = await fetch('http://localhost:3000/api/agreements/'+id+'/cancel', {method:'POST'}); console.log('cancel', cancel.status); process.exit(0); })().catch(()=>process.exit(0));\""

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -252,3 +252,8 @@
 - New `/api/agreements/[id]/confirm` calls the atomic burn and returns updated balances.
 - UI: balance chip in header + guards on Apply/Confirm when balance < 1.
 
+
+### 2025-09-06 (later)
+- Refund flow: `tickets_agreement_refund()` RPC with safety index to prevent duplicate refunds.
+- New API `POST /api/agreements/:id/cancel` updates status and refunds both parties.
+- UI: “Cancel agreement” button visible while status === agreed.

--- a/src/app/agreements/[id]/page.tsx
+++ b/src/app/agreements/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { CancelAgreementButton } from '@/components/CancelAgreementButton';
+import { ConfirmAgreementButton } from '@/components/ConfirmAgreementButton';
+import supabaseServer from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default async function AgreementPage({ params }: { params: { id: string } }) {
+  const supa = supabaseServer();
+  if (!supa) return <p>Server not configured</p>;
+
+  const { data: agreement } = await supa
+    .from('agreements')
+    .select('id, status')
+    .eq('id', params.id)
+    .single();
+
+  if (!agreement) return <p>Agreement not found</p>;
+
+  return (
+    <div className="p-4 space-y-4">
+      {agreement.status === 'pending' && (
+        <ConfirmAgreementButton agreementId={agreement.id} />
+      )}
+      {agreement.status === 'agreed' && <CancelAgreementButton id={agreement.id} />}
+    </div>
+  );
+}

--- a/src/app/api/agreements/[id]/cancel/route.ts
+++ b/src/app/api/agreements/[id]/cancel/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { getAdminClient } from '@/lib/supabase/admin';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const id = params.id;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const supa = createServerClient(url, anon, { cookies });
+
+  const { data: userRes } = await supa.auth.getUser();
+  const me = userRes?.user?.id;
+  if (!me) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+
+  // Load agreement; only participants (or admin via SRK path below) may cancel.
+  const { data: ag, error: agErr } = await supa
+    .from('agreements')
+    .select('id, employer_id, seeker_id, status')
+    .eq('id', id)
+    .single();
+
+  if (agErr || !ag) return NextResponse.json({ ok: false, error: 'agreement_not_found' }, { status: 404 });
+  if (me !== ag.employer_id && me !== ag.seeker_id) {
+    return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 });
+  }
+
+  // Only refund if previously agreed (burn happened).
+  if (ag.status !== 'agreed') {
+    return NextResponse.json({ ok: false, error: 'not_agreed' }, { status: 409 });
+  }
+
+  // Flip status first so UI reflects cancellation even if refund fails later.
+  const { error: upErr } = await supa.from('agreements').update({ status: 'cancelled' }).eq('id', ag.id);
+  if (upErr) return NextResponse.json({ ok: false, error: 'update_failed', detail: upErr.message }, { status: 500 });
+
+  // Admin RPC call for refund
+  const admin = getAdminClient();
+  if (!admin) return NextResponse.json({ ok: false, error: 'server_not_configured' }, { status: 503 });
+
+  const { data: refund, error: refundErr } = await admin.rpc('tickets_agreement_refund', {
+    p_employer: ag.employer_id,
+    p_seeker: ag.seeker_id,
+    p_agreement: ag.id,
+  });
+
+  if (refundErr) {
+    // Leave status as 'cancelled'; surface the error for support.
+    return NextResponse.json({ ok: false, error: 'refund_failed', detail: refundErr.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true, refund }, { status: 200 });
+}

--- a/src/components/CancelAgreementButton.tsx
+++ b/src/components/CancelAgreementButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useState } from 'react';
+
+async function cancelAgreement(id: string) {
+  const r = await fetch(`/api/agreements/${id}/cancel`, { method: 'POST' });
+  const j = await r.json();
+  if (!r.ok || !j?.ok) throw new Error(j?.error ?? 'cancel_failed');
+  return j;
+}
+
+export function CancelAgreementButton({ id }: { id: string }) {
+  const [busy, setBusy] = useState(false);
+  return (
+    <button
+      className="btn-outline"
+      disabled={busy}
+      onClick={async () => {
+        if (!confirm('Cancel this agreement? 1 ticket will be returned to each party.')) return;
+        setBusy(true);
+        try {
+          await cancelAgreement(id);
+          alert('Agreement cancelled. Tickets refunded to both parties.');
+          location.reload();
+        } catch (e: any) {
+          alert(e?.message ?? 'Unable to cancel');
+        } finally {
+          setBusy(false);
+        }
+      }}
+    >
+      Cancel agreement
+    </button>
+  );
+}

--- a/supabase/migrations/20250906121500_tickets_agreement_refund.sql
+++ b/supabase/migrations/20250906121500_tickets_agreement_refund.sql
@@ -1,0 +1,54 @@
+-- Refund 1 ticket to both parties if an agreement that previously burned tickets is cancelled.
+-- Idempotent: will error if no prior burn or if refund already recorded.
+
+create or replace function public.tickets_agreement_refund(
+  p_employer  uuid,
+  p_seeker    uuid,
+  p_agreement uuid
+) returns table (employer_balance int, seeker_balance int)
+language plpgsql
+security definer
+as $$
+declare
+  burns int;
+  refunds int;
+begin
+  -- Count existing burns and refunds tied to this agreement for both users.
+  select count(*) into burns
+  from public.ticket_ledger
+  where ref_id = p_agreement
+    and source = 'agreement'
+    and user_id in (p_employer, p_seeker);
+
+  select count(*) into refunds
+  from public.ticket_ledger
+  where ref_id = p_agreement
+    and source = 'agreement_refund'
+    and user_id in (p_employer, p_seeker);
+
+  if burns < 2 then
+    raise exception 'no_prior_burn_for_agreement';
+  end if;
+
+  if refunds >= 2 then
+    raise exception 'already_refunded';
+  end if;
+
+  -- Perform refund ( +1 both sides )
+  insert into public.ticket_ledger (user_id, delta, source, ref_id)
+  values
+    (p_employer, +1, 'agreement_refund', p_agreement),
+    (p_seeker,   +1, 'agreement_refund', p_agreement);
+
+  employer_balance := public.tickets_balance(p_employer);
+  seeker_balance   := public.tickets_balance(p_seeker);
+  return;
+end
+$$;
+
+-- Prevent accidental duplicate entries per (user, agreement, source)
+create unique index if not exists ux_ticket_ledger_user_agreement_source
+  on public.ticket_ledger (user_id, ref_id, source);
+
+revoke all on function public.tickets_agreement_refund(uuid, uuid, uuid) from public;
+grant execute on function public.tickets_agreement_refund(uuid, uuid, uuid) to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- add `tickets_agreement_refund` RPC and safety index
- expose `/api/agreements/:id/cancel` endpoint to flip status and refund both users
- add cancel button on agreement page and smoke test ping

## Testing
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs`
- `npx playwright test -c playwright.smoke.ts` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell; try `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb6ab2c788327879e7d2367563910