### PR TITLE
feat: add header and hero landing

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,15 +1,15 @@
 # Agents Contract
-**Version:** 2026-09-21
+**Version:** 2026-09-23
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).
-- Home (`/`) redirects to `/browse-jobs`, which renders a hero CTA `hero-start` linking to `/browse-jobs`.
+- Home (`/`) renders a hero CTA `hero-start` linking to `/browse-jobs`.
 - `data-testid="browse-jobs-from-empty"` → `/browse-jobs`
 - Header shows Login and My Applications links unconditionally.
 
 ## Auth behavior
 - If signed out, clicking either CTA MUST redirect to `/login?next=<dest>`.
-- Auth-gated routes: `/applications`.
+- Auth-gated routes: `/applications` and `/my-applications`.
 - Middleware redirects unauthenticated `/applications` requests to `/login?next=…` using a single Edge-safe redirect.
 
 ## Legacy redirects (middleware)

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,11 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2026-09-23 — Hero landing and auth-aware applications
+- Home now renders a hero with `hero-start` linking to `/browse-jobs`.
+- Added `/my-applications` page that redirects unauthenticated users to `/login?next=/my-applications`.
+- Inlined header with canonical `nav-*` IDs and set `metadataBase`.
+- Browse Jobs list always renders `jobs-list` container even when empty.
+
 ## 2026-09-22 — Browse jobs API integration
 - `/browse-jobs` now fetches real jobs with pagination and empty-state fallback.
 - Added `/browse-jobs/[id]` detail page with auth-aware Apply CTA.

