### PR TITLE
Implement mock login flow with shared auth cookie and logout route

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,17 +1,18 @@
 # Agents Contract
-**Version:** 2026-09-26
+**Version:** 2026-09-27
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).
 - Post Job CTAs resolve through `authAware('/gigs/create')` so unauthenticated clicks land on `/login?next=…` on the app host.
 - Home (`/`) renders a hero CTA `hero-start` linking to `/browse-jobs`.
 - `data-testid="browse-jobs-from-empty"` → `/browse-jobs`
-- Header shows Login and My Applications links unconditionally.
+- Header shows My Applications at all times and swaps `nav-login` ↔ `nav-logout` based on auth cookie presence.
 
 ## Auth behavior
 - If signed out, clicking either CTA MUST redirect to `/login?next=<dest>`.
 - Auth-gated routes: `/applications` and `/my-applications`.
 - Middleware redirects unauthenticated `/applications` or `/my-applications` requests to `/login?next=…` using a single Edge-safe redirect.
+- `/api/mock-login?next=/…` sets the shared auth cookie for smoke flows; `/api/logout?next=/…` clears it.
 
 ## Legacy redirects (middleware)
 - `/find` → `/browse-jobs`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,5 +1,9 @@
 <!-- AGENT CONTRACT v2025-12-16 -->
 
+## 2026-09-27
+- Header swaps `nav-login` for `nav-logout` when `qg_auth` is present and keeps Post Job auth-aware.
+- Added `/api/mock-login` stub to mint the auth cookie and `/api/logout` to clear it for smoke flows.
+
 ## 2026-09-20
 - Header reads `qg_auth` cookie client-side and swaps `nav-login` for `nav-my-applications` when authenticated.
 - Landing hero uses `hero-start` with `cta-browse-jobs` CTA.

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,10 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2026-09-27 — Mock auth helpers and logout swap
+- Added `/api/mock-login` to set the shared auth cookie and `/api/logout` to clear it with safe redirects.
+- Header now toggles `nav-login`/`nav-logout` when signed in and links Post Job directly for authed requests.
+- Middleware and auth utilities share cookie constants so gate checks stay consistent.
+
 ## 2026-09-26 — Auth-aware Post Job publish flow
 - `/post-job` now server-redirects to the app host login with `next` preserving `/gigs/create`.
 - Header, landing CTAs, and shared nav use the new `authAware('/gigs/create')` helper so app-host deployments stay absolute.

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
-import { AUTH_COOKIE } from "@/lib/constants";
+import { AUTH_COOKIE, NEXT_COOKIE } from "@/lib/constants";
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
   }
 
   const jar = cookies();
-  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", "qg_next"].forEach(
+  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", NEXT_COOKIE].forEach(
     (n) => {
       try {
         // @ts-ignore – cookie typings differ across Next versions

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,15 +1,28 @@
-import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/constants";
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const next = url.searchParams.get('next') || '/';
+  const target = url.searchParams.get("next") ?? "/";
+  let dest: URL;
+  try {
+    dest = new URL(target, url.origin);
+  } catch {
+    dest = new URL("/", url.origin);
+  }
+  if (dest.origin !== url.origin) {
+    dest = new URL("/", url.origin);
+  }
+
   const jar = cookies();
-  ['sb-access-token', 'sb-refresh-token', 'qg_next'].forEach((n) => {
-    try {
-      // @ts-ignore – cookie typings differ across Next versions
-      jar.delete(n);
-    } catch {}
-  });
-  return NextResponse.redirect(new URL(next, url.origin), { status: 302 });
+  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", "qg_next"].forEach(
+    (n) => {
+      try {
+        // @ts-ignore – cookie typings differ across Next versions
+        jar.delete(n);
+      } catch {}
+    },
+  );
+  return NextResponse.redirect(dest, { status: 302 });
 }

--- a/src/app/api/auth/pkce/callback/route.ts
+++ b/src/app/api/auth/pkce/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { clearAuthCookies, readCookie, safePath } from '@/app/api/auth/pkce/utils';
+import { NEXT_COOKIE } from '@/lib/constants';
 
 const STATE_COOKIE = 'pkce_state';
 const PKCE_COOKIE = 'pkce_verifier';
@@ -46,9 +47,9 @@ export async function GET(req: Request) {
   // TODO: set your app session here (existing mechanism)
 
   // Read and decode the raw `next` value BEFORE clearing cookies.
-  const rawNext = readCookie('qg_next') ?? '/applications';
+  const rawNext = readCookie(NEXT_COOKIE) ?? '/applications';
   const target = safePath(rawNext) ?? '/applications';
-  clearAuthCookies({ also: ['qg_next'] });
+  clearAuthCookies({ also: [NEXT_COOKIE] });
   return NextResponse.redirect(new URL(target, url.origin), { status: 302 });
 }
 

