### PR TITLE
Add apply click tracking pipeline

### DIFF
--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  let body: unknown = null;
+  try {
+    body = await req.json();
+  } catch {
+    // ignore bad JSON
+  }
+
+  // Optional forward to external analytics sink if configured.
+  const forwardUrl =
+    process.env.ANALYTICS_INGEST_URL || process.env.APPLY_TRACK_URL || '';
+  if (forwardUrl) {
+    try {
+      await fetch(forwardUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body ?? {}),
+        cache: 'no-store',
+      });
+    } catch {
+      // swallow; tracking must never break UX or tests
+    }
+  } else {
+    // Useful in CI / dev logs
+    // eslint-disable-next-line no-console
+    console.log('[track]', body);
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/browse-jobs/[id]/ApplyButton.tsx
+++ b/src/app/browse-jobs/[id]/ApplyButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { trackApply } from '@/lib/track';
+
+type ApplyButtonProps = {
+  href: string;
+  jobId: string | number;
+  title?: string;
+};
+
+export function ApplyButton({ href, jobId, title }: ApplyButtonProps) {
+  return (
+    <a
+      data-testid="apply-button"
+      data-analytics="apply-click"
+      href={href}
+      className="mt-6 inline-block rounded bg-blue-500 px-4 py-2 text-white"
+      rel="noopener"
+      onClick={() => trackApply({ id: jobId, title })}
+    >
+      Apply
+    </a>
+  );
+}

--- a/src/app/browse-jobs/[id]/page.tsx
+++ b/src/app/browse-jobs/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { hostAware } from '@/lib/hostAware';
+import { ApplyButton } from './ApplyButton';
 
 type JobDetail = {
   id: string | number;
@@ -51,13 +52,7 @@ export default async function JobDetailPage({ params }: { params: { id: string }
       {job.company ? <div className="text-gray-500">{job.company}</div> : null}
       {job.location ? <div className="text-gray-500">{job.location}</div> : null}
       <div className="prose mt-6">{job.description || '—'}</div>
-      <a
-        data-testid="apply-button"
-        href={applyHref}
-        className="mt-6 inline-block rounded bg-blue-500 px-4 py-2 text-white"
-      >
-        Apply
-      </a>
+      <ApplyButton href={applyHref} jobId={job.id} title={job.title} />
     </main>
   );
 }

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,0 +1,44 @@
+// Lightweight client-side tracking with sendBeacon (non-blocking).
+// Falls back to a keepalive fetch. Never throws.
+type AnyRecord = Record<string, unknown>;
+
+function postBeacon(url: string, body: AnyRecord) {
+  try {
+    const data = JSON.stringify(body);
+    if (typeof navigator !== 'undefined' && 'sendBeacon' in navigator) {
+      const blob = new Blob([data], { type: 'application/json' });
+      // @ts-expect-error: TS doesn't know sendBeacon type in some DOM libs
+      navigator.sendBeacon(url, blob);
+      return;
+    }
+    // keepalive avoids blocking navigation on page transitions
+    fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: data,
+      keepalive: true,
+      cache: 'no-store',
+    }).catch(() => {});
+  } catch {
+    // no-op
+  }
+}
+
+/** Generic event tracker */
+export function track(event: string, payload: AnyRecord = {}) {
+  const url =
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ANALYTICS_URL) ||
+    '/api/track';
+  const ts = Date.now();
+  const path =
+    typeof location !== 'undefined' ? location.pathname + location.search : '';
+  postBeacon(url, { event, ts, path, ...payload });
+}
+
+/** Convenience helper for Apply clicks */
+export function trackApply(job: { id: string | number; title?: string }) {
+  track('apply_click', {
+    jobId: String(job?.id ?? ''),
+    title: job?.title ?? '',
+  });
+}


### PR DESCRIPTION
## Summary
- add a sendBeacon-based tracker helper with a `trackApply` convenience
- expose `/api/track` so events can be forwarded to configured analytics sinks
- wrap the job-detail Apply CTA in a client component that fires the tracking payload

## Testing
- npm run test
- npm run lint *(fails: local `next` binary unavailable because `npm install` requests to registry.npmjs.org are rejected with 403s)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c71103248327aafa6c8211e49742