### PR TITLE
Track apply clicks in cookie and render My Applications

### DIFF
--- a/src/app/api/applications/clear/route.ts
+++ b/src/app/api/applications/clear/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { APPLICATIONS_COOKIE, cookieOptionsForHost } from '@/lib/applications';
+
+export async function POST() {
+  const res = new NextResponse(null, { status: 204 });
+  const opts = cookieOptionsForHost();
+  res.cookies.set(APPLICATIONS_COOKIE, '', { ...opts, maxAge: 0 });
+  return res;
+}
+

--- a/src/app/api/applications/record/route.ts
+++ b/src/app/api/applications/record/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { APPLICATIONS_COOKIE, cookieOptionsForHost } from '@/lib/applications';
+
+export async function POST(req: NextRequest) {
+  let id: string | null = null;
+  try {
+    const body = await req.json();
+    if (body && (body.id ?? body.jobId) != null) {
+      id = String(body.id ?? body.jobId);
+    }
+  } catch {}
+
+  if (!id) return new NextResponse('missing jobId', { status: 400 });
+
+  const cookie = req.cookies.get(APPLICATIONS_COOKIE)?.value;
+  let current: string[] = [];
+  try {
+    current = cookie ? JSON.parse(cookie) : [];
+    if (!Array.isArray(current)) current = [];
+  } catch {
+    current = [];
+  }
+  if (!current.includes(id)) current.unshift(id);
+  current = current.slice(0, 100);
+
+  const res = new NextResponse(null, { status: 204 });
+  res.cookies.set(APPLICATIONS_COOKIE, JSON.stringify(current), cookieOptionsForHost());
+  return res;
+}
+

--- a/src/app/browse-jobs/[id]/ApplyButton.tsx
+++ b/src/app/browse-jobs/[id]/ApplyButton.tsx
@@ -15,11 +15,18 @@ export function ApplyButton({ href, jobId, title }: ApplyButtonProps) {
     if (busy) return;
     setBusy(true);
     try {
-      await fetch('/api/track/apply', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ jobId, title, href }),
-      });
+      await Promise.allSettled([
+        fetch('/api/applications/record', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ jobId }),
+        }),
+        fetch('/api/track/apply', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ jobId, title, href }),
+        }),
+      ]);
     } catch {}
     window.location.href = href;
   }, [busy, href, jobId, title]);

--- a/src/app/my-applications/page.tsx
+++ b/src/app/my-applications/page.tsx
@@ -1,74 +1,14 @@
 import 'server-only';
 
-import { randomUUID } from 'node:crypto';
+import Link from 'next/link';
 import { cookies } from 'next/headers';
