### PR TITLE
Add search filters and server filtering for browse jobs

### DIFF
--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -20,13 +20,16 @@ export function withAppOrigin(path: string): string {
 export type PlainParams = Record<string, string | number | boolean | undefined | null>;
 
 /** Keep only whitelisted keys from a ReadonlyURLSearchParams. */
+const DEFAULT_ALLOWED_PARAMS = ["q", "location", "sort", "page", "pageSize", "applied"] as const;
+
 export function keepParams(
   sp: ReadonlyURLSearchParams,
-  allow: string[],
-): Record<string, string> {
-  const out: Record<string, string> = {};
+  allow: string[] = [...DEFAULT_ALLOWED_PARAMS],
+): Partial<Record<string, string>> {
+  const allowSet = new Set(allow);
+  const out: Partial<Record<string, string>> = {};
   for (const [k, v] of sp.entries()) {
-    if (allow.includes(k)) out[k] = v;
+    if (allowSet.has(k)) out[k] = v;
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- add keyword and location search controls to the Browse Jobs page with server-side defaults, clear link, and preserved pagination params
- extend the jobs fetcher to accept q/location, pass filters through to the API, and update mock filtering plus empty state messaging
- expand keepParams defaults to retain q/location and keep pagination links consistent

## Testing
- npm run lint *(fails: Next CLI not available because dependencies cannot be installed under the container's Node/npm versions)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbbeb534e48327962964c25573d880