### PR TITLE
feat: add analytics tracking for CTAs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,4 +1,7 @@
-<!-- AGENT CONTRACT v2025-12-12 -->
+<!-- AGENT CONTRACT v2025-12-13 -->
+
+## 2025-09-07
+- Header CTAs canonicalized; friendly auth errors; non-blank 404/500; link-audit script.
 
 ## 2025-09-06
 - Auth-aware redirects in CI: unauthenticated CTA clicks redirect to `/login?next=<path>`.

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -1,34 +1,40 @@
+"use client";
+
 import Link from 'next/link';
 import { ROUTES } from '@/lib/routes';
 import { CTA_TARGET } from '@/lib/navMap';
+import { track } from '@/lib/analytics';
 
 export default function LandingHeader() {
   return (
     <nav className="...">
-      <Link
-        data-testid="nav-browse-jobs"
-        data-cta="nav-browse-jobs"
-        href={CTA_TARGET['nav-browse-jobs']}
-        className="hover:underline"
-      >
-        Browse jobs
-      </Link>
-      <Link
-        data-testid="nav-post-job"
-        data-cta="nav-post-job"
-        href={CTA_TARGET['nav-post-job']}
-        className="btn btn-primary"
-      >
-        Post a job
-      </Link>
-      <Link
-        data-testid="nav-my-applications"
-        data-cta="nav-my-applications"
-        href={CTA_TARGET['nav-my-applications']}
-        className="..."
-      >
-        My Applications
-      </Link>
+        <Link
+          data-testid="nav-browse-jobs"
+          data-cta="nav-browse-jobs"
+          href={CTA_TARGET['nav-browse-jobs']}
+          className="hover:underline"
+          onClick={() => track('cta_click', { cta: 'nav-browse-jobs' })}
+        >
+          Browse jobs
+        </Link>
+        <Link
+          data-testid="nav-post-job"
+          data-cta="nav-post-job"
+          href={CTA_TARGET['nav-post-job']}
+          className="btn btn-primary"
+          onClick={() => track('cta_click', { cta: 'nav-post-job' })}
+        >
+          Post a job
+        </Link>
+        <Link
+          data-testid="nav-my-applications"
+          data-cta="nav-my-applications"
+          href={CTA_TARGET['nav-my-applications']}
+          className="..."
+          onClick={() => track('cta_click', { cta: 'nav-my-applications' })}
+        >
+          My Applications
+        </Link>
       <Link data-testid="nav-login" data-cta="nav-login" href={ROUTES.login} className="...">
         Sign in
       </Link>

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from 'next/link';
 import { CTA_TARGET } from '@/lib/navMap';
+import { track } from '@/lib/analytics';
 
 export default function LandingHero() {
   return (
@@ -10,6 +13,7 @@ export default function LandingHero() {
           data-testid="hero-browse-jobs"
           data-cta="hero-browse-jobs"
           className="px-4 py-2 rounded-md bg-gray-100"
+          onClick={() => track('cta_click', { cta: 'hero-browse-jobs' })}
         >
           Browse jobs
         </Link>
@@ -18,6 +22,7 @@ export default function LandingHero() {
           data-testid="hero-post-job"
           data-cta="hero-post-job"
           className="px-4 py-2 rounded-md bg-blue-600 text-white"
+          onClick={() => track('cta_click', { cta: 'hero-post-job' })}
         >
           Post a job
         </Link>

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import React from 'react';
 import Link from 'next/link';
 import { CTA_TARGET } from '@/lib/navMap';
+import { track } from '@/lib/analytics';
 
 type Props = {
   findClassName?: string;
@@ -17,26 +20,28 @@ export default function LandingCTAs({
 }: Props) {
   return (
       <div className="flex gap-3">
-        {showFind && (
-          <Link
-            data-testid="hero-browse-jobs"
-            data-cta="hero-browse-jobs"
-            href={CTA_TARGET['hero-browse-jobs']}
-            className={findClassName}
-          >
-            Browse jobs
-          </Link>
-        )}
-        {showPost && (
-          <Link
-            data-testid="hero-post-job"
-            data-cta="hero-post-job"
-            href={CTA_TARGET['hero-post-job']}
-            className={postClassName}
-          >
-            Post a job
-          </Link>
-        )}
+          {showFind && (
+            <Link
+              data-testid="hero-browse-jobs"
+              data-cta="hero-browse-jobs"
+              href={CTA_TARGET['hero-browse-jobs']}
+              className={findClassName}
+              onClick={() => track('cta_click', { cta: 'hero-browse-jobs' })}
+            >
+              Browse jobs
+            </Link>
+          )}
+          {showPost && (
+            <Link
+              data-testid="hero-post-job"
+              data-cta="hero-post-job"
+              href={CTA_TARGET['hero-post-job']}
+              className={postClassName}
+              onClick={() => track('cta_click', { cta: 'hero-post-job' })}
+            >
+              Post a job
+            </Link>
+          )}
       </div>
     );
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,8 @@
+export function track(event: string, props: Record<string, any> = {}) {
+  // GA4
+  // @ts-ignore
+  if (typeof window !== 'undefined' && window.gtag) window.gtag('event', event, props);
+  // Meta Pixel
+  // @ts-ignore
+  if (typeof window !== 'undefined' && window.fbq) window.fbq('trackCustom', event, props);
+}


### PR DESCRIPTION
## Summary
- track CTA clicks via new analytics helper that forwards to GA4 or Meta Pixel when available
- wire landing header and hero CTAs to emit `cta_click` events
- update agent contract to note canonical CTAs and friendly pages

## Testing
- `npm test`
- `npm run lint`
- `npm run no-legacy`
- `node scripts/check-cta-links.mjs` *(fails: fetch failed (ECONNREFUSED))*
- `npx playwright test -c playwright.smoke.ts` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a3dc09483278e7b3a1eefc2fbe7