--- a/src/app/api/auth/pkce/utils.ts
+++ b/src/app/api/auth/pkce/utils.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import { NEXT_COOKIE } from '@/lib/constants';
 
 export function readCookie(name: string): string | null {
   try {
@@ -22,7 +23,7 @@ export function safePath(p: string | null | undefined): string | null {
 
 export function clearAuthCookies(opts?: { also?: string[] }) {
   const jar = cookies();
-  ['sb-access-token', 'sb-refresh-token', 'qg_next', ...(opts?.also ?? [])].forEach((n) => {
+  ['sb-access-token', 'sb-refresh-token', NEXT_COOKIE, ...(opts?.also ?? [])].forEach((n) => {
     try {
       // @ts-ignore – cookie typings differ across Next versions
       jar.delete(n);

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/constants";
+
+function resolveNext(req: NextRequest): URL {
+  const { origin } = req.nextUrl;
+  const target = req.nextUrl.searchParams.get("next") ?? "/";
+  let url: URL;
+  try {
+    url = new URL(target, origin);
+  } catch {
+    url = new URL("/", origin);
+  }
+  if (url.origin !== origin) {
+    return new URL("/", origin);
+  }
+  return url;
+}
+
+export async function GET(req: NextRequest) {
+  const redirectTo = resolveNext(req);
+  const res = NextResponse.redirect(redirectTo);
+  const base = {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  };
+  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", "qg_next"].forEach(
+    (name) => {
+      res.cookies.set({
+        name,
+        value: "",
+        ...base,
+      });
+    },
+  );
+  return res;
+}

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { AUTH_COOKIE } from "@/lib/constants";
+import { AUTH_COOKIE, NEXT_COOKIE } from "@/lib/constants";
 
 function resolveNext(req: NextRequest): URL {
   const { origin } = req.nextUrl;
@@ -26,7 +26,7 @@ export async function GET(req: NextRequest) {
     path: "/",
     maxAge: 0,
   };
-  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", "qg_next"].forEach(
+  [AUTH_COOKIE, "sb-access-token", "sb-refresh-token", NEXT_COOKIE].forEach(
     (name) => {
       res.cookies.set({
         name,

--- a/src/app/api/mock-login/route.ts
+++ b/src/app/api/mock-login/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/constants";
+
+function resolveNext(req: NextRequest): URL {
+  const { origin } = req.nextUrl;
+  const target = req.nextUrl.searchParams.get("next") ?? "/";
+  let url: URL;
+  try {
+    url = new URL(target, origin);
+  } catch {
+    url = new URL("/", origin);
+  }
+  if (url.origin !== origin) {
+    return new URL("/", origin);
+  }
+  return url;
+}
+
+export async function GET(req: NextRequest) {
+  const redirectTo = resolveNext(req);
+  const res = NextResponse.redirect(redirectTo);
+  res.cookies.set({
+    name: AUTH_COOKIE,
+    value: "1",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 2 * 60 * 60,
+  });
+  return res;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,34 @@
-export default function LoginPage() {
+import Link from "next/link";
+
+type LoginPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default function LoginPage({ searchParams }: LoginPageProps) {
+  const nextParam = searchParams?.next;
+  const nextValue = Array.isArray(nextParam) ? nextParam[0] : nextParam;
+  const safeNext =
+    typeof nextValue === "string" && nextValue.trim().length > 0
+      ? nextValue
+      : "/my-applications";
+  const startHref = `/api/mock-login?next=${encodeURIComponent(safeNext)}`;
+
   return (
-    <main className="mx-auto max-w-4xl p-6">
-      <h1 className="text-2xl font-semibold">Login</h1>
-      <p className="mt-2 text-sm text-gray-600">
-        This is a placeholder login page.
-      </p>
+    <main className="container mx-auto px-4 py-16">
+      <h1 className="text-3xl font-semibold mb-3">Login</h1>
+      <p className="text-gray-600 mb-8">This is a placeholder login page.</p>
+      <a
+        data-testid="login-start"
+        href={startHref}
+        className="inline-block rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Continue
+      </a>
+      <div className="mt-6">
+        <Link href="/" className="underline">
+          Back to home
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -11,7 +11,7 @@ export default function LogoutPage() {
         await createClient().auth.signOut();
       } catch {}
       // Let server clear cookies, then land home.
-      window.location.replace('/api/auth/logout?next=/');
+      window.location.replace('/api/logout?next=/');
     };
     run();
   }, [router]);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,14 @@
-import { authAware } from '@/lib/hostAware';
+import { isAuthedServer } from "@/lib/auth/isAuthedServer";
+import { authAware, hostAware } from "@/lib/hostAware";
 
 export default function Header() {
+  const authed = isAuthedServer();
+  const postHref = authed
+    ? hostAware("/gigs/create")
+    : authAware("/gigs/create");
+  const logoutHref = hostAware("/api/logout?next=/");
+  const loginHref = hostAware("/login");
+
   return (
     <header className="w-full border-b">
       <nav className="container mx-auto flex items-center justify-between px-4 py-3">
@@ -8,13 +16,17 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <a data-testid="nav-browse-jobs" href="/browse-jobs">Browse Jobs</a>
           <a data-testid="nav-my-applications" href="/my-applications">My Applications</a>
-          <a data-testid="nav-login" href="/login">Login</a>
+          {authed ? (
+            <a data-testid="nav-logout" href={logoutHref}>
+              Logout
+            </a>
+          ) : (
+            <a data-testid="nav-login" href={loginHref}>
+              Login
+            </a>
+          )}
           {/* App-host action */}
-          <a
-            data-testid="nav-post-job"
-            href={authAware('/gigs/create')}
-            rel="noopener"
-          >
+          <a data-testid="nav-post-job" href={postHref} rel="noopener">
             Post a job
           </a>
         </div>

--- a/src/lib/auth/isAuthedServer.ts
+++ b/src/lib/auth/isAuthedServer.ts
@@ -1,0 +1,10 @@
+import { cookies } from "next/headers";
+import { AUTH_COOKIE_NAMES } from "@/lib/constants";
+
+export function isAuthedServer(): boolean {
+  const jar = cookies();
+  return AUTH_COOKIE_NAMES.some((name) => {
+    const value = jar.get(name)?.value;
+    return typeof value === "string" && value.length > 0;
+  });
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,18 @@
+// Shared constants for auth/session behavior.
+// Safe to import from both edge and server contexts.
+export const AUTH_COOKIE = "qg_auth";
+
+export const LEGACY_AUTH_COOKIE_CANDIDATES = [
+  "auth",
+  "session",
+  "next-auth.session-token",
+  "sb:token",
+  "sb-access-token",
+  "sb-refresh-token",
+  "qg_next",
+] as const;
+
+export const AUTH_COOKIE_NAMES = [
+  AUTH_COOKIE,
+  ...LEGACY_AUTH_COOKIE_CANDIDATES,
+] as const;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,8 @@
 // Safe to import from both edge and server contexts.
 export const AUTH_COOKIE = "qg_auth";
 
+// Known cookies that actually represent an authenticated session.
+// Do **not** include transient cookies (like redirect pointers).
 export const LEGACY_AUTH_COOKIE_CANDIDATES = [
   "auth",
   "session",
@@ -9,10 +11,13 @@ export const LEGACY_AUTH_COOKIE_CANDIDATES = [
   "sb:token",
   "sb-access-token",
   "sb-refresh-token",
-  "qg_next",
 ] as const;
 
 export const AUTH_COOKIE_NAMES = [
   AUTH_COOKIE,
   ...LEGACY_AUTH_COOKIE_CANDIDATES,
 ] as const;
+
+// Return-path pointer used during login redirects.
+// This must NEVER be treated as an auth cookie.
+export const NEXT_COOKIE = "qg_next" as const;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { AUTH_COOKIE_NAMES } from "@/lib/constants";
 
 // Gate both /applications and /my-applications at the edge so unauthenticated
 // requests redirect before the page is rendered (matches agents contract).
@@ -10,19 +11,15 @@ export function middleware(req: NextRequest) {
     path.startsWith("/applications") || path.startsWith("/my-applications");
   if (!isGated) return NextResponse.next();
 
-  // Treat presence of any known auth cookie as "signed in".
-  const c = req.cookies;
-  const authed =
-    c.get("qg_auth") ||
-    c.get("auth") ||
-    c.get("session") ||
-    c.get("next-auth.session-token") ||
-    c.get("sb:token");
+  const authed = AUTH_COOKIE_NAMES.some((name) => {
+    const value = req.cookies.get(name)?.value;
+    return typeof value === "string" && value.length > 0;
+  });
 
   if (!authed) {
     const dest = new URL("/login", url.origin);
-    // Preserve full original destination
-    dest.searchParams.set("next", url.pathname + url.search);
+    const fullPath = url.search ? `${path}${url.search}` : path;
+    dest.searchParams.set("next", fullPath);
     return NextResponse.redirect(dest);
   }
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- add shared auth cookie constants and a server helper for detecting mock sessions across middleware and layout header
- introduce `/api/mock-login` and `/api/logout` endpoints plus update the existing auth logout handler to set or clear the cookie safely
- refresh the login and logout experiences and contract docs so the header swaps Login/Logout based on the mock session state

## Testing
- not run (npm install blocked by registry 403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68c8d459b9d08327a512bd1b149fc310