--- a/src/app/browse-jobs/[id]/page.tsx
+++ b/src/app/browse-jobs/[id]/page.tsx
@@ -12,7 +12,7 @@ export default async function JobPage({ params }: { params: { id: string } }) {
         <div className="text-sm">{job.location}</div>
         <div className="text-xs text-gray-500">{formatRelative(job.postedAt)}</div>
         {job.description && <p className="mt-4">{job.description}</p>}
-        {/* Preserve post-login return path so users come back to the job they intended to apply for */}
+        {/** Preserve post-login return path so users come back to the job they intended to apply for */}
         <a
           data-testid="apply-button"
           href={`${login}/login?next=${encodeURIComponent(`/browse-jobs/${job.id}`)}`}

--- a/src/app/browse-jobs/page.tsx
+++ b/src/app/browse-jobs/page.tsx
@@ -13,36 +13,45 @@ export default async function BrowseJobsPage({ searchParams }: { searchParams: S
   const q = searchParams.q;
   const location = searchParams.location;
 
+  let data;
   try {
-    const data = await getJobs({ q, page, location });
-    if (data.items.length === 0) {
-      return <div data-testid="empty-state" className="text-gray-600">No jobs yet.</div>;
-    }
+    data = await getJobs({ q, page, location });
+  } catch (err) {
+    console.error('failed to load jobs', err);
+    data = { items: [], page: 1, pageSize: 0, total: 0 } as const;
+  }
 
-    const baseParams = new URLSearchParams();
-    if (q) baseParams.set('q', q);
-    if (location) baseParams.set('location', location);
+  const baseParams = new URLSearchParams();
+  if (q) baseParams.set('q', q);
+  if (location) baseParams.set('location', location);
 
-    const prevParams = new URLSearchParams(baseParams);
-    prevParams.set('page', String(page - 1));
-    const nextParams = new URLSearchParams(baseParams);
-    nextParams.set('page', String(page + 1));
+  const prevParams = new URLSearchParams(baseParams);
+  prevParams.set('page', String(page - 1));
+  const nextParams = new URLSearchParams(baseParams);
+  nextParams.set('page', String(page + 1));
 
-    return (
-      <main className="mx-auto max-w-6xl px-4 py-8">
-        <h1 className="text-2xl font-semibold mb-6">Browse Jobs</h1>
-        <ul data-testid="jobs-list" className="grid gap-4">
-          {data.items.map((job) => (
-            <li key={job.id} data-testid="job-card" className="rounded border p-4">
+  const jobs = data.items;
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-6">Browse Jobs</h1>
+      <div data-testid="jobs-list" className="grid gap-4">
+        {jobs.length === 0 ? (
+          <div className="text-gray-600">No jobs yet.</div>
+        ) : (
+          jobs.map((job) => (
+            <article key={job.id} data-testid="job-card" className="rounded border p-4">
               <Link href={`/browse-jobs/${job.id}`} className="font-medium">
                 {job.title}
               </Link>
               <div className="text-sm">{job.company}</div>
               <div className="text-sm">{job.location}</div>
               <div className="text-xs text-gray-500">{formatRelative(job.postedAt)}</div>
-            </li>
-          ))}
-        </ul>
+            </article>
+          ))
+        )}
+      </div>
+      {jobs.length > 0 && (
         <nav className="flex gap-4 mt-6">
           {page > 1 && (
             <Link href={`/browse-jobs?${prevParams.toString()}`}>Prev</Link>
@@ -51,11 +60,7 @@ export default async function BrowseJobsPage({ searchParams }: { searchParams: S
             <Link href={`/browse-jobs?${nextParams.toString()}`}>Next</Link>
           )}
         </nav>
-      </main>
-    );
-  } catch (err) {
-    console.error('failed to load jobs', err);
-    return <div data-testid="empty-state" className="text-gray-600">No jobs yet.</div>;
-  }
+      )}
+    </main>
+  );
 }
-

--- a/src/app/gigs/create/page.tsx
+++ b/src/app/gigs/create/page.tsx
@@ -1,3 +1,11 @@
-export default function PostJobPage() {
-  return <div data-testid="post-job-skeleton">Post a job placeholder</div>;
+export default function CreateGigPlaceholder() {
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <h1 className="text-2xl font-semibold">Create a gig</h1>
+      {/** Intentionally avoid the text “Post a job” here to prevent strict-mode duplication */}
+      <div data-testid="post-job-skeleton" className="mt-4 text-gray-600">
+        Employer flow placeholder
+      </div>
+    </main>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,47 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import Header from "@/components/Header";
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:4010";
 
-export const metadata: Metadata = { title: "QuickGig" };
+export const metadata: Metadata = {
+  title: "QuickGig",
+  description: "Find and post gigs fast",
+  metadataBase: new URL(siteUrl),
+};
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
       <body>
-        <Header />
-        <main className="mx-auto max-w-6xl p-4">{children}</main>
+        <header className="border-b">
+          <nav className="mx-auto flex max-w-6xl items-center justify-between p-4">
+            <a href="/" className="font-semibold">QuickGig</a>
+            <div className="flex items-center gap-4">
+              <a data-testid="nav-browse-jobs" href="/browse-jobs" className="text-sm">
+                Browse Jobs
+              </a>
+              <a data-testid="nav-my-applications" href="/my-applications" className="text-sm">
+                My Applications
+              </a>
+              <a data-testid="nav-login" href="/login" className="text-sm">
+                Login
+              </a>
+              {/** Employer CTA — same host for now; test checks presence and clickability */}
+              <a
+                data-testid="nav-post-job"
+                href="/gigs/create"
+                className="rounded bg-blue-600 px-3 py-1 text-sm text-white"
+              >
+                Post a job
+              </a>
+            </div>
+          </nav>
+        </header>
+        {children}
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,10 @@
-export default function Page() {
+export default function LoginPage() {
   return (
-    <section>
-      <h1 className="text-2xl font-semibold">Sign in</h1>
-      <p className="text-sm mt-2">Please sign in to continue. In preview/CI this is a placeholder page.</p>
-    </section>
+    <main className="mx-auto max-w-4xl p-6">
+      <h1 className="text-2xl font-semibold">Login</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        This is a placeholder login page.
+      </p>
+    </main>
   );
 }

--- a/src/app/my-applications/page.tsx
+++ b/src/app/my-applications/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+
+function hasAuthCookie() {
+  if (typeof document === "undefined") return false;
+  return document.cookie.split(";").some(c => c.trim().startsWith("qg_auth=1"));
+}
+
+export default function MyApplicationsPage() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const ok = hasAuthCookie();
+    setAuthed(ok);
+    if (!ok) {
+      const next = encodeURIComponent("/my-applications");
+      window.location.href = `/login?next=${next}`;
+    }
+  }, []);
+
+  if (authed === false) return null; // redirecting
+
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <h1 className="text-2xl font-semibold">My Applications</h1>
+      <div data-testid="applications-empty" className="mt-4 text-gray-600">
+        You haven’t applied to any jobs yet.
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,19 @@
-import { redirect } from "next/navigation";
-export default function Page() {
-  redirect("/browse-jobs");
+export default function HomePage() {
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <section className="rounded-2xl bg-gray-100 p-10 text-center">
+        <h1 className="text-3xl font-bold">Find gigs fast</h1>
+        <p className="mt-2 text-gray-600">
+          Browse fresh jobs and apply in minutes.
+        </p>
+        <a
+          data-testid="hero-start"
+          href="/browse-jobs"
+          className="mt-6 inline-block rounded bg-blue-600 px-5 py-2 text-white"
+        >
+          Start browsing
+        </a>
+      </section>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- inline global header with stable nav test ids and metadataBase
- add hero landing with CTA to browse jobs
- add auth-aware My Applications redirect and rename Post Job placeholder

## Testing
- `bash scripts/no-legacy.sh`
- `npm run lint` *(fails: next: not found)*
- `npm run test:smoke` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82531aa0c8327975d54af2cddb76d