### PR TITLE
feat: add host-aware navigation and job apply links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 NEXT_PUBLIC_SITE_URL=https://app.quickgig.ph
 # NEXT_PUBLIC_APP_URL=https://app.quickgig.ph
 NEXT_PUBLIC_LANDING_URL=https://quickgig.ph
-# Base URLs for API and app host
-NEXT_PUBLIC_API_BASE_URL=
+# Public site API (used by /browse-jobs). When unset, UI fails soft and renders an empty state.
+NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+
+# App Host (opens authenticated areas like /applications or /gigs/create).
+# If unset, links fall back to relative paths (good for local dev/CI).
+NEXT_PUBLIC_APP_HOST_BASE_URL=https://app.example.com
 NEXT_PUBLIC_APP_HOST=
 # Used to build absolute URLs on the server (optional if headers/VERCEL_URL works)
 NEXT_PUBLIC_APP_ORIGIN= # defaults to https://app.quickgig.ph

--- a/agents.md
+++ b/agents.md
@@ -1,5 +1,5 @@
 # Agents Contract
-**Version:** 2026-09-24
+**Version:** 2026-09-25
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).

--- a/src/app/browse-jobs/[id]/page.tsx
+++ b/src/app/browse-jobs/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { hostAware } from '@/lib/hostAware';
 
 type JobDetail = {
@@ -29,16 +30,20 @@ export default async function JobDetailPage({ params }: { params: { id: string }
     return (
       <main className="container mx-auto px-4 py-8">
         <h1 className="text-2xl font-semibold mb-2">Job not found</h1>
-        <a className="underline" href="/browse-jobs">Back to jobs</a>
+        <Link className="underline" href="/browse-jobs">
+          Back to jobs
+        </Link>
       </main>
     );
   }
 
-  // Build an auth-aware Apply link that preserves the return path after login
+  // Build an auth-aware Apply link:
+  // • If the job has a direct applyUrl, target it (respect absolute/relative via hostAware).
+  // • Otherwise, fall back to /login?next=<returnTo> on the configured APP host.
   const returnTo = `/browse-jobs/${encodeURIComponent(String(job.id))}`;
   const applyHref = job.applyUrl
     ? hostAware(job.applyUrl)
-    : `/login?next=${encodeURIComponent(returnTo)}`;
+    : hostAware(`/login?next=${encodeURIComponent(returnTo)}`);
 
   return (
     <main className="container mx-auto px-4 py-8">

--- a/src/app/browse-jobs/[id]/page.tsx
+++ b/src/app/browse-jobs/[id]/page.tsx
@@ -1,29 +1,58 @@
-import { getJob } from '@/lib/api';
-import { formatRelative } from '@/libs/date';
+import { hostAware } from '@/lib/hostAware';
 
-export default async function JobPage({ params }: { params: { id: string } }) {
+type JobDetail = {
+  id: string | number;
+  title: string;
+  company?: string;
+  location?: string;
+  description?: string;
+  applyUrl?: string;
+};
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function getJob(id: string): Promise<JobDetail | null> {
+  if (!API_BASE) return { id, title: 'Job', description: 'Details unavailable.' };
   try {
-    const job = await getJob(params.id);
-    const login = process.env.NEXT_PUBLIC_APP_HOST || '';
+    const res = await fetch(`${API_BASE}/jobs/${encodeURIComponent(id)}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error(String(res.status));
+    const data = await res.json();
+    return data || null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = await getJob(params.id);
+  if (!job) {
     return (
-      <main className="mx-auto max-w-3xl px-4 py-8">
-        <h1 className="text-2xl font-semibold mb-2">{job.title}</h1>
-        <div className="text-sm">{job.company}</div>
-        <div className="text-sm">{job.location}</div>
-        <div className="text-xs text-gray-500">{formatRelative(job.postedAt)}</div>
-        {job.description && <p className="mt-4">{job.description}</p>}
-        {/** Preserve post-login return path so users come back to the job they intended to apply for */}
-        <a
-          data-testid="apply-button"
-          href={`${login}/login?next=${encodeURIComponent(`/browse-jobs/${job.id}`)}`}
-          className="mt-6 inline-block rounded bg-blue-500 px-4 py-2 text-white"
-        >
-          Apply
-        </a>
+      <main className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-semibold mb-2">Job not found</h1>
+        <a className="underline" href="/browse-jobs">Back to jobs</a>
       </main>
     );
-  } catch (err) {
-    console.error('failed to load job', err);
-    return <div className="text-gray-600">Job not found.</div>;
   }
+
+  // Build an auth-aware Apply link that preserves the return path after login
+  const returnTo = `/browse-jobs/${encodeURIComponent(String(job.id))}`;
+  const applyHref = job.applyUrl
+    ? hostAware(job.applyUrl)
+    : `/login?next=${encodeURIComponent(returnTo)}`;
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-semibold">{job.title}</h1>
+      {job.company ? <div className="text-gray-500">{job.company}</div> : null}
+      {job.location ? <div className="text-gray-500">{job.location}</div> : null}
+      <div className="prose mt-6">{job.description || '—'}</div>
+      <a
+        data-testid="apply-button"
+        href={applyHref}
+        className="mt-6 inline-block rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        Apply
+      </a>
+    </main>
+  );
 }

--- a/src/app/browse-jobs/page.tsx
+++ b/src/app/browse-jobs/page.tsx
@@ -1,77 +1,64 @@
-// Server component that fails soft when API is not configured.
-import type { Metadata } from 'next';
+import 'server-only';
 
 type Job = {
-  id: string | number;
+  id: number | string;
   title: string;
-  company?: string;
+  company: string;
   location?: string;
-  url?: string;
 };
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-async function fetchJobs(): Promise<Job[]> {
-  if (!API_BASE) {
+async function fetchJobs(
+  page = 1
+): Promise<{ jobs: Job[]; nextPage: number | null }> {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  // CI/Smoke environments may not set the real API.
+  // Degrade gracefully so smoke can assert the empty state.
+  if (!base) {
     console.warn(
-      '[BrowseJobs] NEXT_PUBLIC_API_BASE_URL is not set; rendering empty state.',
+      'NEXT_PUBLIC_API_BASE_URL not set; returning empty jobs for CI/smoke.'
     );
-    return [];
+    return { jobs: [], nextPage: null };
   }
   try {
-    const res = await fetch(`${API_BASE}/jobs`, {
-      // Avoid caching in CI to reduce flakiness
+    const res = await fetch(`${base.replace(/\/$/, '')}/jobs?page=${page}`, {
       cache: 'no-store',
     });
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    const data = await res.json();
-    // Accept either {jobs: Job[]} or Job[]
-    return Array.isArray(data) ? data : Array.isArray(data.jobs) ? data.jobs : [];
+    if (!res.ok) throw new Error(String(res.status));
+    return res.json();
   } catch (err) {
-    console.error('[BrowseJobs] failed to load jobs:', err);
-    return [];
+    console.warn('Failed to load jobs, rendering empty state.', err);
+    return { jobs: [], nextPage: null };
   }
 }
 
-export const metadata: Metadata = {
-  title: 'Browse Jobs • QuickGig',
-};
-
 export default async function BrowseJobsPage() {
-  const jobs = await fetchJobs();
-
-  if (!jobs.length) {
+  const { jobs } = await fetchJobs();
+  if (!jobs || jobs.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-2xl font-semibold mb-4">Browse Jobs</h1>
-        <div
-          data-testid="jobs-empty-state"
-          className="rounded-lg border p-8 text-center text-gray-500"
-        >
-          No jobs yet. Please check back later.
-        </div>
-      </main>
+      <div
+        data-testid="jobs-empty-state"
+        className="p-6 text-center text-slate-500"
+      >
+        No jobs yet — check back soon.
+      </div>
     );
   }
-
   return (
-    <main className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-semibold mb-4">Browse Jobs</h1>
-      <ul data-testid="jobs-list" className="grid gap-4 md:grid-cols-2">
-        {jobs.map((j) => (
-          <li key={String(j.id)} className="rounded-lg border p-4">
-            <a
-              className="block"
-              href={`/browse-jobs/${encodeURIComponent(String(j.id))}`}
-            >
-              <div className="text-lg font-medium">{j.title}</div>
-              {j.company ? <div className="text-sm text-gray-500">{j.company}</div> : null}
-              {j.location ? <div className="text-sm text-gray-500">{j.location}</div> : null}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </main>
+    <ul className="divide-y" data-testid="jobs-list">
+      {jobs.map((j) => (
+        <li key={String(j.id)} className="p-4" data-testid="job-card">
+          <a href={`/browse-jobs/${encodeURIComponent(String(j.id))}`}>
+            <div className="font-medium">{j.title}</div>
+            {j.company ? (
+              <div className="text-slate-500">{j.company}</div>
+            ) : null}
+            {j.location ? (
+              <div className="text-slate-500">{j.location}</div>
+            ) : null}
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Header from "@/components/Header";
 const siteUrl =
   process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:4010";
 
@@ -17,30 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <header className="border-b">
-          <nav className="mx-auto flex max-w-6xl items-center justify-between p-4">
-            <a href="/" className="font-semibold">QuickGig</a>
-            <div className="flex items-center gap-4">
-              <a data-testid="nav-browse-jobs" href="/browse-jobs" className="text-sm">
-                Browse Jobs
-              </a>
-              <a data-testid="nav-my-applications" href="/my-applications" className="text-sm">
-                My Applications
-              </a>
-              <a data-testid="nav-login" href="/login" className="text-sm">
-                Login
-              </a>
-              {/** Employer CTA — same host for now; test checks presence and clickability */}
-              <a
-                data-testid="nav-post-job"
-                href="/gigs/create"
-                className="rounded bg-blue-600 px-3 py-1 text-sm text-white"
-              >
-                Post a job
-              </a>
-            </div>
-          </nav>
-        </header>
+        <Header />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import { hostAware } from '@/lib/hostAware';
+
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-5xl p-6">
@@ -14,6 +16,26 @@ export default function HomePage() {
         >
           Browse jobs
         </a>
+
+        {/* App CTAs that should open on the App Host (absolute when configured) */}
+        <div className="mt-8 flex gap-4">
+          <a
+            data-testid="app-cta-post-job"
+            className="underline"
+            href={hostAware('/gigs/create')}
+            rel="noopener"
+          >
+            Post a job
+          </a>
+          <a
+            data-testid="app-cta-my-applications"
+            className="underline"
+            href={hostAware('/applications')}
+            rel="noopener"
+          >
+            My Applications
+          </a>
+        </div>
       </section>
     </main>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,36 +1,24 @@
-"use client";
-import Link from "next/link";
-import { useState } from "react";
-
-const APP_HOST = process.env.NEXT_PUBLIC_APP_HOST || "";
+import { hostAware } from '@/lib/hostAware';
 
 export default function Header() {
-  const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b">
-      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="text-xl font-semibold">QuickGig</Link>
-        <nav className="hidden md:flex gap-6 items-center">
-          {/* What tests expect to find */}
-          <Link data-testid="nav-browse-jobs" href="/browse-jobs">Browse Jobs</Link>
-          <Link data-testid="nav-my-applications" href={`${APP_HOST}/login`}>My Applications</Link>
-          {/* Use different visible text to avoid strict-mode duplicate with page body */}
-          <Link data-testid="nav-post-job" href={`${APP_HOST}/gigs/create`} className="btn btn-primary">Post</Link>
-          <Link data-testid="nav-login" href="/login">Login</Link>
-        </nav>
-        <div className="md:hidden">
-          {/* simplified mobile menu */}
-          <details>
-            <summary className="cursor-pointer">Menu</summary>
-            <div className="mt-2 flex flex-col gap-3">
-              <Link data-testid="nav-browse-jobs" href="/browse-jobs">Browse Jobs</Link>
-              <Link data-testid="nav-my-applications" href={`${APP_HOST}/login`}>My Applications</Link>
-              <Link data-testid="nav-post-job" href={`${APP_HOST}/gigs/create`} className="btn btn-primary">Post</Link>
-              <Link data-testid="nav-login" href="/login">Login</Link>
-            </div>
-          </details>
+    <header className="w-full border-b">
+      <nav className="container mx-auto flex items-center justify-between px-4 py-3">
+        <a href="/" className="font-semibold">QuickGig</a>
+        <div className="flex items-center gap-4">
+          <a data-testid="nav-browse-jobs" href="/browse-jobs">Browse Jobs</a>
+          <a data-testid="nav-my-applications" href="/my-applications">My Applications</a>
+          <a data-testid="nav-login" href="/login">Login</a>
+          {/* App-host action */}
+          <a
+            data-testid="nav-post-job"
+            href={hostAware('/gigs/create')}
+            rel="noopener"
+          >
+            Post a job
+          </a>
         </div>
-      </div>
+      </nav>
     </header>
   );
 }

--- a/src/lib/hostAware.ts
+++ b/src/lib/hostAware.ts
@@ -1,0 +1,14 @@
+const APP_HOST = process.env.NEXT_PUBLIC_APP_HOST_BASE_URL || process.env.NEXT_PUBLIC_APP_BASE_URL;
+/**
+ * Builds an absolute URL to the App Host when configured, else returns the given path.
+ * Examples:
+ *   hostAware('/gigs/create') -> 'https://app.example.com/gigs/create' | '/gigs/create'
+ */
+export function hostAware(path: string) {
+  if (!APP_HOST) return path;
+  try {
+    return new URL(path, APP_HOST).toString();
+  } catch {
+    return path;
+  }
+}

--- a/src/lib/hostAware.ts
+++ b/src/lib/hostAware.ts
@@ -1,14 +1,19 @@
-const APP_HOST = process.env.NEXT_PUBLIC_APP_HOST_BASE_URL || process.env.NEXT_PUBLIC_APP_BASE_URL;
-/**
- * Builds an absolute URL to the App Host when configured, else returns the given path.
- * Examples:
- *   hostAware('/gigs/create') -> 'https://app.example.com/gigs/create' | '/gigs/create'
- */
-export function hostAware(path: string) {
-  if (!APP_HOST) return path;
+// Build an absolute, host-aware URL when an app host is configured.
+// - Absolute inputs are returned unchanged.
+// - Relative inputs are prefixed with NEXT_PUBLIC_APP_HOST (or NEXT_PUBLIC_HOST_BASE_URL).
+export function hostAware(urlOrPath: string): string {
+  const base =
+    process.env.NEXT_PUBLIC_APP_HOST ?? process.env.NEXT_PUBLIC_HOST_BASE_URL;
+  if (!base) return urlOrPath;
+  // Absolute already? leave untouched
   try {
-    return new URL(path, APP_HOST).toString();
+    // eslint-disable-next-line no-new
+    new URL(urlOrPath);
+    return urlOrPath;
   } catch {
-    return path;
+    const root = base.replace(/\/$/, "");
+    const path = urlOrPath.startsWith("/") ? urlOrPath : `/${urlOrPath}`;
+    return `${root}${path}`;
   }
 }
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,5 +29,7 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/applications/:path*", "/my-applications/:path*"],
+  // Both /applications and /my-applications are auth-gated. Keep gating at the Edge
+  // so unauthenticated users are redirected before any page renders.
+  matcher: ["/applications/:path*", "/my-applications"],
 };


### PR DESCRIPTION
## Summary
- factor header into reusable component with host-aware Post Job link
- add hostAware helper to build absolute URLs when an app host is set
- wire landing and job detail CTAs to use host-aware URLs and preserve return paths

## Testing
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: unsupported engine / npm version)*
- `npx playwright test -c playwright.smoke.ts` *(fails: 403 Forbidden fetching playwright)*
- `npm test`
- `bash scripts/no-legacy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c830a1c8e48327b8ab4273e80d0041