### PR TITLE
feat: enable Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@supabase/auth-helpers-shared": "^0.7.0",
     "@supabase/supabase-js": "^2.45.0",
     "@supabase/ssr": "^0.5.0",
+    "@vercel/speed-insights": "^1.0.0",
     "autoprefixer": "^10",
     "cookie": "^0.6.0",
     "nanoid": "^3.3.11",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import Header from "@/components/Header";
 import { metadataBaseOrigin } from "@/lib/env";
 
@@ -19,6 +20,8 @@ export default function RootLayout({
       <body>
         <Header />
         {children}
+        {/* Vercel Speed Insights: collects real user performance metrics */}
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add @vercel/speed-insights dependency
- render SpeedInsights from the root layout so Vercel can collect RUM metrics

## Testing
- npm install *(fails: 403 Forbidden to registry.npmjs.org via proxy)*
- npm run lint *(fails: missing Next.js binary because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc884e329083279b46c94e58501ed8