### PR TITLE
feat(CTA): canonicalize header/hero CTAs + add audit (desktop & mobile)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,5 +1,5 @@
 # Agents Contract
-**Version:** 2025-12-12
+**Version:** 2025-12-13
 
 ## Routes & CTAs (source of truth)
 - Use `ROUTES` constants for all navigational links (no raw string paths).
@@ -35,6 +35,7 @@
 - Applications IDs: `applications-list`, `application-row`, `applications-empty`.
 - The landing page must not render duplicate CTAs with identical accessible names.
 - Smoke helper `expectAuthAwareRedirect(page, dest, timeout)` accepts a string or RegExp and succeeds on `/login?next=` or the destination.
+  - Exported from `tests/smoke/_helpers.ts`; reuse in audit/e2e tests instead of reimplementing.
 
 ## CI guardrails
 - `scripts/no-legacy.sh` forbids raw legacy paths (e.g., `/find`, `/post-job`).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,6 +24,10 @@
 - CTAs include `data-cta` matching their test ID
 - Unauth flows: redirect to **/login?next=<dest>** counts as success
 - No white screens (page-level error/skeleton boundaries in gated flows)
+- Header CTA testids: `nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-menu-button`
+- Hero CTA testids: `hero-browse-jobs`, `hero-post-job`
+- Canonical routes: `/browse-jobs`, `/post-job`, `/applications`
+- Auth-aware: unauthenticated clicks on gated CTAs may redirect to `/login?next=<dest>`.
 
 **Observability**
 - Sentry enabled (frontend DSN)

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 import { useUser } from '@/hooks/useUser';
-import LinkApp from '@/components/LinkApp';
+import Link from 'next/link';
 import { NAV_ITEMS, ROUTES } from '@/lib/routes';
+import { CTA_TARGET, type CtaKey } from '@/lib/navMap';
 import dynamic from 'next/dynamic';
 import { isAdmin } from '@/lib/admin';
 
