### PR TITLE
Add browse pagination and filters

### DIFF
--- a/src/app/browse-jobs/page.tsx
+++ b/src/app/browse-jobs/page.tsx
@@ -17,6 +17,12 @@ function parsePage(value: string | string[] | undefined, fallback = 1): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parsePageSize(value: string | string[] | undefined, fallback = 10): number {
+  const parsed = Number(firstValue(value));
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(50, Math.max(1, parsed));
+}
+
 export default async function BrowseJobsPage({
   searchParams = {},
 }: {
@@ -25,7 +31,7 @@ export default async function BrowseJobsPage({
   const q = firstValue(searchParams.q).trim();
   const location = firstValue(searchParams.location).trim();
   const page = parsePage(searchParams.page, 1);
-  const pageSize = 10;
+  const pageSize = parsePageSize(searchParams.pageSize, 10);
 
   const { items, total } = await fetchJobs({ page, pageSize, q, location });
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -38,6 +44,7 @@ export default async function BrowseJobsPage({
     if (q) params.set('q', q);
     if (location) params.set('location', location);
     params.set('page', String(page));
+    params.set('pageSize', String(pageSize));
     Object.entries(overrides).forEach(([key, value]) => {
       if (value === undefined || value === '') params.delete(key);
       else params.set(key, String(value));
@@ -79,19 +86,36 @@ export default async function BrowseJobsPage({
             data-testid="filter-location"
           />
         </label>
-        <div className="flex items-end gap-2">
-          <button className="rounded bg-blue-600 px-4 py-2 text-white" data-testid="filter-apply">
-            Search
-          </button>
-          {(q || location) && (
-            <Link
-              href="/browse-jobs"
-              className="rounded border px-4 py-2 text-sm"
-              data-testid="filter-clear"
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium">Page size</span>
+            <select
+              name="pageSize"
+              defaultValue={String(pageSize)}
+              className="rounded border px-3 py-2"
+              data-testid="filter-page-size"
             >
-              Clear
-            </Link>
-          )}
+              <option value="10">10</option>
+              <option value="20">20</option>
+              <option value="30">30</option>
+              <option value="40">40</option>
+              <option value="50">50</option>
+            </select>
+          </label>
+          <div className="flex items-end gap-2">
+            <button className="rounded bg-blue-600 px-4 py-2 text-white" data-testid="filter-apply">
+              Search
+            </button>
+            {(q || location) && (
+              <Link
+                href="/browse-jobs"
+                className="rounded border px-4 py-2 text-sm"
+                data-testid="filter-clear"
+              >
+                Clear
+              </Link>
+            )}
+          </div>
         </div>
       </form>
 

--- a/src/app/browse-jobs/page.tsx
+++ b/src/app/browse-jobs/page.tsx
@@ -17,9 +17,13 @@ function parsePage(value: string | string[] | undefined, fallback = 1): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function parsePageSize(value: string | string[] | undefined, fallback = 10): number {
-  const parsed = Number(firstValue(value));
-  if (!Number.isFinite(parsed)) return fallback;
+function parsePageSize(
+  value: string | string[] | undefined,
+  fallback = 10,
+): number {
+  const raw = firstValue(value);
+  const parsed = raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return Math.min(50, Math.max(1, parsed));
 }
 

--- a/src/lib/jobs.ts
+++ b/src/lib/jobs.ts
@@ -38,10 +38,11 @@ export async function fetchJobs(opts: JobsQuery = {}): Promise<{
   const isProd = isVercelProd();
   const base = apiBaseUrl();
   const page = Number.isFinite(opts.page) && (opts.page ?? 0) > 0 ? Number(opts.page) : 1;
-  const pageSize =
+  const rawPageSize =
     Number.isFinite(opts.pageSize) && (opts.pageSize ?? 0) > 0
       ? Number(opts.pageSize)
       : DEFAULT_PAGE_SIZE;
+  const pageSize = Math.min(50, Math.max(1, rawPageSize));
   const q = opts.q?.trim();
   const location = opts.location?.trim();
   const search = new URLSearchParams();


### PR DESCRIPTION
## Summary
- add page size sanitization when fetching jobs to keep API queries bounded
- enhance browse jobs page to parse ?pageSize= and persist it through pagination links
- expose a page size selector alongside existing keyword/location filters

## Testing
- npm run lint *(fails: `next` binary missing because installation from registry returns 403)*
- npm run typecheck *(fails: `@types/node` missing due to dependency install incomplete under restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3e8152708327938ea6084d1242f1