### PR TITLE
feat: harden jobs fallback and post-job redirect

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,9 +1,9 @@
 # Agents Contract
-**Version:** 2026-09-30
+**Version:** 2026-10-01
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).
-- Post Job CTAs resolve through `authAware('/gigs/create')` so unauthenticated clicks land on `/login?next=…` on the app host.
+- Post Job CTAs resolve through `authAware('/gigs/create')` so unauthenticated clicks land on `/login?next=…` on the app host; the `/post-job` route handler performs a host-aware 302 directly to `/gigs/create`.
 - Home (`/`) renders a hero CTA `hero-start` linking to `/browse-jobs`.
 - `data-testid="browse-jobs-from-empty"` → `/browse-jobs`
 - Header shows My Applications at all times and swaps `nav-login` ↔ `nav-logout` based on auth cookie presence.

--- a/agents.md
+++ b/agents.md
@@ -1,5 +1,5 @@
 # Agents Contract
-**Version:** 2026-09-29
+**Version:** 2026-09-30
 
 ## Routes & CTAs (source of truth)
 - Header CTAs use canonical IDs (`nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`).
@@ -17,10 +17,10 @@
 
 ## Legacy redirects (middleware)
 - `/find` → `/browse-jobs`
-- `/post`, `/posts`, and `/gigs/new` → `/post-job` (server page issues the auth-aware redirect)
+- `/post`, `/posts`, and `/gigs/new` → `/post-job` (route issues a 302 to `/gigs/create`; header/nav remain auth-aware)
 
 - Stable header test IDs: `nav-browse-jobs`, `nav-post-job`, `nav-my-applications`, `nav-login`.
-- Browse list IDs: `jobs-list`, `job-card`; empty state `jobs-empty-state`.
+- Browse list IDs: `jobs-list`, `job-card`; empty state `jobs-empty`.
 - Job detail ID: `apply-button`.
 - Applications IDs: `applications-list`, `application-row`, `applications-empty`.
 - Header smokes query `:visible` to ignore hidden duplicates; CTA href checks accept relative or absolute app URLs.

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,10 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2026-09-30 — Prod-safe jobs fallback & legacy redirect
+- Env reader only hard-requires `NEXT_PUBLIC_API_BASE_URL` on Vercel production; previews/CI/dev render fallbacks.
+- `/browse-jobs` exposes `jobs-empty` for the empty state and keeps deterministic mock listings when the API is unavailable.
+- Added a route handler so `/post-job` issues a 302 to `/gigs/create` while header CTAs remain auth-aware (My Applications uses `authAware` when signed out).
+
 ## 2026-09-29 — Auth cookie helpers & apply tracking
 - Added `/api/mock/login` and `/api/mock/logout` POST helpers (with shared cookie domains) and wired the login page to submit forms.
 - Middleware now inspects the raw cookie header so Edge gating stays in sync with SSR checks.

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,5 +1,9 @@
 # Backfill / Change Log (Landing → App routing)
 
+## 2026-10-01 — /post-job served via route handler
+- Removed the conflicting `/post-job/page.tsx` so the route handler owns the 302 redirect to `/gigs/create`.
+- Route handler now documents the host-aware redirect behavior.
+
 ## 2026-09-30 — Prod-safe jobs fallback & legacy redirect
 - Env reader only hard-requires `NEXT_PUBLIC_API_BASE_URL` on Vercel production; previews/CI/dev render fallbacks.
 - `/browse-jobs` exposes `jobs-empty` for the empty state and keeps deterministic mock listings when the API is unavailable.

