### PR TITLE
codex patch: ship Post Job publish flow (auth-aware + app-host aware) and hard redirect for /post-job

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,8 +1,9 @@
 # Agents Contract
-**Version:** 2026-09-25
+**Version:** 2026-09-26
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).
+- Post Job CTAs resolve through `authAware('/gigs/create')` so unauthenticated clicks land on `/login?next=…` on the app host.
 - Home (`/`) renders a hero CTA `hero-start` linking to `/browse-jobs`.
 - `data-testid="browse-jobs-from-empty"` → `/browse-jobs`
 - Header shows Login and My Applications links unconditionally.
@@ -14,6 +15,7 @@
 
 ## Legacy redirects (middleware)
 - `/find` → `/browse-jobs`
+- `/post`, `/posts`, and `/gigs/new` → `/post-job` (server page issues the auth-aware redirect)
 
 - Stable header test IDs: `nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`.
 - Browse list IDs: `jobs-list`, `job-card`; empty state `jobs-empty-state`.

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,10 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2026-09-26 — Auth-aware Post Job publish flow
+- `/post-job` now server-redirects to the app host login with `next` preserving `/gigs/create`.
+- Header, landing CTAs, and shared nav use the new `authAware('/gigs/create')` helper so app-host deployments stay absolute.
+- Legacy `/post*` routes and rewrites funnel into `/post-job` to keep the auth-aware publish flow consistent.
+
 ## 2026-09-24 — Edge-gate my-applications
 - Middleware now gates `/my-applications` alongside `/applications` and preserves the full destination in `next` query param.
 - `/browse-jobs` soft-fails when API base is missing and exposes `jobs-empty-state` when no jobs are available.

