### PR TITLE
dev: add local CTA/link audit runner + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ build/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 # local env files
 .env*

--- a/docs/dev-local-audits.md
+++ b/docs/dev-local-audits.md
@@ -1,0 +1,26 @@
+# Local CTA/Link Audits
+
+Ensure you are in the repository root and using the Node version from `.nvmrc`:
+
+```bash
+nvm use
+```
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+Run the audit:
+
+```bash
+npm run audit:links --silent
+# or explicitly:
+BASE_URLS="https://quickgig.ph,https://app.quickgig.ph,https://preview-quickgig.vercel.app,https://preview-app.vercel.app" \
+node scripts/check-cta-links.mjs
+# or with wrapper:
+npm run audit:links:urls -- "https://quickgig.ph,https://app.quickgig.ph,https://preview-quickgig.vercel.app,https://preview-app.vercel.app"
+```
+
+Exit codes: `0` means all links returned 2xx responses, `1` indicates at least one 4xx/5xx response. A summary of non-2xx results prints to stdout.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "e2e:prod": "BASE_URL=https://app.quickgig.ph npx playwright test",
     "test": "echo \"E2E disabled while product is WIP\" && exit 0",
     "no-legacy": "bash scripts/no-legacy.sh",
-    "report:status": "tsx scripts/generate-status.ts"
+    "report:status": "tsx scripts/generate-status.ts",
+    "audit:links": "node --unhandled-rejections=strict scripts/check-cta-links.mjs",
+    "audit:links:urls": "bash tools/dev/audit-links.sh",
+    "smoke:local": "start-server-and-test \"next start -p 3000\" http://localhost:3000 \"npx playwright test -c playwright.smoke.ts\""
   },
   "dependencies": {
     "@jobuntux/psgc": "^0.2.1",

--- a/scripts/check-cta-links.mjs
+++ b/scripts/check-cta-links.mjs
@@ -1,33 +1,71 @@
-const base = (process.env.CTA_BASE || 'http://localhost:3000').replace(/\/$/, '');
+const DEFAULT_BASES = [
+  'https://quickgig.ph',
+  'https://app.quickgig.ph',
+  'https://preview-quickgig.vercel.app',
+  'https://preview-app.vercel.app',
+];
+
 const pages = ['/browse-jobs'];
-
-const results = [];
-
 const CTA_RE = /<a[^>]*data-cta="([^"]+)"[^>]*href="([^"]+)"/g;
 
-for (const pagePath of pages) {
-  const res = await fetch(base + pagePath);
-  const html = await res.text();
-  for (const match of html.matchAll(CTA_RE)) {
-    const id = match[1];
-    const href = match[2];
-    const url = base + href;
-    const resp = await fetch(url, { redirect: 'manual' });
-    const status = resp.status;
-    if (status === 200) {
-      results.push([id, href, status, 'OK']);
-      continue;
-    }
-    if (status === 302) {
-      const loc = resp.headers.get('location') || '';
-      if (/^\/login\?next=/.test(loc)) {
-        results.push([id, href, status, 'OK']);
-        continue;
+const bases = (process.env.BASE_URLS || DEFAULT_BASES.join(','))
+  .split(',')
+  .map((u) => u.trim().replace(/\/$/, ''))
+  .filter(Boolean);
+
+const links = new Set();
+
+for (const base of bases) {
+  for (const page of pages) {
+    try {
+      const res = await fetch(base + page);
+      const html = await res.text();
+      for (const match of html.matchAll(CTA_RE)) {
+        const href = match[2];
+        const url = new URL(href, base).href;
+        links.add(url);
       }
+    } catch (err) {
+      console.error(`Failed to fetch ${base + page}:`, err);
+      links.add(base + page);
     }
-    results.push([id, href, status, 'FAIL']);
   }
 }
 
-console.table(results);
-if (results.some(r => r[3] !== 'OK')) process.exit(1);
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+
+async function check(url) {
+  try {
+    let resp = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    if (resp.status === 405 || resp.status === 403) {
+      resp = await fetch(url, { method: 'GET', redirect: 'follow' });
+    }
+    return resp.status;
+  } catch (err) {
+    return 0;
+  }
+}
+
+const results = [];
+
+for (const url of links) {
+  const status = await check(url);
+  results.push({ url, status });
+}
+
+const bad = results.filter((r) => r.status < 200 || r.status >= 300);
+
+if (bad.length) {
+  console.log(red('Non-2xx responses:'));
+  for (const r of bad) {
+    const color = r.status >= 400 || r.status === 0 ? red : yellow;
+    console.log(`${color(r.status)} ${r.url}`);
+  }
+} else {
+  console.log(green('All links returned 2xx responses'));
+}
+
+process.exit(bad.some((r) => r.status >= 400 || r.status === 0) ? 1 : 0);
+

--- a/tools/dev/audit-links.sh
+++ b/tools/dev/audit-links.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <comma-separated-urls>"
+  echo "Example: $0 https://quickgig.ph,https://app.quickgig.ph,https://preview-quickgig.vercel.app,https://preview-app.vercel.app"
+  exit 2
+fi
+BASE_URLS="$1" \
+node --unhandled-rejections=strict scripts/check-cta-links.mjs


### PR DESCRIPTION
## Summary
- add npm scripts for local link audits and smoke tests
- wrap CTA/link audit with helper script and docs
- harden link audit script and ignore log files

## Testing
- `nvm use && npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stripe)*
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm run no-legacy`
- `npm run audit:links:urls -- "https://quickgig.ph,https://app.quickgig.ph"` *(non-2xx responses; exits with failure)*
- `npm run smoke:local` *(fails: start-server-and-test: not found)*

## How to run
```bash
nvm use
npm ci
npm run audit:links --silent
# or explicitly:
BASE_URLS="https://quickgig.ph,https://app.quickgig.ph,https://preview-quickgig.vercel.app,https://preview-app.vercel.app" \
node scripts/check-cta-links.mjs
# or with wrapper:
npm run audit:links:urls -- "https://quickgig.ph,https://app.quickgig.ph,https://preview-quickgig.vercel.app,https://preview-app.vercel.app"
```

------
https://chatgpt.com/codex/tasks/task_e_68be22b93e248327b90bbd96dc75b567