--- a/src/app/browse-jobs/page.tsx
+++ b/src/app/browse-jobs/page.tsx
@@ -96,7 +96,7 @@ export default async function BrowseJobsPage({
       </form>
 
       {items.length === 0 ? (
-        <div className="mt-8 rounded border p-6 text-gray-600" data-testid="jobs-empty-state">
+        <div className="mt-8 rounded border p-6 text-gray-600" data-testid="jobs-empty">
           {q || location ? (
             <>
               No jobs found for{' '}

--- a/src/app/post-job/page.tsx
+++ b/src/app/post-job/page.tsx
@@ -1,7 +1,0 @@
-import { redirect } from 'next/navigation';
-import { authAware } from '@/lib/hostAware';
-
-export default function PostJobRedirect() {
-  redirect(authAware('/gigs/create'));
-}
-

--- a/src/app/post-job/route.ts
+++ b/src/app/post-job/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+import { hostAware } from '@/lib/hostAware';
+
+export function GET(request: Request) {
+  const destination = hostAware('/gigs/create');
+  const target = new URL(destination, request.url);
+  return NextResponse.redirect(target, 302);
+}

--- a/src/app/post-job/route.ts
+++ b/src/app/post-job/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 
 import { hostAware } from '@/lib/hostAware';
 
+// Legacy QuickGig route: /post-job
+// Redirect to app host's job creation page without auth gating.
 export function GET(request: Request) {
   const destination = hostAware('/gigs/create');
   const target = new URL(destination, request.url);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,9 @@ export default function Header() {
     : authAware("/gigs/create");
   const logoutHref = hostAware("/api/logout?next=/");
   const loginHref = hostAware("/login");
+  const myApplicationsHref = authed
+    ? hostAware("/my-applications")
+    : authAware("/my-applications");
 
   return (
     <header className="w-full border-b">
@@ -15,7 +18,9 @@ export default function Header() {
         <a href="/" className="font-semibold">QuickGig</a>
         <div className="flex items-center gap-4">
           <a data-testid="nav-browse-jobs" href="/browse-jobs">Browse Jobs</a>
-          <a data-testid="nav-my-applications" href="/my-applications">My Applications</a>
+          <a data-testid="nav-my-applications" href={myApplicationsHref}>
+            My Applications
+          </a>
           {authed ? (
             <a data-testid="nav-logout" href={logoutHref}>
               Logout

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -34,14 +34,17 @@ export function requireServer(key: string): string {
 // Minimal, safe env reader that won't crash CI/preview builds,
 // but *will* enforce correctness in real production deploys.
 export function isVercelProd(): boolean {
-  return rawEnv.VERCEL_ENV === 'production' && !rawEnv.CI;
+  const isVercel = rawEnv.VERCEL === '1' || rawEnv.VERCEL?.toLowerCase() === 'true';
+  const isProdEnv = rawEnv.VERCEL_ENV === 'production';
+  const isCi = rawEnv.CI === 'true' || rawEnv.CI === '1';
+  return Boolean(isVercel && isProdEnv && !isCi);
 }
 
 export function apiBaseUrl(): string | undefined {
   const url = rawEnv.NEXT_PUBLIC_API_BASE_URL?.trim();
   if (!url) {
-    if (NODE_ENV === 'production' && isVercelProd()) {
-      throw new Error('NEXT_PUBLIC_API_BASE_URL is required in production');
+    if (isVercelProd()) {
+      throw new Error('NEXT_PUBLIC_API_BASE_URL is required in Vercel production');
     }
     return undefined; // allow empty in CI/preview/local so pages render empty state
   }

--- a/src/lib/jobs.ts
+++ b/src/lib/jobs.ts
@@ -1,4 +1,4 @@
-import { apiBaseUrl } from "@/lib/env";
+import { apiBaseUrl, isVercelProd } from "@/lib/env";
 import { supabase } from "@/lib/supabaseClient";
 import { MOCK_JOBS, MOCK_JOB_BY_ID, type MockJob } from "@/mocks/jobs";
 import type { Insert } from "@/types/db";
@@ -35,7 +35,7 @@ export async function fetchJobs(opts: JobsQuery = {}): Promise<{
   items: MockJob[];
   total: number;
 }> {
-  const isProd = process.env.NODE_ENV === "production";
+  const isProd = isVercelProd();
   const base = apiBaseUrl();
   const page = Number.isFinite(opts.page) && (opts.page ?? 0) > 0 ? Number(opts.page) : 1;
   const pageSize =
@@ -97,7 +97,7 @@ export async function fetchJobs(opts: JobsQuery = {}): Promise<{
 }
 
 export async function fetchJob(id: string | number): Promise<MockJob | null> {
-  const isProd = process.env.NODE_ENV === "production";
+  const isProd = isVercelProd();
   const base = apiBaseUrl();
   if (!base) {
     if (!isProd) {


### PR DESCRIPTION
## Summary
- restrict NEXT_PUBLIC_API_BASE_URL to throw only on real Vercel production and reuse that guard across jobs fetchers
- surface the jobs empty state under data-testid="jobs-empty" while keeping deterministic mock listings and auth-aware header links
- restore the `/post-job` route as an explicit 302 to `/gigs/create` and document the new contract updates

## Testing
- npm run lint *(fails: Next.js not installed because dependencies cannot be installed under the sandbox Node 22 runtime)*
- npm install --engine-strict=false *(fails: package engines require Node <21 and npm <11 in this environment)*
- npm run typecheck *(fails: missing @types/node because dependencies could not be installed)*
- npm run no-legacy


------
https://chatgpt.com/codex/tasks/task_e_68ca293098bc8327b593f5e532821705