@@ -15,10 +16,7 @@ export default function AppHeader() {
 
   const links = NAV_ITEMS.filter(item => !(user && item.key === 'login')).map(
     item => ({
-      href:
-        !user && item.auth === 'auth-aware'
-          ? `${ROUTES.login}?next=${encodeURIComponent(item.to)}`
-          : item.to,
+      href: (CTA_TARGET as Record<CtaKey, string>)[item.idDesktop as CtaKey] ?? item.to,
       label: item.label,
       testId: item.idDesktop,
       mobileId: item.idMobile,
@@ -45,17 +43,17 @@ export default function AppHeader() {
     <header data-testid="app-header" className="border-b bg-white/60 backdrop-blur">
       <div className="mx-auto max-w-5xl flex items-center justify-between p-4">
         <div className="flex items-center gap-4">
-          <LinkApp
-            href={ROUTES.browseJobs}
+          <Link
+            href={CTA_TARGET['nav-browse-jobs']}
             className="font-semibold"
             data-cta="nav-browse-jobs"
           >
             QuickGig
-          </LinkApp>
+          </Link>
           <nav className="hidden md:flex items-center gap-4">
             {links.map(link =>
               link.href ? (
-                <LinkApp
+                <Link
                   key={link.testId}
                   data-testid={link.testId}
                   data-cta={link.testId}
@@ -63,7 +61,7 @@ export default function AppHeader() {
                   prefetch={false}
                 >
                   {link.label}
-                </LinkApp>
+                </Link>
               ) : (
                 <button
                   key={link.testId}
@@ -89,12 +87,12 @@ export default function AppHeader() {
         </div>
         <div className="flex items-center gap-3">
           <TicketBalanceChip />
-          <LinkApp
+          <Link
             href={`${ROUTES.billingTickets}?next=${encodeURIComponent(ROUTES.postJob)}`}
             className="border rounded-xl px-3 py-1 text-sm"
           >
             Buy ticket
-          </LinkApp>
+          </Link>
         </div>
       </div>
       {open ? (
@@ -108,7 +106,7 @@ export default function AppHeader() {
           <div className="flex flex-col gap-2 p-4">
             {links.map(link =>
               link.href ? (
-                <LinkApp
+                <Link
                   key={link.mobileId}
                   data-testid={link.mobileId}
                   data-cta={link.mobileId}
@@ -118,7 +116,7 @@ export default function AppHeader() {
                   className="link"
                 >
                   {link.label}
-                </LinkApp>
+                </Link>
               ) : (
                 <button
                   key={link.mobileId}

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -1,36 +1,40 @@
-import LinkApp from '@/components/LinkApp';
+import Link from 'next/link';
 import { ROUTES } from '@/lib/routes';
+import { CTA_TARGET } from '@/lib/navMap';
 
 export default function LandingHeader() {
   return (
     <nav className="...">
-      <LinkApp
+      <Link
         data-testid="nav-browse-jobs"
         data-cta="nav-browse-jobs"
-        href={ROUTES.browseJobs}
+        href={CTA_TARGET['nav-browse-jobs']}
         className="hover:underline"
       >
         Browse jobs
-      </LinkApp>
-      <LinkApp
+      </Link>
+      <Link
         data-testid="nav-post-job"
         data-cta="nav-post-job"
-        href={`${ROUTES.login}?next=${encodeURIComponent(ROUTES.postJob)}`}
+        href={CTA_TARGET['nav-post-job']}
         className="btn btn-primary"
       >
         Post a job
-      </LinkApp>
-      <LinkApp
+      </Link>
+      <Link
         data-testid="nav-my-applications"
         data-cta="nav-my-applications"
-        href={`${ROUTES.login}?next=${encodeURIComponent(ROUTES.applications)}`}
+        href={CTA_TARGET['nav-my-applications']}
         className="..."
       >
         My Applications
-      </LinkApp>
-      <LinkApp data-testid="nav-login" data-cta="nav-login" href={ROUTES.login} className="...">
+      </Link>
+      <Link data-testid="nav-login" data-cta="nav-login" href={ROUTES.login} className="...">
         Sign in
-      </LinkApp>
+      </Link>
+      <button type="button" data-testid="nav-menu-button" aria-label="Open menu" className="md:hidden">
+        Menu
+      </button>
     </nav>
   );
 }

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,24 +1,26 @@
-import LinkApp from '@/components/LinkApp';
-import { ROUTES } from '@/lib/routes';
+import Link from 'next/link';
+import { CTA_TARGET } from '@/lib/navMap';
 
 export default function LandingHero() {
   return (
     <section className="...">
       <div className="flex gap-3">
-        <LinkApp
-          href={ROUTES.browseJobs}
+        <Link
+          href={CTA_TARGET['hero-browse-jobs']}
           data-testid="hero-browse-jobs"
+          data-cta="hero-browse-jobs"
           className="px-4 py-2 rounded-md bg-gray-100"
         >
           Browse jobs
-        </LinkApp>
-        <LinkApp
-          href={ROUTES.postJob}
+        </Link>
+        <Link
+          href={CTA_TARGET['hero-post-job']}
           data-testid="hero-post-job"
+          data-cta="hero-post-job"
           className="px-4 py-2 rounded-md bg-blue-600 text-white"
         >
           Post a job
-        </LinkApp>
+        </Link>
       </div>
     </section>
   );

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import LinkApp from '@/components/LinkApp';
-import { ROUTES } from '@/lib/routes';
+import Link from 'next/link';
+import { CTA_TARGET } from '@/lib/navMap';
 
 type Props = {
   findClassName?: string;
@@ -18,18 +18,24 @@ export default function LandingCTAs({
   return (
       <div className="flex gap-3">
         {showFind && (
-          <LinkApp
+          <Link
             data-testid="hero-browse-jobs"
-            href={ROUTES.browseJobs}
+            data-cta="hero-browse-jobs"
+            href={CTA_TARGET['hero-browse-jobs']}
             className={findClassName}
           >
             Browse jobs
-          </LinkApp>
+          </Link>
         )}
         {showPost && (
-          <LinkApp data-testid="hero-post-job" href={ROUTES.postJob} className={postClassName}>
+          <Link
+            data-testid="hero-post-job"
+            data-cta="hero-post-job"
+            href={CTA_TARGET['hero-post-job']}
+            className={postClassName}
+          >
             Post a job
-          </LinkApp>
+          </Link>
         )}
       </div>
     );

--- a/src/lib/navMap.ts
+++ b/src/lib/navMap.ts
@@ -1,0 +1,16 @@
+import { ROUTES } from '@/lib/routes';
+
+export type CtaKey =
+  | 'nav-browse-jobs'
+  | 'hero-browse-jobs'
+  | 'nav-post-job'
+  | 'hero-post-job'
+  | 'nav-my-applications';
+
+export const CTA_TARGET: Record<CtaKey, string> = {
+  'nav-browse-jobs': ROUTES.browseJobs,
+  'hero-browse-jobs': ROUTES.browseJobs,
+  'nav-post-job': ROUTES.postJob,
+  'hero-post-job': ROUTES.postJob,
+  'nav-my-applications': ROUTES.applications,
+};

--- a/tests/audit/cta-links.spec.ts
+++ b/tests/audit/cta-links.spec.ts
@@ -1,17 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-// Inline minimal auth-aware checker to avoid coupling to smoke helpers
-async function expectAuthAwareRedirect(page: any, dest: string | RegExp, timeout = 8000) {
-  const enc = typeof dest === 'string' ? encodeURIComponent(dest) : '__regex__';
-  const loginRe = new RegExp(`/login\\?next=${enc}$`);
-  const destRe = typeof dest === 'string'
-    ? new RegExp(`${dest.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')}$`)
-    : dest;
-
-  await expect
-    .poll(async () => page.url(), { timeout })
-    .toMatch(new RegExp(`${loginRe.source}|${destRe.source}`));
-}
+import { expectAuthAwareRedirect } from '../smoke/_helpers';
 
 const CTAS = [
   { id: 'nav-browse-jobs', dest: '/browse-jobs', gated: false },

--- a/tests/audit/cta-links.spec.ts
+++ b/tests/audit/cta-links.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// Inline minimal auth-aware checker to avoid coupling to smoke helpers
+async function expectAuthAwareRedirect(page: any, dest: string | RegExp, timeout = 8000) {
+  const enc = typeof dest === 'string' ? encodeURIComponent(dest) : '__regex__';
+  const loginRe = new RegExp(`/login\\?next=${enc}$`);
+  const destRe = typeof dest === 'string'
+    ? new RegExp(`${dest.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')}$`)
+    : dest;
+
+  await expect
+    .poll(async () => page.url(), { timeout })
+    .toMatch(new RegExp(`${loginRe.source}|${destRe.source}`));
+}
+
+const CTAS = [
+  { id: 'nav-browse-jobs', dest: '/browse-jobs', gated: false },
+  { id: 'nav-post-job', dest: /\/post-job$|\/gigs\/create\/?$/i, gated: true },
+  { id: 'nav-my-applications', dest: '/applications', gated: true },
+  { id: 'hero-browse-jobs', dest: '/browse-jobs', gated: false },
+  { id: 'hero-post-job', dest: /\/post-job$|\/gigs\/create\/?$/i, gated: true },
+] as const;
+
+async function openMobileMenuIfHidden(page: any) {
+  const btn = page.getByTestId('nav-menu-button');
+  if (await btn.count()) {
+    const anyNav = page.getByTestId('nav-browse-jobs');
+    if (!(await anyNav.isVisible().catch(() => false))) {
+      await btn.click();
+      await page.waitForTimeout(200);
+    }
+  }
+}
+
+for (const vp of [{ w: 1280, h: 800 }, { w: 390, h: 844 }]) {
+  test.describe(`CTA audit @ ${vp.w}x${vp.h}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize({ width: vp.w, height: vp.h });
+      await page.goto('/');
+      await openMobileMenuIfHidden(page);
+    });
+
+    for (const cta of CTAS) {
+      test(`${cta.id} routes to ${cta.gated ? 'dest or /login?next' : 'dest'}`, async ({ page }) => {
+        const el = page.getByTestId(cta.id).first();
+        await expect(el).toBeVisible();
+        await Promise.all([page.waitForLoadState('domcontentloaded'), el.click()]);
+        if (cta.gated) {
+          await expectAuthAwareRedirect(page, cta.dest);
+        } else {
+          const destRe = typeof cta.dest === 'string'
+            ? new RegExp(`${cta.dest.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')}$`)
+            : cta.dest;
+          await expect.poll(async () => page.url()).toMatch(destRe);
+        }
+      });
+    }
+  });
+}

--- a/tests/audit/href-canonical.spec.ts
+++ b/tests/audit/href-canonical.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const HREFS: Record<string, string> = {
+  'nav-browse-jobs': '/browse-jobs',
+  'hero-browse-jobs': '/browse-jobs',
+  'nav-post-job': '/post-job',
+  'hero-post-job': '/post-job',
+  'nav-my-applications': '/applications',
+};
+
+test('header/hero CTAs use canonical hrefs', async ({ page }) => {
+  await page.goto('/');
+  for (const [id, href] of Object.entries(HREFS)) {
+    const a = page.getByTestId(id);
+    await expect(a).toHaveAttribute('href', href);
+  }
+});


### PR DESCRIPTION
## Summary
- centralize canonical CTA targets
- align header and hero CTAs with stable test IDs and hrefs
- audit header/hero CTAs on desktop and mobile

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Module '@/types/db' has no exported member 'Insert')*
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs` *(fails: connect ECONNREFUSED ::1:3000)*
- `PLAYWRIGHT_WEBSERVER_CMD="npm run dev" npx playwright test --config=tests/audit tests/audit/cta-links.spec.ts` *(fails: Looks like Playwright Test or Playwright was just installed or updated. Please run the following command to download new browsers: npx playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5acd11c483279609e10c71e9d9d6