--- a/next.config.js
+++ b/next.config.js
@@ -57,10 +57,9 @@ const baseConfig = {
     async redirects() {
       return [
         // legacy to canonical
-        { source: "/post", destination: "/gigs/create", permanent: true },
-        { source: "/posts", destination: "/gigs/create", permanent: true },
-        { source: "/gigs/new", destination: "/gigs/create", permanent: true },
-        { source: "/post-job", destination: "/gigs/create", permanent: true },
+        { source: "/post", destination: "/post-job", permanent: true },
+        { source: "/posts", destination: "/post-job", permanent: true },
+        { source: "/gigs/new", destination: "/post-job", permanent: true },
         { source: "/find", destination: "/browse-jobs", permanent: true },
         { source: "/finds", destination: "/browse-jobs", permanent: true },
         { source: "/jobs", destination: "/browse-jobs", permanent: true },
@@ -90,8 +89,8 @@ const baseConfig = {
     },
     async rewrites() {
       return [
-        { source: "/employer/post", destination: "/gigs/create" },
-        { source: "/jobs/post", destination: "/gigs/create" },
+        { source: "/employer/post", destination: "/post-job" },
+        { source: "/jobs/post", destination: "/post-job" },
       ];
     },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { hostAware } from '@/lib/hostAware';
+import { authAware, hostAware } from '@/lib/hostAware';
 
 export default function HomePage() {
   return (
@@ -22,7 +22,7 @@ export default function HomePage() {
           <a
             data-testid="app-cta-post-job"
             className="underline"
-            href={hostAware('/gigs/create')}
+            href={authAware('/gigs/create')}
             rel="noopener"
           >
             Post a job

--- a/src/app/post-job/page.tsx
+++ b/src/app/post-job/page.tsx
@@ -1,12 +1,7 @@
-export default function PostJobPlaceholder() {
-  return (
-    <main className="mx-auto max-w-3xl px-4 py-8">
-      {/* Keep this exact text for the smoke check */}
-      <h1 className="text-2xl font-semibold mb-4">Post a job</h1>
-      <div data-testid="post-job-skeleton" className="rounded-lg border p-6 text-gray-600">
-        This is a placeholder. Posting will be enabled after wiring the app host flow.
-      </div>
-    </main>
-  );
+import { redirect } from 'next/navigation';
+import { authAware } from '@/lib/hostAware';
+
+export default function PostJobRedirect() {
+  redirect(authAware('/gigs/create'));
 }
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { authAware } from "@/lib/hostAware";
 
 export default function AppHeader() {
   return (
@@ -8,7 +9,9 @@ export default function AppHeader() {
         <Link href="/" className="font-semibold">QuickGig</Link>
         <nav className="ml-auto flex items-center gap-3">
           <Link href="/browse-jobs" data-testid="nav-browse-jobs">Browse Jobs</Link>
-          <Link href="/post-job" data-testid="nav-post-job">Post a job</Link>
+          <Link href={authAware('/gigs/create')} data-testid="nav-post-job" rel="noopener">
+            Post a job
+          </Link>
           <Link href="/applications" data-testid="nav-my-applications">My Applications</Link>
           <Link href="/login" data-testid="nav-login">Login</Link>
         </nav>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { hostAware } from '@/lib/hostAware';
+import { authAware } from '@/lib/hostAware';
 
 export default function Header() {
   return (
@@ -12,7 +12,7 @@ export default function Header() {
           {/* App-host action */}
           <a
             data-testid="nav-post-job"
-            href={hostAware('/gigs/create')}
+            href={authAware('/gigs/create')}
             rel="noopener"
           >
             Post a job

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -3,15 +3,21 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { NAV_ITEMS, ROUTES } from '@/lib/routes';
+import { authAware } from '@/lib/hostAware';
 import { track } from '@/lib/analytics';
 
 export default function LandingHeader() {
   const [open, setOpen] = useState(false);
-  const links = NAV_ITEMS.map(item => ({
-    href: item.to,
-    label: item.label,
-    testId: item.id,
-  }));
+  const links = NAV_ITEMS.map(item => {
+    const href = item.auth === 'auth-aware' ? authAware(item.to) : item.to;
+    const external = /^https?:\/\//.test(href);
+    return {
+      href,
+      external,
+      label: item.label,
+      testId: item.id,
+    };
+  });
 
   return (
     <header className="border-b bg-white/60 backdrop-blur">
@@ -26,6 +32,8 @@ export default function LandingHeader() {
               data-testid={link.testId}
               data-cta={link.testId}
               href={link.href}
+              rel={link.external ? 'noopener' : undefined}
+              prefetch={!link.external}
               className="hover:underline"
               onClick={() => track('cta_click', { cta: link.testId })}
             >
@@ -58,6 +66,8 @@ export default function LandingHeader() {
                 data-testid={link.testId}
                 data-cta={link.testId}
                 href={link.href}
+                rel={link.external ? 'noopener' : undefined}
+                prefetch={!link.external}
                 onClick={() => {
                   setOpen(false);
                   track('cta_click', { cta: link.testId });

--- a/src/components/landing/LandingCTAs.tsx
+++ b/src/components/landing/LandingCTAs.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { track } from '@/lib/analytics';
 import { ROUTES } from '@/lib/routes';
+import { authAware } from '@/lib/hostAware';
 
 type Props = {
   browseClassName?: string;
@@ -39,7 +40,8 @@ export default function LandingCTAs({
         <Link
           data-testid="hero-post-job"
           data-cta="hero-post-job"
-          href={ROUTES.postJob}
+          href={authAware(ROUTES.postJob)}
+          rel="noopener"
           className={postClassName}
           onClick={() => track('cta_click', { cta: 'hero-post-job' })}
         >

--- a/src/lib/hostAware.ts
+++ b/src/lib/hostAware.ts
@@ -1,19 +1,19 @@
 // Build an absolute, host-aware URL when an app host is configured.
 // - Absolute inputs are returned unchanged.
 // - Relative inputs are prefixed with NEXT_PUBLIC_APP_HOST (or NEXT_PUBLIC_HOST_BASE_URL).
-export function hostAware(urlOrPath: string): string {
+export function hostAware(path: string): string {
   const base =
-    process.env.NEXT_PUBLIC_APP_HOST ?? process.env.NEXT_PUBLIC_HOST_BASE_URL;
-  if (!base) return urlOrPath;
-  // Absolute already? leave untouched
-  try {
-    // eslint-disable-next-line no-new
-    new URL(urlOrPath);
-    return urlOrPath;
-  } catch {
-    const root = base.replace(/\/$/, "");
-    const path = urlOrPath.startsWith("/") ? urlOrPath : `/${urlOrPath}`;
-    return `${root}${path}`;
-  }
+    (process.env.NEXT_PUBLIC_APP_HOST ?? process.env.NEXT_PUBLIC_HOST_BASE_URL ?? '')
+      .replace(/\/$/, '');
+  if (!base) return path;
+  if (/^https?:\/\//i.test(path)) return path;
+  const normalised = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalised}`;
+}
+
+export function authAware(destPath: string): string {
+  const destAbs = hostAware(destPath);
+  const next = encodeURIComponent(destAbs);
+  return hostAware(`/login?next=${next}`);
 }
 

--- a/tests/smoke/core.spec.ts
+++ b/tests/smoke/core.spec.ts
@@ -6,6 +6,7 @@ import {
   expectAuthAwareRedirect,
   visByTestId,
   loginRe,
+  loginOr,
 } from './_helpers';
 
 test('Browse Jobs renders', async ({ page }) => {
@@ -27,9 +28,9 @@ test('My Applications is auth-gated', async ({ page }) => {
   await expectAuthAwareRedirect(page, new RegExp(`${loginRe.source}|\/applications$`));
 });
 
-test('Post a Job placeholder', async ({ page }) => {
+test('Post Job redirects through auth-aware flow', async ({ page }) => {
   await page.goto('/post-job');
-  await expect(page.getByText('Post a job', { exact: false })).toBeVisible();
+  await expectAuthAwareRedirect(page, loginOr(/\/gigs\/create$/));
 });
 
 test('Header/nav is wired', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add an `authAware` helper to wrap `hostAware` URLs and switch header and landing CTAs to the auth-aware publish flow
- hard-redirect `/post-job` through the login-preserving target and update legacy redirects/rewrites to point at the new page
- document the new behavior in the agent contract/backfill and update the smoke test to expect the auth-aware redirect

## Testing
- `bash scripts/no-legacy.sh`
- `npm run lint` *(fails: `next` binary unavailable because dependencies cannot be installed in this environment due to registry/engine restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bb38be908327b7e0929ae4dd26ba