-import { hasAuthCookieHeader } from '@/lib/auth/cookies';
-
-type Application = {
-  id: string | number;
-  jobTitle?: string;
-  company?: string;
-  status?: string;
-  appliedAt?: string;
-};
-
-async function fetchApplications(cookieHeader?: string): Promise<Application[]> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (!baseUrl) return [];
-
-  try {
-    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/applications`, {
-      cache: 'no-store',
-      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
-      credentials: 'include',
-    });
-
-    if (response.status === 401) {
-      return [];
-    }
-
-    if (!response.ok) {
-      throw new Error(String(response.status));
-    }
-
-    const body = await response.json();
-    const rawList: any[] = Array.isArray((body as any)?.applications)
-      ? (body as any).applications
-      : Array.isArray(body)
-      ? (body as any)
-      : [];
-
-    return rawList.map((application: any) => ({
-      id:
-        application?.id ??
-        application?.applicationId ??
-        application?.jobId ??
-        randomUUID(),
-      jobTitle:
-        application?.jobTitle ??
-        application?.title ??
-        application?.job?.title ??
-        'Untitled job',
-      company:
-        application?.company ??
-        application?.job?.company ??
-        application?.org?.name ??
-        '—',
-      status: application?.status ?? application?.state ?? 'submitted',
-      appliedAt: application?.appliedAt ?? application?.createdAt ?? undefined,
-    }));
-  } catch {
-    return [];
-  }
-}
+import { hasAuthCookies } from '@/lib/auth/cookies';
+import { fetchJob } from '@/lib/jobs';
+import { readAppliedIdsFromCookie } from '@/lib/applications';
 
 export default async function MyApplicationsPage() {
   const jar = cookies();
-  const cookieHeader = jar
-    .getAll()
-    .map((c) => `${c.name}=${c.value}`)
-    .join('; ');
-  const authed = hasAuthCookieHeader(cookieHeader || undefined);
+  const authed = hasAuthCookies(jar);
 
   if (!authed) {
     return (
@@ -79,40 +19,42 @@ export default async function MyApplicationsPage() {
     );
   }
 
-  const applications = await fetchApplications(cookieHeader || undefined);
-  const hasApplications = applications.length > 0;
+  const ids = readAppliedIdsFromCookie();
+  const jobs = (
+    await Promise.all(ids.map((id) => fetchJob(id)))
+  ).filter((job): job is NonNullable<typeof job> => Boolean(job));
+
+  if (!jobs.length) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="text-2xl font-semibold">My Applications</h1>
+        <div
+          className="mt-6 rounded border border-dashed p-6 text-center text-slate-600"
+          data-testid="applications-empty"
+        >
+          You haven’t applied to any jobs yet.
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-3xl p-6">
       <h1 className="text-2xl font-semibold">My Applications</h1>
-      {hasApplications ? (
-        <ul data-testid="applications-list" className="mt-6 divide-y">
-          {applications.map((application) => (
-            <li
-              key={String(application.id)}
-              data-testid="application-row"
-              className="py-4"
-            >
-              <div className="flex items-baseline justify-between">
-                <div>
-                  <div className="font-medium">{application.jobTitle}</div>
-                  <div className="text-sm text-slate-600">{application.company}</div>
-                </div>
-                <div className="text-sm text-slate-500">
-                  {application.status ?? 'submitted'}
-                </div>
-              </div>
+      <ul className="mt-6 space-y-3" data-testid="applications-list">
+        {jobs.map((job) => {
+          const id = String(job.id);
+          const title = job.title?.trim() || `Job #${id}`;
+          return (
+            <li key={id} className="rounded border p-4" data-testid="application-row">
+              <Link className="text-blue-600 underline" href={`/browse-jobs/${encodeURIComponent(id)}`}>
+                {title}
+              </Link>
             </li>
-          ))}
-        </ul>
-      ) : (
-        <div
-          data-testid="applications-empty"
-          className="mt-6 rounded border border-dashed p-6 text-center text-slate-600"
-        >
-          You haven’t applied to any jobs yet.
-        </div>
-      )}
+          );
+        })}
+      </ul>
     </main>
   );
 }
+

--- a/src/lib/applications.ts
+++ b/src/lib/applications.ts
@@ -1,0 +1,31 @@
+import { cookies, headers } from 'next/headers';
+import { cookieDomainFor } from '@/lib/auth/cookies';
+
+export const APPLICATIONS_COOKIE = 'gg_apps';
+
+export function readAppliedIdsFromCookie(): string[] {
+  const raw = cookies().get(APPLICATIONS_COOKIE)?.value;
+  if (!raw) return [];
+  try {
+    const val = JSON.parse(raw);
+    if (Array.isArray(val)) {
+      return [...new Set(val.map((v) => String(v)))].slice(0, 100);
+    }
+  } catch {}
+  return [];
+}
+
+// Helper for API routes to set the applications cookie consistently
+export function cookieOptionsForHost() {
+  const host = headers().get('host') || '';
+  const domain = cookieDomainFor(host.split(':')[0] ?? '');
+  return {
+    httpOnly: true as const,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 90, // 90 days
+    ...(domain ? { domain } : {}),
+  };
+}
+


### PR DESCRIPTION
## Summary
- add shared helper for reading/writing the applications cookie and API routes to record or clear entries
- update the job Apply button to persist job IDs when users click apply before tracking redirects
- SSR the My Applications page from the recorded IDs, fetching job details and keeping existing fallbacks

## Testing
- npm run lint *(fails: `next` CLI unavailable because dependencies cannot be installed under the container's Node 22 runtime)*
- npm run typecheck *(fails: missing `@types/node` because npm install cannot fetch packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96df3ffd88327a220da63bf89bb3a